### PR TITLE
Fix a bug where the status where reverted to ongoing on closing the form

### DIFF
--- a/source/components/molecules/FooterAction/FooterAction.js
+++ b/source/components/molecules/FooterAction/FooterAction.js
@@ -55,8 +55,6 @@ const FooterAction = ({
       case 'close': {
         return () => {
           if (onUpdate && caseStatus === 'ongoing') onUpdate(answers);
-          if (updateCaseInContext && caseStatus === 'ongoing')
-            updateCaseInContext(answers, 'ongoing', stepNumber);
           if (onClose) onClose();
         };
       }


### PR DESCRIPTION
The way we set the status to submitted does not change the internal caseStatus, so when you then close the form it's always reset to status ongoing. The easy fix right now is to not update the database on closing the form, which is okay behaviour anyways. 

For later, we should look over how we handle this status and probably do it in an easier, more direct fashion.