### PR TITLE
Feat/form text replacement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,7 +74,9 @@
       1,
       {
         "extensions": [
-          ".js"
+          ".js",
+          ".tsx",
+          ".jsx"
         ]
       }
     ],

--- a/source/components/molecules/FooterAction/FooterAction.js
+++ b/source/components/molecules/FooterAction/FooterAction.js
@@ -55,8 +55,6 @@ const FooterAction = ({
       case 'close': {
         return () => {
           if (onUpdate && caseStatus === 'ongoing') onUpdate(answers);
-          if (updateCaseInContext && caseStatus === 'ongoing')
-            updateCaseInContext(answers, 'ongoing', stepNumber);
           if (onClose) onClose();
         };
       }

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,40 +1,51 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
-import { Step } from 'app/components/organisms';
+import Step from '../../components/organisms/Step/Step';
+import { Step as StepType } from '../../types/FormTypes';
+import { CaseStatus } from '../../types/CaseType';
+import { User } from '../../types/UserTypes';
 import Stepper from '../../components/atoms/Stepper/Stepper';
 import useForm from './hooks/useForm';
 
-const FormStepper = styled(Stepper)``;
 const FormContainer = styled.View`
   flex: 1;
   height: auto;
 `;
+
+interface Props {
+  startAt: number;
+  steps: StepType[];
+  user: User;
+  initialAnswers: Record<string, any>;
+  status?: CaseStatus;
+  onClose: () => void;
+  onSubmit: () => void;
+  onStart: () => any;
+  updateCaseInContext: (data: Record<string, any>, status: CaseStatus, currentStep: number) => void;
+}
 
 /**
  * The Container Component Form allows you to create, process and reuse forms. The Form component
  * is a tool to help you solve the problem of allowing end-users to interact with the
  * data and modify the data in your application.
  */
-
-function Form({
+const Form: React.FC<Props> = ({
   startAt,
   steps,
-  firstName,
+  user,
   onClose,
   onStart,
   onSubmit,
   initialAnswers,
   status,
   updateCaseInContext,
-}) {
+}) => {
   const initialState = {
     submitted: false,
     counter: startAt,
     steps,
-    user: {
-      firstName,
-    },
+    user,
     formAnswers: initialAnswers,
   };
 
@@ -49,7 +60,7 @@ function Form({
   } = useForm(initialState);
   return (
     <FormContainer>
-      <FormStepper active={formState.counter}>
+      <Stepper active={formState.counter}>
         {formState.steps.map(
           ({ id, banner, theme, title, group, description, questions, actions }) => (
             <Step
@@ -80,10 +91,10 @@ function Form({
             />
           )
         )}
-      </FormStepper>
+      </Stepper>
     </FormContainer>
   );
-}
+};
 
 Form.propTypes = {
   /**
@@ -107,9 +118,9 @@ Form.propTypes = {
    */
   steps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   /**
-   * The firstName of the respondent.
+   * The user info.
    */
-  firstName: PropTypes.string.isRequired,
+  user: PropTypes.object,
   /**
    * Initial answer for each question.
    */

--- a/source/containers/Form/hooks/formActions.js
+++ b/source/containers/Form/hooks/formActions.js
@@ -1,11 +1,11 @@
 import { increaseCount, decreaseCount } from '../../../helpers/Counter';
+import { replaceMarkdownTextInSteps } from './textReplacement';
 /**
  * Action Types
  */
 
 /** @type { string } */
-export const REPLACE_FIRSTNAME_MARKDOWN_IN_ALL_STEP_TITLES =
-  'REPLACE_FIRSTNAME_MARKDOWN_IN_ALL_STEP_TITLES';
+export const REPLACE_MARKDOWN_TEXT = 'REPLACE_MARKDOWN_TEXT';
 
 /** @type { string } */
 export const INCREASE_COUNTER = 'INCREASE_COUNTER';
@@ -24,7 +24,7 @@ export const actionTypes = {
   INCREASE_COUNTER,
   DECREASE_COUNTER,
   UPDATE_ANSWER,
-  REPLACE_FIRSTNAME_MARKDOWN_IN_ALL_STEP_TITLES,
+  REPLACE_MARKDOWN_TEXT,
   START_FORM,
 };
 
@@ -32,12 +32,9 @@ export const actionTypes = {
  * Action for replacing title markdown in steps.
  * @param {object} state the current state of the form
  */
-export function replaceFirstNameMarkdownInAllStepTitles(state) {
+export function replaceMarkdownText(state) {
   const { steps, user } = state;
-  const updatedSteps = steps.map(s => ({
-    ...s,
-    title: s.title.replace('#firstName', user.firstName),
-  }));
+  const updatedSteps = replaceMarkdownTextInSteps(steps, user);
   return {
     ...state,
     steps: updatedSteps,

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -1,38 +1,12 @@
 import { increaseCount, decreaseCount } from '../../../helpers/Counter';
 import { replaceMarkdownTextInSteps } from './textReplacement';
-/**
- * Action Types
- */
-
-/** @type { string } */
-export const REPLACE_MARKDOWN_TEXT = 'REPLACE_MARKDOWN_TEXT';
-
-/** @type { string } */
-export const INCREASE_COUNTER = 'INCREASE_COUNTER';
-
-/** @type { string } */
-export const DECREASE_COUNTER = 'DECREASE_COUNTER';
-
-/** @type { string } */
-export const START_FORM = 'START_FORM';
-
-/** @type { string } */
-export const UPDATE_ANSWER = 'UPDATE_ANSWER';
-
-/** @type { object } */
-export const actionTypes = {
-  INCREASE_COUNTER,
-  DECREASE_COUNTER,
-  UPDATE_ANSWER,
-  REPLACE_MARKDOWN_TEXT,
-  START_FORM,
-};
+import { FormReducerState } from './useForm';
 
 /**
  * Action for replacing title markdown in steps.
- * @param {object} state the current state of the form
+ * @param {FormReducerState} state the current state of the form
  */
-export function replaceMarkdownText(state) {
+export function replaceMarkdownText(state: FormReducerState) {
   const { steps, user } = state;
   const updatedSteps = replaceMarkdownTextInSteps(steps, user);
   return {
@@ -43,9 +17,9 @@ export function replaceMarkdownText(state) {
 
 /**
  * Action for decreasing the form counter.
- * @param {object} state the current state of the form
+ * @param {FormReducerState} state the current state of the form
  */
-export function decreaseFormCounter(state) {
+export function decreaseFormCounter(state: FormReducerState) {
   const { counter } = state;
   return {
     ...state,
@@ -55,9 +29,9 @@ export function decreaseFormCounter(state) {
 
 /**
  * Action for increasing the form counter.
- * @param {object} state the current state of the form
+ * @param {FormReducerState} state the current state of the form
  */
-export function increaseFormCounter(state) {
+export function increaseFormCounter(state: FormReducerState) {
   const { steps, counter } = state;
   return {
     ...state,
@@ -69,7 +43,7 @@ export function increaseFormCounter(state) {
  * Action to run when starting a form.
  * @param {object} state the current state of the form
  */
-export function startForm(state, payload) {
+export function startForm(state: FormReducerState, payload: { callback: () => void }) {
   // TODO: Pass user input values.
   payload.callback({});
   const { steps, counter } = state;
@@ -81,21 +55,24 @@ export function startForm(state, payload) {
 
 /**
  * Action to run when starting a form.
- * @param {object} state the current state of the form
+ * @param {FormReducerState} state the current state of the form
  */
-export function submitForm(state, payload) {
+export function submitForm(
+  state: FormReducerState,
+  payload: { callback: (formAnswers: Record<string, any>) => void }
+) {
   payload.callback(state.formAnswers);
   return { ...state, submitted: true };
 }
 
 /**
  * Action for updating the answers in the form state.
- * @param {object} state The current state of the form
- * @param {object} answer The new answer(s): an object with key:value pairs, to be inserted into the states formAnswers
+ * @param {FormReducerState} state The current state of the form
+ * @param {Record<string, any>} answer The new answer(s): an object with key:value pairs, to be inserted into the states formAnswers
  */
-export function updateAnswer(state, answer) {
+export function updateAnswer(state: FormReducerState, answer: Record<string, any>) {
   // make a deep copy of the formAnswers, and use that to update. Not sure if completely needed.
-  const updatedAnswers = JSON.parse(JSON.stringify(state.formAnswers));
+  const updatedAnswers: Record<string, any> = JSON.parse(JSON.stringify(state.formAnswers));
   Object.keys(answer).forEach(key => (updatedAnswers[key] = answer[key]));
 
   return {

--- a/source/containers/Form/hooks/formReducer.js
+++ b/source/containers/Form/hooks/formReducer.js
@@ -1,6 +1,6 @@
 import {
   actionTypes,
-  replaceFirstNameMarkdownInAllStepTitles,
+  replaceMarkdownText,
   increaseFormCounter,
   decreaseFormCounter,
   startForm,
@@ -19,8 +19,11 @@ function formReducer(state, action) {
   const { type, payload } = action;
 
   switch (type) {
-    case actionTypes.REPLACE_FIRSTNAME_MARKDOWN_IN_ALL_STEP_TITLES: {
-      return replaceFirstNameMarkdownInAllStepTitles(state);
+    /**
+     * Replaces markdown texts (texts starting with #) with computed values
+     */
+    case actionTypes.REPLACE_MARKDOWN_TEXT: {
+      return replaceMarkdownText(state);
     }
 
     /**

--- a/source/containers/Form/hooks/formReducer.ts
+++ b/source/containers/Form/hooks/formReducer.ts
@@ -1,5 +1,5 @@
+import { FormReducerState } from './useForm';
 import {
-  actionTypes,
   replaceMarkdownText,
   increaseFormCounter,
   decreaseFormCounter,
@@ -8,21 +8,42 @@ import {
   updateAnswer,
 } from './formActions';
 
+type Action =
+  | {
+      type: 'REPLACE_MARKDOWN_TEXT';
+    }
+  | {
+      type: 'INCREASE_COUNTER';
+    }
+  | {
+      type: 'DECREASE_COUNTER';
+    }
+  | {
+      type: 'START_FORM';
+      payload: { callback: () => void };
+    }
+  | {
+      type: 'UPDATE_ANSWER';
+      payload: Record<string, any>;
+    }
+  | {
+      type: 'SUBMIT_FORM';
+      payload: { callback: (formAnswers: Record<string, any>) => void };
+    };
+
 /**
  * The formReducer is a pure function that takes the previous state and an action, and returns the
  * next state. (previousState, action) => nextState. It's called a reducer because it's the type
  * of function you would pass to Array.
- * @param {object} state
+ * @param {FormReducerState} state
  * @param {object} action
  */
-function formReducer(state, action) {
-  const { type, payload } = action;
-
-  switch (type) {
+function formReducer(state: FormReducerState, action: Action) {
+  switch (action.type) {
     /**
      * Replaces markdown texts (texts starting with #) with computed values
      */
-    case actionTypes.REPLACE_MARKDOWN_TEXT: {
+    case 'REPLACE_MARKDOWN_TEXT': {
       return replaceMarkdownText(state);
     }
 
@@ -30,7 +51,7 @@ function formReducer(state, action) {
      * Incrementing the counter of the form based on the lenght of steps.
      * This allow going forward to the next step in the form.
      */
-    case actionTypes.INCREASE_COUNTER: {
+    case 'INCREASE_COUNTER': {
       return increaseFormCounter(state);
     }
 
@@ -38,23 +59,23 @@ function formReducer(state, action) {
      * Decrementing the counter of the form until it hits 0.
      * This allow going back to the previous step in the form.
      */
-    case actionTypes.DECREASE_COUNTER: {
+    case 'DECREASE_COUNTER': {
       return decreaseFormCounter(state);
     }
 
-    case actionTypes.START_FORM: {
-      return startForm(state, payload);
+    case 'START_FORM': {
+      return startForm(state, action.payload);
     }
 
-    case actionTypes.UPDATE_ANSWER: {
-      return updateAnswer(state, payload);
+    case 'UPDATE_ANSWER': {
+      return updateAnswer(state, action.payload);
     }
 
     /**
      * Action for handling the submission of form answers.
      */
-    case actionTypes.SUBMIT_FORM: {
-      return submitForm(state, payload);
+    case 'SUBMIT_FORM': {
+      return submitForm(state, action.payload);
     }
 
     default:

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -1,0 +1,50 @@
+import { Step } from '../../../types/FormTypes';
+import { User } from '../../../types/UserTypes';
+
+/**
+ * The first argument is the string that should be replaced,
+ * the second should be something that we can use to compute the
+ * replacement value, such as getting it from the user object,
+ * or perhaps computing some dates based on the current time.
+ */
+const replacementRules = [
+  ['#firstName', 'user.firstName'],
+  ['#lastName', 'user.lastName'],
+];
+
+const computeText = (descriptor: string, user: User): string => {
+  const strArr = descriptor.split('.');
+  if (strArr[0] === 'user') {
+    const res = strArr.slice(1).reduce((prev, current) => {
+      if (prev && prev[current]) return prev[current];
+      return undefined;
+    }, user);
+    if (res) return res;
+  }
+  return '';
+};
+
+const replaceText = (text: string, user: User) => {
+  let res = text;
+  replacementRules.forEach(([template, descriptor]) => {
+    res = res.replace(template, computeText(descriptor, user));
+  });
+  return res;
+};
+
+export const replaceMarkdownTextInSteps = (steps: Step[], user: User): Step[] => {
+  const newSteps = steps.map(step => {
+    if (step.questions) {
+      step.questions = step.questions.map(qs => {
+        if (qs.label && qs.label !== '') {
+          qs.label = replaceText(qs.label, user);
+        }
+        return qs;
+      });
+    }
+    if (step.title) step.title = replaceText(step.title, user);
+    if (step.description) step.description = replaceText(step.description, user);
+    return step;
+  });
+  return newSteps;
+};

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -10,6 +10,9 @@ import { User } from '../../../types/UserTypes';
 const replacementRules = [
   ['#firstName', 'user.firstName'],
   ['#lastName', 'user.lastName'],
+  ['#datum1', 'date.nextMonth.first'],
+  ['#datum2', 'date.nextMonth.last'],
+  ['#year', 'date.currentYear'], // this is the current year of next month
 ];
 
 const computeText = (descriptor: string, user: User): string => {
@@ -20,6 +23,23 @@ const computeText = (descriptor: string, user: User): string => {
       return undefined;
     }, user);
     if (res) return res;
+  }
+  if (strArr[0] === 'date') {
+    const today = new Date();
+    if (strArr[1] === 'nextMonth') {
+      const month = today.getMonth() + 2;
+      if (strArr[2] === 'first') {
+        return `1/${month}`;
+      }
+      if (strArr[2] === 'last') {
+        const days = new Date(today.getFullYear(), month, 0).getDate();
+        return `${days}/${month}`;
+      }
+    }
+    if (strArr[1] === 'currentYear') {
+      const year = new Date(today.getFullYear(), today.getMonth() + 1, 1).getFullYear();
+      return `${year}`;
+    }
   }
   return '';
 };

--- a/source/containers/Form/hooks/useForm.js
+++ b/source/containers/Form/hooks/useForm.js
@@ -7,7 +7,7 @@ function useForm(initialState) {
 
   useEffect(() => {
     dispatch({
-      type: actionTypes.REPLACE_FIRSTNAME_MARKDOWN_IN_ALL_STEP_TITLES,
+      type: actionTypes.REPLACE_MARKDOWN_TEXT,
     });
   }, []);
 

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -1,13 +1,22 @@
 import { useReducer, useEffect } from 'react';
 import formReducer from './formReducer';
-import { actionTypes } from './formActions';
+import { Step } from '../../../types/FormTypes';
+import { User } from '../../../types/UserTypes';
 
-function useForm(initialState) {
+export interface FormReducerState {
+  submitted: boolean;
+  counter: number;
+  steps: Step[];
+  user: User;
+  formAnswers: Record<string, any>;
+}
+
+function useForm(initialState: FormReducerState) {
   const [formState, dispatch] = useReducer(formReducer, initialState);
 
   useEffect(() => {
     dispatch({
-      type: actionTypes.REPLACE_MARKDOWN_TEXT,
+      type: 'REPLACE_MARKDOWN_TEXT',
     });
   }, []);
 
@@ -16,7 +25,7 @@ function useForm(initialState) {
    */
   const goToNextStep = () =>
     dispatch({
-      type: actionTypes.INCREASE_COUNTER,
+      type: 'INCREASE_COUNTER',
     });
 
   /**
@@ -24,7 +33,7 @@ function useForm(initialState) {
    */
   const goToPreviousStep = () =>
     dispatch({
-      type: actionTypes.DECREASE_COUNTER,
+      type: 'DECREASE_COUNTER',
     });
 
   const isLastStep = () => formState.steps.length === formState.counter;
@@ -34,9 +43,9 @@ function useForm(initialState) {
    * to handle a form start action.
    * @param {func} callback callback function to be called on when a start action is triggerd
    */
-  const startForm = callback => {
+  const startForm = (callback: () => void) => {
     dispatch({
-      type: actionTypes.START_FORM,
+      type: 'START_FORM',
       payload: { callback },
     });
   };
@@ -45,9 +54,9 @@ function useForm(initialState) {
    * Function for handling a on submit action in the form.
    * @param {func} callback callback function to be called on form submit.
    */
-  const handleSubmit = callback => {
+  const handleSubmit = (callback: (formAnswers: Record<string, any>) => void) => {
     dispatch({
-      type: actionTypes.SUBMIT_FORM,
+      type: 'SUBMIT_FORM',
       payload: { callback },
     });
   };
@@ -61,14 +70,15 @@ function useForm(initialState) {
    * to handle a form close action.
    * @param {func} callback callback function to be called on when a close action is triggerd
    */
-  const closeForm = callback => callback({ state: formState }, isLastStep());
+  const closeForm = (callback: (s: { state: FormReducerState }, isLastStep: boolean) => any) =>
+    callback({ state: formState }, isLastStep());
 
   /**
    * Function for updating answer.
    */
-  const handleInputChange = answer => {
+  const handleInputChange = (answer: Record<string, any>) => {
     // console.log(answer);
-    dispatch({ type: actionTypes.UPDATE_ANSWER, payload: answer });
+    dispatch({ type: 'UPDATE_ANSWER', payload: answer });
   };
 
   return {

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -70,7 +70,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
         <Form
           steps={form.steps}
           startAt={caseData?.currentStep || initialCase?.currentStep || 1}
-          firstName={user?.firstName || ''}
+          user={user}
           onClose={handleCloseForm}
           onStart={handleStartForm}
           onSubmit={handleSubmitForm}

--- a/source/types/CaseType.ts
+++ b/source/types/CaseType.ts
@@ -1,11 +1,12 @@
+export type CaseStatus = 'ongoing' | 'submitted';
 export interface Case {
-    createdAt: number;
-    updatedAt: number;
-    currentStep: number;
-    data: Record<string, any>;
-    formId: string;
-    id: string;
-    type: string;
-    personalNumber: string;
-    status: 'ongoing' | 'submitted'; // do we have/need other statuses?
+  createdAt: number;
+  updatedAt: number;
+  currentStep: number;
+  data: Record<string, any>;
+  formId: string;
+  id: string;
+  type: string;
+  personalNumber: string;
+  status: CaseStatus; // do we have/need other statuses?
 }

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -28,6 +28,12 @@ export interface Action {
   label: string;
 }
 
+export interface Banner {
+  iconSrc?: string;
+  imageSrc?: string;
+  backgroundColor?: string;
+}
+
 export interface Step {
   title: string;
   description: string;
@@ -35,6 +41,7 @@ export interface Step {
   group: string;
   questions?: Question[];
   actions?: Action[];
+  banner?: Banner;
 }
 
 export interface Form {

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -1,50 +1,48 @@
+export interface SubstepItem {
+  category: string;
+  title: string;
+  formId: string;
+  loadPrevious?: string[];
+}
+export interface ListInput {
+  type: 'text' | 'number';
+  key: string;
+  label: string;
+  loadPrevious?: string[];
+}
 export interface Question {
-    label: string;
-    type: string;
-    id: string;
-    description?: string;
-    conditionalOn?: string;
-    placeholder?: string;
-    explainer?: string;
-    loadPrevious?: string[];  
-    items?: SubstepItem[];
-    inputs?: ListInput[];
-  }
-  
-  export interface SubstepItem {
-    category: string;
-    title: string;
-    formId: string;
-    loadPrevious?: string[];
-  }
-  
-  export interface ListInput {
-    type: 'text' | 'number';
-    key: string;
-    label: string;
-    loadPrevious?: string[];
-  }
-  export interface Action {
-    type: string;
-    label: string;
-  }
-  
-  export interface Step {
-    title: string;
-    description: string;
-    id?: string;
-    group: string;
-    questions?: Question[];
-    actions?: Action[];
-  }
-  
-  export interface Form {
-    name: string;
-    description: string;
-    steps?: Step[];
-    id: string;
-    subform?: boolean;
-    formType?: string;
-    provider?: string;
-  }
-  
+  label: string;
+  type: string;
+  id: string;
+  description?: string;
+  conditionalOn?: string;
+  placeholder?: string;
+  explainer?: string;
+  loadPrevious?: string[];
+  items?: SubstepItem[];
+  inputs?: ListInput[];
+}
+
+export interface Action {
+  type: string;
+  label: string;
+}
+
+export interface Step {
+  title: string;
+  description: string;
+  id?: string;
+  group: string;
+  questions?: Question[];
+  actions?: Action[];
+}
+
+export interface Form {
+  name: string;
+  description: string;
+  steps?: Step[];
+  id: string;
+  subform?: boolean;
+  formType?: string;
+  provider?: string;
+}


### PR DESCRIPTION
Previously, there was the very specific replace_first_name functionality, which mapped #firstName to the users first name in the form. This replaces this by the more general replace markdown behaviour, as specified in the textReplacement file. This file contains some beginning rules for replacing some strings with dates or user info. 

In addition, the Form hooks are converted to typescript, with some typing added. This changes how we handle Action types to a more typescripty way, that specifies what the payload should be given the different types, which I found quite nice. 