### PR TITLE
Feature/dynamic banner height

### DIFF
--- a/source/components/molecules/Banner/Banner.js
+++ b/source/components/molecules/Banner/Banner.js
@@ -4,10 +4,9 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 const BannerWrapper = styled.View`
-  top: 0;
   margin: 0;
   padding: 0;
-  min-height: ${props => (props.image ? '256' : '192')}px;
+  min-height: ${props => (props.image ? '256px' : '192px')};
   background: ${props => props.backgroundColor};
   position: relative;
   justify-content: flex-end;
@@ -21,16 +20,11 @@ const BannerImageIcon = styled(Image)`
 `;
 
 const BannerImageWrapper = styled.View`
-  overflow: hidden;
-  position: relative;
-  bottom: 0;
-  right: 0;
-  left: 0;
-  height: auto;
+  height: 256px;
 `;
 const BannerImage = styled(Image)`
   width: 100%;
-  height: 256px;
+  height: 100%;
 `;
 
 const Banner = ({ imageSrc, iconSrc, backgroundColor, style }) => (

--- a/source/components/molecules/FooterAction/FooterAction.js
+++ b/source/components/molecules/FooterAction/FooterAction.js
@@ -6,7 +6,7 @@ const ActionContainer = styled.View(props => ({
   display: 'flex',
   justifyContent: 'space-around',
   bottom: 0,
-  height: props.height,
+  padding: 32,
   backgroundColor: props.background,
 }));
 
@@ -18,10 +18,10 @@ const ButtonWrapper = styled.View`
 `;
 
 const FooterAction = props => {
-  const { children, height, background, ButtonList } = props;
+  const { children, background, ButtonList } = props;
 
   return (
-    <ActionContainer height={height} background={background}>
+    <ActionContainer background={background}>
       <ButtonWrapper>
         {ButtonList && <ButtonList />}
         {children}
@@ -33,12 +33,10 @@ const FooterAction = props => {
 FooterAction.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
   ButtonList: PropTypes.node,
-  height: PropTypes.string,
   background: PropTypes.string,
 };
 
 FooterAction.defaultProps = {
-  height: '192px',
   background: '#00213F',
 };
 export default FooterAction;

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -22,11 +22,11 @@ const StepBackNavigation = styled(BackNavigation)`
   padding: 24px;
 `;
 
-const StepBanner = styled(Banner)``;
-
-const StepBody = styled.View`
+const StepBanner = styled(Banner)`
   flex: 1;
 `;
+
+const StepBody = styled.View``;
 
 const StepFooter = styled(FooterAction)`
   position: absolute;


### PR DESCRIPTION
In order to bring the StepBody and StepFooter closer in a Step when there is lack of content, the StepBanner needs to embrace the remaning space in the view and expand. 

The Banner in a step does now expand if there is space for it. On top of this the StepFooter is also changed to have the height of its content + padding. 