### PR TITLE
Add some types for Form, Case and User

### DIFF
--- a/source/types/CaseType.ts
+++ b/source/types/CaseType.ts
@@ -1,0 +1,11 @@
+export interface Case {
+    createdAt: number;
+    updatedAt: number;
+    currentStep: number;
+    data: Record<string, any>;
+    formId: string;
+    id: string;
+    type: string;
+    personalNumber: string;
+    status: 'ongoing' | 'submitted'; // do we have/need other statuses?
+}

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -1,0 +1,50 @@
+export interface Question {
+    label: string;
+    type: string;
+    id: string;
+    description?: string;
+    conditionalOn?: string;
+    placeholder?: string;
+    explainer?: string;
+    loadPrevious?: string[];  
+    items?: SubstepItem[];
+    inputs?: ListInput[];
+  }
+  
+  export interface SubstepItem {
+    category: string;
+    title: string;
+    formId: string;
+    loadPrevious?: string[];
+  }
+  
+  export interface ListInput {
+    type: 'text' | 'number';
+    key: string;
+    label: string;
+    loadPrevious?: string[];
+  }
+  export interface Action {
+    type: string;
+    label: string;
+  }
+  
+  export interface Step {
+    title: string;
+    description: string;
+    id?: string;
+    group: string;
+    questions?: Question[];
+    actions?: Action[];
+  }
+  
+  export interface Form {
+    name: string;
+    description: string;
+    steps?: Step[];
+    id: string;
+    subform?: boolean;
+    formType?: string;
+    provider?: string;
+  }
+  

--- a/source/types/UserTypes.ts
+++ b/source/types/UserTypes.ts
@@ -1,0 +1,14 @@
+export interface User {
+    firstName: string;
+    lastName: string;
+    mobilePhone: string;
+    email: string;
+    civilStatus: string; //might not actually be a string...
+    address: Address;
+}
+
+export interface Address {
+    street: string;
+    postalCode: string;
+    city: string;
+}


### PR DESCRIPTION
Since we've merged the typescript support, this is a prepatory addition for typing the project. I add some types that mimic those used in the FormBuilder, for the Forms, Cases, and Users. 

Added a types folder at /source/types, which is intended for types/interfaces that are needed across many different places; for other types that are not so widely used, we should define them where they are to be used. I'm not completely sure what is the best practice here, but this approach seems sensible to me. 