### PR TITLE
Fix a helper modal bug

### DIFF
--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -117,6 +117,7 @@ const HelpButton = props => {
         </ModalContainer>
       </Modal>
       <TouchableHighlight
+        onPressIn={() => setModalVisible(false)}
         onPress={() => {
           setModalVisible(true);
         }}


### PR DESCRIPTION
If you closed the helper modal by swiping down, when you then try and open it again, it doesn't work. This is apparently a known react native bug (https://github.com/facebook/react-native/issues/26892), and I just apply one of the later simple suggestions there which fixes it by forcing a re-render on when you try to open it. 