### PR TITLE
Fix datepicker on Android

### DIFF
--- a/source/components/molecules/DateTimePicker/DateTimePickerForm.tsx
+++ b/source/components/molecules/DateTimePicker/DateTimePickerForm.tsx
@@ -1,25 +1,43 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Platform } from 'react-native';
 import Input from '../../atoms/Input';
 
-const DateTimePickerForm = props => {
-  const { onSelect, value, mode, selectorProps, color, ...other } = props;
+interface Props {
+  onSelect: (date: Date) => void;
+  value: string | number;
+  mode: 'datetime' | 'time' | 'date';
+  color: string;
+  selectorProps: Record<string, any>;
+}
 
+const DateTimePickerForm: React.FC<Props> = ({
+  onSelect,
+  value,
+  mode,
+  selectorProps,
+  color,
+  ...other
+}) => {
   const [isVisible, setIsVisible] = useState(false);
 
-  let dateTimeString;
+  let dateTimeString: string;
   const date = value ? new Date(value) : new Date();
 
-  const dateString = `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(
-    2,
-    0
-  )}-${`${date.getDate()}`.padStart(2, 0)}`;
-  const timeString = `${`${date.getHours()}`.padStart(2, 0)}:${`${date.getMinutes()}`.padStart(
-    2,
-    0
-  )}`;
+  const dateString = `${date.getFullYear()}-${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}-${date
+    .getDate()
+    .toString()
+    .padStart(2, '0')}`;
+  const timeString = `${date
+    .getHours()
+    .toString()
+    .padStart(2, '0')}:${date
+    .getMinutes()
+    .toString()
+    .padStart(2, '0')}`;
   if (value) {
     switch (mode) {
       case 'datetime':
@@ -34,6 +52,11 @@ const DateTimePickerForm = props => {
         dateTimeString = dateString;
     }
   }
+
+  const onChange = (date: Date) => {
+    setIsVisible(Platform.OS === 'ios');
+    onSelect(date);
+  };
 
   return (
     <View>
@@ -51,7 +74,7 @@ const DateTimePickerForm = props => {
       {isVisible && (
         <DateTimePicker
           value={date}
-          onChange={(_event, x) => onSelect(x)}
+          onChange={(_event, date) => onChange(date)}
           mode={mode}
           textColor={color === 'light' ? 'white' : 'dark'}
           {...selectorProps}


### PR DESCRIPTION
## Feature description
Fix so that the datepicker component closes correctly on Android.

## Solution description
Android and iOS treats the onChange event differently for the built in date pickers, so one has to account for this and, on android, close the date picker on the change event (whereas on iOs, the change event is triggered on every change, so here it should not close on this event). 

I also converted the date picker component to typescript. 

## What areas is affected by these changes?.
Only the date picker component.

## Is there any existing behaviour change of other features due to this code change?
No.

## Covered unit tests cases / E2E test cases?
No.

## Are your code structured in a way so that reviewers can understand it?
Yes.

## Was this feature tested in the following environments?
It was tested on android and iOs simulators.