### PR TITLE
Add summary list component

### DIFF
--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Input, FieldLabel, Select, Text } from 'source/components/atoms';
 import { CheckboxField, EditableList, GroupListWithAvatar } from 'source/components/molecules';
-import SubstepList from 'source/components/organisms/SubstepList';
 import { View } from 'react-native';
 import ConditionalTextField from 'app/components/molecules/ConditinalTextField';
 import colors from '../../../styles/colors';
-import DateTimePickerForm from '../DateTimePicker';
+import DateTimePickerForm from '../DateTimePicker/DateTimePickerForm';
 import NavigationButtonField from '../NavigationButtonField/NavigationButtonField';
-import NavigationButtonFieldGroup from '../NavigationButtonGroup/NavigationButtonGroup';
+import NavigationButtonGroup from '../NavigationButtonGroup/NavigationButtonGroup';
+import SummaryList from '../../organisms/SummaryList/SummaryList';
+import RepeaterField from '../RepeaterField/RepeaterField';
 
 const inputTypes = {
   text: {
@@ -49,14 +50,8 @@ const inputTypes = {
     props: {},
   },
   navigationButtonGroup: {
-    component: NavigationButtonFieldGroup,
+    component: NavigationButtonGroup,
     props: {},
-  },
-  substepListSummary: {
-    component: SubstepList,
-    changeEvent: 'onChange',
-    props: { summary: true },
-    initialValue: {},
   },
   select: {
     component: Select,
@@ -75,25 +70,37 @@ const inputTypes = {
     props: {},
     initialValue: '',
   },
+  summaryList: {
+    component: SummaryList,
+    changeEvent: 'onChange',
+    props: { answers: true },
+  },
+  repeaterField: {
+    component: RepeaterField,
+    changeEvent: 'onChange',
+    props: { answers: true },
+  },
 };
 
-const FormField = props => {
-  const {
-    label,
-    labelLine,
-    inputType,
-    color,
-    id,
-    onChange,
-    value,
-    answers,
-    conditionalOn,
-    labelHelp,
-    ...other
-  } = props;
+const FormField = ({
+  label,
+  labelLine,
+  inputType,
+  color,
+  id,
+  onChange,
+  value,
+  answers,
+  conditionalOn,
+  labelHelp,
+  ...other
+}) => {
   const input = inputTypes[inputType];
-  const saveInput = value => {
-    if (onChange) onChange({ [id]: value });
+  if (!input) {
+    return <Text>{`Invalid field type: ${inputType}`}</Text>;
+  }
+  const saveInput = (value, fieldId = id) => {
+    if (onChange) onChange({ [fieldId]: value });
   };
   if (!input) {
     return <Text>{`Invalid field type: ${inputType}`}</Text>;
@@ -111,6 +118,7 @@ const FormField = props => {
     ...inputProps,
     ...other,
   };
+  if (input?.props?.answers) inputCompProps.answers = answers;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;
 
   /** Checks if the field is conditional on another input, and if so,

--- a/source/components/organisms/SummaryList/SummaryList.stories.js
+++ b/source/components/organisms/SummaryList/SummaryList.stories.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react-native';
+import StoryWrapper from '../../molecules/StoryWrapper';
+import SummaryList from './SummaryList';
+import { Input, FieldLabel, Text } from '../../atoms';
+
+const stories = storiesOf('Summary List', module);
+
+const items = [
+  { id: 'f1', type: 'text', title: 'favoritfrukt', category: 'fruit' },
+  { id: 'f2', type: 'text', title: 'grönsak', category: 'vegetable' },
+];
+
+const categories = [
+  { category: 'fruit', description: 'Frukt' },
+  { category: 'vegetable', description: 'Grönsak' },
+];
+
+const SummaryStory = () => {
+  const [state, setState] = useState({});
+  return (
+    <>
+      <FieldLabel>
+        <Text>Frukt</Text>
+      </FieldLabel>
+      <Input
+        value={state.f1}
+        onChangeText={text => {
+          setState(s => {
+            s.f1 = text;
+            return { ...s };
+          });
+        }}
+      />
+      <FieldLabel>
+        <Text>Grönsak</Text>
+      </FieldLabel>
+      <Input
+        value={state.f2}
+        onChangeText={text => {
+          setState(s => {
+            s.f2 = text;
+            return { ...s };
+          });
+        }}
+      />
+      <SummaryList
+        heading="Sammanfattning"
+        items={items}
+        categories={categories}
+        addButtonText="Add something"
+        color="light"
+        onChange={(answer, id) => {
+          setState(s => {
+            s[id] = answer;
+            return { ...s };
+          });
+        }}
+        d
+        answers={state}
+      />
+    </>
+  );
+};
+
+stories.add('default', () => (
+  <StoryWrapper>
+    <SummaryStory />
+  </StoryWrapper>
+));

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import GroupedList from '../../molecules/GroupedList/GroupedList';
-import SummaryListItem from './SummaryListItem';
+import SummaryListItemComponent from './SummaryListItem';
 
-export interface Item {
+export interface SummaryListItem {
   title: string;
   id: string;
   type: 'number' | 'text' | 'date' | 'arrayNumber' | 'arrayText' | 'arrayDate';
@@ -18,7 +18,7 @@ interface SummaryListCategory {
 
 interface Props {
   heading: string;
-  items: Item[];
+  items: SummaryListItem[];
   categories?: SummaryListCategory[];
   onChange: (answers: Record<string, any> | string | number, fieldId: string) => void;
   color: string;
@@ -36,7 +36,7 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
    * @param item The list item
    * @param index The index, when summarizing a repeater field with multiple answers
    */
-  const changeFromInput = (item: Item, index?: number) => (text: string) => {
+  const changeFromInput = (item: SummaryListItem, index?: number) => (text: string) => {
     if (
       ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
       typeof index !== 'undefined' &&
@@ -55,7 +55,7 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
    * @param item The list item
    * @param index The index, when summarizing a repeater field with multiple answers
    */
-  const removeListItem = (item: Item, index?: number) => () => {
+  const removeListItem = (item: SummaryListItem, index?: number) => () => {
     if (typeof index !== 'undefined') {
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
       oldAnswer.splice(index, 1);
@@ -67,13 +67,13 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
 
   /** Generates a list item */
   const generateListItem = (
-    item: Item,
+    item: SummaryListItem,
     value: string | number | Record<string, any>,
     index?: number
   ) => ({
     category: item.category,
     component: (
-      <SummaryListItem
+      <SummaryListItemComponent
         item={item}
         index={index ? index + 1 : undefined}
         value={value}

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import GroupedList from '../../molecules/GroupedList/GroupedList';
+import SummaryListItem from './SummaryListItem';
+
+export interface Item {
+  title: string;
+  id: string;
+  type: 'number' | 'text' | 'date' | 'arrayNumber' | 'arrayText' | 'arrayDate';
+  category?: string;
+  inputId?: string;
+}
+
+interface Category {
+  category: string;
+  description: string;
+}
+
+interface Props {
+  heading: string;
+  items: Item[];
+  categories?: Category[];
+  onChange: (answers: Record<string, any> | string | number, fieldId: string) => void;
+  color: string;
+  answers: Record<string, any>;
+}
+/**
+ * Summary list, that is linked and summarizes values from other input components.
+ * The things to summarize is specified in the items prop.
+ * The things are grouped into categories, as specified by the categories props.
+ */
+const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, color, answers }) => {
+  console.log(answers);
+  const changeFromInput = (item: Item, index?: number) => (text: string) => {
+    if (
+      ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
+      typeof index !== 'undefined' &&
+      item.inputId
+    ) {
+      const oldValue: Record<string, string | number>[] = answers[item.id];
+      oldValue[index][item.inputId] = text;
+      onChange(oldValue, item.id);
+    } else {
+      onChange(text, item.id);
+    }
+  };
+
+  const removeItem = (item: Item, index?: number) => () => {
+    if (typeof index !== 'undefined') {
+      const oldValue: Record<string, string | number>[] = answers[item.id];
+      oldValue.splice(index, 1);
+      onChange(oldValue, item.id);
+    } else {
+      onChange(undefined, item.id);
+    }
+  };
+
+  const listItems = [];
+  items
+    .filter(item => {
+      const val = answers[item.id];
+      return typeof val !== 'undefined';
+    })
+    .forEach(item => {
+      if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {
+        const values: Record<string, string | number>[] = answers[item.id];
+        if (values && values?.length > 0) {
+          values.forEach((v, index) => {
+            listItems.push({
+              category: item.category,
+              component: (
+                <SummaryListItem
+                  item={item}
+                  index={index + 1}
+                  value={v[item?.inputId || item.id]}
+                  changeFromInput={changeFromInput(item, index)}
+                  removeItem={removeItem(item, index)}
+                  color={color}
+                />
+              ),
+            });
+          });
+        }
+      } else {
+        listItems.push({
+          category: item.category,
+          component: (
+            <SummaryListItem
+              item={item}
+              value={answers[item.id]}
+              changeFromInput={changeFromInput(item)}
+              removeItem={removeItem(item)}
+              color={color}
+            />
+          ),
+        });
+      }
+    });
+  return <GroupedList heading={heading} items={listItems} categories={categories} color={color} />;
+};
+
+SummaryList.propTypes = {
+  /**
+   * The header text of the list.
+   */
+  heading: PropTypes.string,
+  /**
+   * List of all items, corresponding to all subforms
+   */
+  items: PropTypes.array,
+  /**
+   * The categories of the grouping
+   */
+  categories: PropTypes.array,
+  /**
+   * What should happen to update the values
+   */
+  onChange: PropTypes.func,
+  /**
+   * Sets the color scheme of the list. default is red.
+   */
+  color: PropTypes.string,
+  /**
+   * Message to display before anything has been added to the list.
+   */
+  answers: PropTypes.object,
+};
+
+SummaryList.defaultProps = {
+  items: [],
+  color: 'red',
+  onChange: () => {},
+};
+export default SummaryList;

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -30,7 +30,6 @@ interface Props {
  * The things are grouped into categories, as specified by the categories props.
  */
 const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, color, answers }) => {
-  console.log(answers);
   const changeFromInput = (item: Item, index?: number) => (text: string) => {
     if (
       ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
@@ -96,7 +95,11 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
         });
       }
     });
-  return <GroupedList heading={heading} items={listItems} categories={categories} color={color} />;
+  return (
+    listItems.length > 0 && (
+      <GroupedList heading={heading} items={listItems} categories={categories} color={color} />
+    )
+  );
 };
 
 SummaryList.propTypes = {

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import GroupedList from '../../molecules/GroupedList/GroupedList';
-import SummaryListItemComponent from './SummaryListItem';
+import React from "react";
+import PropTypes from "prop-types";
+import GroupedList from "../../molecules/GroupedList/GroupedList";
+import SummaryListItemComponent from "./SummaryListItem";
 
 export interface SummaryListItem {
   title: string;
   id: string;
-  type: 'number' | 'text' | 'date' | 'arrayNumber' | 'arrayText' | 'arrayDate';
+  type: "number" | "text" | "date" | "arrayNumber" | "arrayText" | "arrayDate";
   category?: string;
   inputId?: string;
 }
@@ -20,7 +20,10 @@ interface Props {
   heading: string;
   items: SummaryListItem[];
   categories?: SummaryListCategory[];
-  onChange: (answers: Record<string, any> | string | number, fieldId: string) => void;
+  onChange: (
+    answers: Record<string, any> | string | number,
+    fieldId: string
+  ) => void;
   color: string;
   answers: Record<string, any>;
 }
@@ -29,17 +32,26 @@ interface Props {
  * The things to summarize is specified in the items prop.
  * The things are grouped into categories, as specified by the categories props.
  */
-const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, color, answers }) => {
+const SummaryList: React.FC<Props> = ({
+  heading,
+  items,
+  categories,
+  onChange,
+  color,
+  answers,
+}) => {
   /**
    * Given an item, and possibly an index in the case of repeater fields, this generates a function that
    * updates the form data from the input.
    * @param item The list item
    * @param index The index, when summarizing a repeater field with multiple answers
    */
-  const changeFromInput = (item: SummaryListItem, index?: number) => (text: string) => {
+  const changeFromInput = (item: SummaryListItem, index?: number) => (
+    text: string
+  ) => {
     if (
-      ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
-      typeof index !== 'undefined' &&
+      ["arrayNumber", "arrayText", "arrayDate"].includes(item.type) &&
+      typeof index !== "undefined" &&
       item.inputId
     ) {
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
@@ -56,7 +68,7 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
    * @param index The index, when summarizing a repeater field with multiple answers
    */
   const removeListItem = (item: SummaryListItem, index?: number) => () => {
-    if (typeof index !== 'undefined') {
+    if (typeof index !== "undefined") {
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
       oldAnswer.splice(index, 1);
       onChange(oldAnswer, item.id);
@@ -86,16 +98,18 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
 
   const listItems = [];
   items
-    .filter(item => {
-      const val = answers[item.id];
-      return typeof val !== 'undefined';
+    .filter((item) => {
+      const answer = answers[item.id];
+      return typeof answer !== "undefined";
     })
-    .forEach(item => {
-      if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {
+    .forEach((item) => {
+      if (["arrayNumber", "arrayText", "arrayDate"].includes(item.type)) {
         const values: Record<string, string | number>[] = answers[item.id];
         if (values && values?.length > 0) {
           values.forEach((v, index) => {
-            listItems.push(generateListItem(item, v[item?.inputId || item.id], index));
+            listItems.push(
+              generateListItem(item, v[item?.inputId || item.id], index)
+            );
           });
         }
       } else {
@@ -104,7 +118,12 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
     });
   return (
     listItems.length > 0 && (
-      <GroupedList heading={heading} items={listItems} categories={categories} color={color} />
+      <GroupedList
+        heading={heading}
+        items={listItems}
+        categories={categories}
+        color={color}
+      />
     )
   );
 };
@@ -138,7 +157,7 @@ SummaryList.propTypes = {
 
 SummaryList.defaultProps = {
   items: [],
-  color: 'red',
+  color: "red",
   onChange: () => {},
 };
 export default SummaryList;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable no-nested-ternary */
-import React from 'react';
-import { View } from 'react-native';
-import { TouchableHighlight } from 'react-native-gesture-handler';
-import styled from 'styled-components/native';
-import PropTypes from 'prop-types';
-import { Input, Text, Icon } from '../../atoms';
-import colors from '../../../styles/colors';
-import { SummaryListItem as SummaryListItemType } from './SummaryList';
-import DateTimePickerForm from '../../molecules/DateTimePicker/DateTimePickerForm';
+import React from "react";
+import { View } from "react-native";
+import { TouchableHighlight } from "react-native-gesture-handler";
+import styled from "styled-components/native";
+import PropTypes from "prop-types";
+import { Input, Text, Icon } from "../../atoms";
+import colors from "../../../styles/colors";
+import { SummaryListItem as SummaryListItemType } from "./SummaryList";
+import DateTimePickerForm from "../../molecules/DateTimePicker/DateTimePickerForm";
 
 const SummaryListItemWrapper = styled(View)`
   flex-direction: row;
@@ -49,12 +49,12 @@ const dateStyle = {
   height: 40,
   paddingTop: 8,
   paddingBottom: 2,
-  backgroundColor: 'transparent',
+  backgroundColor: "transparent",
   borderTopWidth: 0,
   borderStartWidth: 0,
   borderEndWidth: 0,
   borderBottomWidth: 1,
-  borderColor: 'black',
+  borderColor: "black",
 };
 
 interface Props {
@@ -66,11 +66,22 @@ interface Props {
   color: string;
 }
 
-const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput, removeItem, color }) => {
+/**
+ * A component for rendering an singel item in a SummaryList Component.
+ * Each summary item contains input fields with a descriptive label, the ability to clear the inputs and .
+ */
+const SummaryListItem: React.FC<Props> = ({
+  item,
+  value,
+  index,
+  changeFromInput,
+  removeItem,
+  color,
+}) => {
   const inputComponent = (input: SummaryListItemType) => {
     switch (input.type) {
-      case 'text':
-      case 'arrayText':
+      case "text":
+      case "arrayText":
         return (
           <SummaryListSmallInput
             textAlign="right"
@@ -78,8 +89,8 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
             onChangeText={changeFromInput}
           />
         );
-      case 'number':
-      case 'arrayNumber':
+      case "number":
+      case "arrayNumber":
         return (
           <SummaryListSmallInput
             textAlign="right"
@@ -88,13 +99,13 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
             onChangeText={changeFromInput}
           />
         );
-      case 'date':
-      case 'arrayDate':
+      case "date":
+      case "arrayDate":
         return (
           <DateTimePickerForm
             value={value as string}
             mode="date"
-            selectorProps={{ locale: 'sv' }}
+            selectorProps={{ locale: "sv" }}
             onSelect={changeFromInput}
             color={color}
             style={dateStyle}
@@ -112,10 +123,11 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
   };
   return (
     <SummaryListItemWrapper key={`${item.title}`}>
-      <SummaryListSmallText>{`${item.title}`}{index ? ` ${index}`: null}</SummaryListSmallText>
-      <SummaryListInputWrapper>
-        {inputComponent(item)}
-      </SummaryListInputWrapper>
+      <SummaryListSmallText>
+        {`${item.title}`}
+        {index ? ` ${index}` : null}
+      </SummaryListSmallText>
+      <SummaryListInputWrapper>{inputComponent(item)}</SummaryListInputWrapper>
       <TouchableHighlight activeOpacity={1} onPress={removeItem}>
         <SummaryListDeleteButton name="clear" />
       </TouchableHighlight>
@@ -143,6 +155,6 @@ SummaryListItem.propTypes = {
   color: PropTypes.string,
 };
 SummaryListItem.defaultProps = {
-  color: 'light',
+  color: "light",
 };
 export default SummaryListItem;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -1,0 +1,147 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import { View } from 'react-native';
+import { TouchableHighlight } from 'react-native-gesture-handler';
+import styled from 'styled-components/native';
+import PropTypes from 'prop-types';
+import { Input, Text, Icon } from '../../atoms';
+import colors from '../../../styles/colors';
+import { Item } from './SummaryList';
+import DateTimePickerForm from '../../molecules/DateTimePicker/DateTimePickerForm';
+
+const ItemWrapper = styled(View)`
+  flex-direction: row;
+  align-items: flex-end;
+  height: 46px;
+`;
+const InputWrapper = styled.View`
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1;
+  padding-left: 50px;
+`;
+const SmallInput = styled(Input)`
+  height: 40px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  background-color: transparent;
+  border: none;
+  border-bottom-width: 1px;
+  border-color: black;
+`;
+const SmallText = styled(Text)`
+  height: 40px;
+  font-size: 14px;
+  padding-top: 11px;
+  padding-bottom: 8px;
+  padding-left: 17px;
+`;
+const DeleteButton = styled(Icon)`
+  padding-top: 5px;
+  padding-left: 0px;
+  padding-right: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  margin-bottom: 15px;
+  color: black;
+`;
+const dateStyle = {
+  height: 40,
+  paddingTop: 8,
+  paddingBottom: 2,
+  backgroundColor: 'transparent',
+  borderTopWidth: 0,
+  borderStartWidth: 0,
+  borderEndWidth: 0,
+  borderBottomWidth: 1,
+  borderColor: 'black',
+};
+
+interface Props {
+  item: Item;
+  value: Record<string, any> | string | number;
+  index?: number;
+  changeFromInput: (text: string | number) => void;
+  removeItem: () => void;
+  color: string;
+}
+
+const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput, removeItem, color }) => {
+  const inputComponent = (input: Item) => {
+    switch (input.type) {
+      case 'text':
+      case 'arrayText':
+        return (
+          <SmallInput
+            textAlign="right"
+            value={value}
+            onChangeText={changeFromInput}
+          />
+        );
+      case 'number':
+      case 'arrayNumber':
+        return (
+          <SmallInput
+            textAlign="right"
+            keyboardType="numeric"
+            value={value}
+            onChangeText={changeFromInput}
+          />
+        );
+      case 'date':
+      case 'arrayDate':
+        return (
+          <DateTimePickerForm
+            value={value as string}
+            mode="date"
+            selectorProps={{ locale: 'sv' }}
+            onSelect={changeFromInput}
+            color={color}
+            style={dateStyle}
+          />
+        );
+      default:
+        return (
+          <SmallInput
+            textAlign="right"
+            value={value}
+            onChangeText={changeFromInput}
+          />
+        );
+    }
+  };
+  return (
+    <ItemWrapper key={`${item.title}`}>
+      <SmallText>{`${item.title}`}{index ? ` ${index}`: null}</SmallText>
+      <InputWrapper>
+        {inputComponent(item)}
+      </InputWrapper>
+      <TouchableHighlight activeOpacity={1} onPress={removeItem}>
+        <DeleteButton name="clear" />
+      </TouchableHighlight>
+    </ItemWrapper>
+  );
+};
+SummaryListItem.propTypes = {
+  /**
+   * The header text of the list.
+   */
+  item: PropTypes.any,
+  /**
+   * The values of the entire list object
+   */
+  value: PropTypes.any,
+  /**
+   * What should happen to update the values
+   */
+  changeFromInput: PropTypes.func,
+  removeItem: PropTypes.func,
+  /**
+   * Sets the color scheme of the list. default is red.
+   */
+  color: PropTypes.string,
+};
+SummaryListItem.defaultProps = {
+  color: 'light',
+};
+export default SummaryListItem;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -6,21 +6,21 @@ import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import { Input, Text, Icon } from '../../atoms';
 import colors from '../../../styles/colors';
-import { Item } from './SummaryList';
+import { SummaryListItem as SummaryListItemType } from './SummaryList';
 import DateTimePickerForm from '../../molecules/DateTimePicker/DateTimePickerForm';
 
-const ItemWrapper = styled(View)`
+const SummaryListItemWrapper = styled(View)`
   flex-direction: row;
   align-items: flex-end;
   height: 46px;
 `;
-const InputWrapper = styled.View`
+const SummaryListInputWrapper = styled.View`
   align-items: center;
   justify-content: flex-end;
   flex: 1;
   padding-left: 50px;
 `;
-const SmallInput = styled(Input)`
+const SummaryListSmallInput = styled(Input)`
   height: 40px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -29,14 +29,14 @@ const SmallInput = styled(Input)`
   border-bottom-width: 1px;
   border-color: black;
 `;
-const SmallText = styled(Text)`
+const SummaryListSmallText = styled(Text)`
   height: 40px;
   font-size: 14px;
   padding-top: 11px;
   padding-bottom: 8px;
   padding-left: 17px;
 `;
-const DeleteButton = styled(Icon)`
+const SummaryListDeleteButton = styled(Icon)`
   padding-top: 5px;
   padding-left: 0px;
   padding-right: 0px;
@@ -58,7 +58,7 @@ const dateStyle = {
 };
 
 interface Props {
-  item: Item;
+  item: SummaryListItemType;
   value: Record<string, any> | string | number;
   index?: number;
   changeFromInput: (text: string | number) => void;
@@ -67,12 +67,12 @@ interface Props {
 }
 
 const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput, removeItem, color }) => {
-  const inputComponent = (input: Item) => {
+  const inputComponent = (input: SummaryListItemType) => {
     switch (input.type) {
       case 'text':
       case 'arrayText':
         return (
-          <SmallInput
+          <SummaryListSmallInput
             textAlign="right"
             value={value}
             onChangeText={changeFromInput}
@@ -81,7 +81,7 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
       case 'number':
       case 'arrayNumber':
         return (
-          <SmallInput
+          <SummaryListSmallInput
             textAlign="right"
             keyboardType="numeric"
             value={value}
@@ -102,7 +102,7 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
         );
       default:
         return (
-          <SmallInput
+          <SummaryListSmallInput
             textAlign="right"
             value={value}
             onChangeText={changeFromInput}
@@ -111,15 +111,15 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
     }
   };
   return (
-    <ItemWrapper key={`${item.title}`}>
-      <SmallText>{`${item.title}`}{index ? ` ${index}`: null}</SmallText>
-      <InputWrapper>
+    <SummaryListItemWrapper key={`${item.title}`}>
+      <SummaryListSmallText>{`${item.title}`}{index ? ` ${index}`: null}</SummaryListSmallText>
+      <SummaryListInputWrapper>
         {inputComponent(item)}
-      </InputWrapper>
+      </SummaryListInputWrapper>
       <TouchableHighlight activeOpacity={1} onPress={removeItem}>
-        <DeleteButton name="clear" />
+        <SummaryListDeleteButton name="clear" />
       </TouchableHighlight>
-    </ItemWrapper>
+    </SummaryListItemWrapper>
   );
 };
 SummaryListItem.propTypes = {
@@ -135,9 +135,10 @@ SummaryListItem.propTypes = {
    * What should happen to update the values
    */
   changeFromInput: PropTypes.func,
+  /** function to remove the item from the list */
   removeItem: PropTypes.func,
   /**
-   * Sets the color scheme of the list. default is red.
+   * Sets the color scheme of the list. default is light.
    */
   color: PropTypes.string,
 };

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -39,6 +39,7 @@ function loadStories() {
 	require('../source/components/organisms/FormList/FormList.stories');
 	require('../source/components/organisms/Step/Step.stories');
 	require('../source/components/organisms/SubstepList/SubstepList.stories');
+	require('../source/components/organisms/SummaryList/SummaryList.stories');
 	require('../source/components/organisms/WatsonAgent/WatsonAgent.stories');
 }
 
@@ -78,6 +79,7 @@ const stories = [
 	'../source/components/organisms/FormList/FormList.stories',
 	'../source/components/organisms/Step/Step.stories',
 	'../source/components/organisms/SubstepList/SubstepList.stories',
+	'../source/components/organisms/SummaryList/SummaryList.stories',
 	'../source/components/organisms/WatsonAgent/WatsonAgent.stories'
 ];
 


### PR DESCRIPTION
## Feature description
Much improved and simplified PR for adding the summary list component. Now changes 5 files, compared to the earlier 20+ files.

## Solution description
Adds a new input/view component that summarizes other input fields. Also updates the form-field component to deal with the new components (repeater and summary). 

## How do I test these changes?
Check the story for Summary List in the storybook. Review the code for the summary list component, and the story to see how it is used. 

## What areas is affected by these changes?.
The new component, and form field. 

## Is there any existing behaviour change of other features due to this code change?
No.

## Covered unit tests cases / E2E test cases?
No.

## Are your code structured in a way so that reviewers can understand it?
Yes, hopefully. The things to send into the summary list is a little involved, but hopefully by looking at prop types and the story people can understand it. 

## Was this feature tested in the following environments?
- [x] On a iOS device/simulator.
