### PR TITLE
Add layout animation to form field components

### DIFF
--- a/source/App.js
+++ b/source/App.js
@@ -2,6 +2,7 @@
 /* eslint-disable react/no-unused-state */
 /* eslint-disable react/sort-comp */
 import React from 'react';
+import { Platform, UIManager } from 'react-native';
 import Config from 'react-native-config';
 import { ThemeProvider } from 'styled-components/native';
 import Navigator from './navigator';
@@ -18,6 +19,12 @@ import { NotificationProvider } from './store/NotificationContext';
  */
 
 const App = () => {
+  // turn on layout animation.
+  if (Platform.OS === 'android') {
+    if (UIManager.setLayoutAnimationEnabledExperimental) {
+      UIManager.setLayoutAnimationEnabledExperimental(true);
+    }
+  }
   if (Config.IS_STORYBOOK === 'true') {
     return (
       <AuthProvider>

--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import { Icon } from 'source/components/atoms';
@@ -55,33 +55,35 @@ const CloseButton = styled.View({
   backgroundColor: '#00213F',
 });
 
-const BackNavigation = ({ style, onBack, onClose, isBackBtnVisible }) =>
-  isBackBtnVisible ? (
-    <ButtonWrapper style={style}>
+const BackNavigation = ({ style, onBack, onClose, showBackButton, showCloseButton }) => (
+  <ButtonWrapper style={style}>
+    {showBackButton ? (
       <BackButton onStartShouldSetResponder={onBack}>
         <Icon name="keyboard-backspace" style={styles.iconBack} />
       </BackButton>
+    ) : (
+      <View />
+    )}
+
+    {showCloseButton ? (
       <CloseButton onStartShouldSetResponder={onClose}>
         <Icon name="close" style={styles.iconClose} />
       </CloseButton>
-    </ButtonWrapper>
-  ) : (
-    <CloseButtonWrapper style={style}>
-      <CloseButton onStartShouldSetResponder={onClose}>
-        <Icon name="close" style={styles.iconClose} />
-      </CloseButton>
-    </CloseButtonWrapper>
-  );
+    ) : null}
+  </ButtonWrapper>
+);
 
 BackNavigation.propTypes = {
   style: PropTypes.array,
   onBack: PropTypes.func,
   onClose: PropTypes.func,
-  isBackBtnVisible: PropTypes.bool,
+  showBackButton: PropTypes.bool,
+  showCloseButton: PropTypes.bool,
 };
 
 BackNavigation.defaultProps = {
-  isBackBtnVisible: true,
+  showBackButton: true,
+  showCloseButton: true,
 };
 
 export default BackNavigation;

--- a/source/components/molecules/Banner/Banner.js
+++ b/source/components/molecules/Banner/Banner.js
@@ -35,7 +35,14 @@ const BannerImage = styled(Image)`
   height: 100%;
 `;
 
-const Banner = ({ stepNumber, totalStepNumber, imageSrc, iconSrc, backgroundColor, style }) => (
+const Banner = ({
+  currentPosition,
+  totalStepNumber,
+  imageSrc,
+  iconSrc,
+  backgroundColor,
+  style,
+}) => (
   <BannerWrapper
     image={imageSrc}
     style={style}
@@ -50,16 +57,21 @@ const Banner = ({ stepNumber, totalStepNumber, imageSrc, iconSrc, backgroundColo
     {Object.prototype.hasOwnProperty.call(icons, iconSrc) ? (
       <BannerImageIcon source={icons[iconSrc]} />
     ) : null}
-    {totalStepNumber > 1 && (
+    {totalStepNumber > 1 && currentPosition.level === 0 && (
       <ProgressCounterText>
-        Steg {stepNumber}/{totalStepNumber}
+        Steg {currentPosition.currentMainStep}/{totalStepNumber}
       </ProgressCounterText>
     )}
   </BannerWrapper>
 );
 
 Banner.propTypes = {
-  stepNumber: PropTypes.number,
+  /** The current position in the form */
+  currentPosition: PropTypes.shape({
+    index: PropTypes.number,
+    level: PropTypes.number,
+    currentMainStep: PropTypes.number,
+  }),
   totalStepNumber: PropTypes.number,
   imageSrc: PropTypes.string,
   iconSrc: PropTypes.string.isRequired,

--- a/source/components/molecules/FooterAction/FooterAction.js
+++ b/source/components/molecules/FooterAction/FooterAction.js
@@ -27,7 +27,7 @@ const FooterAction = ({
   onUpdate,
   onSubmit,
   updateCaseInContext,
-  stepNumber,
+  currentPosition,
   children,
 }) => {
   const { user, handleSign, status } = useContext(AuthContext);
@@ -35,7 +35,8 @@ const FooterAction = ({
   useEffect(() => {
     const signCase = () => {
       if (onUpdate) onUpdate(answers);
-      if (updateCaseInContext) updateCaseInContext(answers, 'submitted', stepNumber);
+      if (updateCaseInContext)
+        updateCaseInContext(answers, 'submitted', currentPosition.currentMainStep);
       if (formNavigation.next) formNavigation.next();
     };
 
@@ -68,7 +69,7 @@ const FooterAction = ({
         return () => {
           if (onUpdate && caseStatus === 'ongoing') onUpdate(answers);
           if (updateCaseInContext && caseStatus === 'ongoing')
-            updateCaseInContext(answers, 'ongoing', stepNumber);
+            updateCaseInContext(answers, 'ongoing', currentPosition.currentMainStep);
           if (formNavigation.next) formNavigation.next();
         };
       }
@@ -160,8 +161,12 @@ FooterAction.propTypes = {
   onSubmit: PropTypes.func,
   /** Behaviour for updating case in context and backend */
   updateCaseInContext: PropTypes.func,
-  /** The steps position in the form */
-  stepNumber: PropTypes.number,
+  /** The current position in the form */
+  currentPosition: PropTypes.shape({
+    index: PropTypes.number,
+    level: PropTypes.number,
+    currentMainStep: PropTypes.number,
+  }),
 };
 
 FooterAction.defaultProps = {

--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Input, FieldLabel, Select, Text } from 'source/components/atoms';
 import { CheckboxField, EditableList, GroupListWithAvatar } from 'source/components/molecules';
-import SubstepList from 'source/components/organisms/SubstepList';
 import { View } from 'react-native';
 import ConditionalTextField from 'app/components/molecules/ConditinalTextField';
 import colors from '../../../styles/colors';
-import DateTimePickerForm from '../DateTimePicker';
+import DateTimePickerForm from '../DateTimePicker/DateTimePickerForm';
 import NavigationButtonField from '../NavigationButtonField/NavigationButtonField';
-import NavigationButtonFieldGroup from '../NavigationButtonGroup/NavigationButtonGroup';
+import NavigationButtonGroup from '../NavigationButtonGroup/NavigationButtonGroup';
+import SummaryList from '../../organisms/SummaryList/SummaryList';
+import RepeaterField from '../RepeaterField/RepeaterField';
 
 const inputTypes = {
   text: {
@@ -49,14 +50,8 @@ const inputTypes = {
     props: {},
   },
   navigationButtonGroup: {
-    component: NavigationButtonFieldGroup,
+    component: NavigationButtonGroup,
     props: {},
-  },
-  substepListSummary: {
-    component: SubstepList,
-    changeEvent: 'onChange',
-    props: { summary: true },
-    initialValue: {},
   },
   select: {
     component: Select,
@@ -75,25 +70,37 @@ const inputTypes = {
     props: {},
     initialValue: '',
   },
+  summaryList: {
+    component: SummaryList,
+    changeEvent: 'onChange',
+    props: { answers: true },
+  },
+  repeaterField: {
+    component: RepeaterField,
+    changeEvent: 'onChange',
+    props: { answers: true },
+  },
 };
 
-const FormField = props => {
-  const {
-    label,
-    labelLine,
-    inputType,
-    color,
-    id,
-    onChange,
-    value,
-    answers,
-    conditionalOn,
-    labelHelp,
-    ...other
-  } = props;
+const FormField = ({
+  label,
+  labelLine,
+  inputType,
+  color,
+  id,
+  onChange,
+  value,
+  answers,
+  conditionalOn,
+  labelHelp,
+  ...other
+}) => {
   const input = inputTypes[inputType];
-  const saveInput = value => {
-    if (onChange) onChange({ [id]: value });
+  if (!input) {
+    return <Text>{`Invalid field type: ${inputType}`}</Text>;
+  }
+  const saveInput = (value, fieldId = id) => {
+    if (onChange) onChange({ [fieldId]: value });
   };
   if (!input) {
     return <Text>{`Invalid field type: ${inputType}`}</Text>;
@@ -111,6 +118,7 @@ const FormField = props => {
     ...inputProps,
     ...other,
   };
+  if (input?.props?.answers) inputCompProps.answers = answers;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;
 
   /** Checks if the field is conditional on another input, and if so,

--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Input, FieldLabel, Select, Text } from 'source/components/atoms';
 import { CheckboxField, EditableList, GroupListWithAvatar } from 'source/components/molecules';
-import { View } from 'react-native';
+import SubstepList from 'source/components/organisms/SubstepList';
+import { View, LayoutAnimation } from 'react-native';
 import ConditionalTextField from 'app/components/molecules/ConditinalTextField';
 import colors from '../../../styles/colors';
 import DateTimePickerForm from '../DateTimePicker/DateTimePickerForm';
@@ -144,6 +145,7 @@ const FormField = ({
     );
 
   if (checkCondition(conditionalOn)) {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     return (
       <View>
         {label ? (

--- a/source/components/molecules/FormField/FormField.stories.js
+++ b/source/components/molecules/FormField/FormField.stories.js
@@ -29,41 +29,6 @@ const items = [
   },
 ];
 
-const SubstepListFormField = () => {
-  const [answers, setAnswers] = useState({});
-
-  const onChange = values => {
-    const newAnswers = JSON.parse(JSON.stringify(answers));
-    Object.keys(values).forEach(key => {
-      newAnswers[key] = values[key];
-    });
-    setAnswers(newAnswers);
-  };
-
-  return (
-    <StoryWrapper>
-      <FormField
-        id="1"
-        inputType="substepList"
-        heading={heading}
-        onChange={onChange}
-        value={answers[1] || ''}
-        categories={categories}
-        items={items}
-      />
-      <FormField
-        id="1"
-        inputType="substepListSummary"
-        heading="Summary"
-        onChange={onChange}
-        value={answers[1] || ''}
-        categories={categories}
-        items={items}
-      />
-    </StoryWrapper>
-  );
-};
-
 const DateFormField = () => {
   const [date, setDate] = useState({ 7: '' });
   return (
@@ -79,67 +44,61 @@ const DateFormField = () => {
   );
 };
 
-storiesOf('Form Field input', module)
-  .add('Default', () => (
-    <StoryWrapper>
-      <ScrollView>
-        <FormField
-          id="1"
-          label="Text input"
-          color="light"
-          placeholder="write something"
-          inputType="text"
-        />
-        <FormField
-          id="2"
-          label="Text input, green"
-          color="green"
-          placeholder="write something else"
-          inputType="text"
-        />
-        <FormField
-          id="3"
-          label="Number input"
-          labelLine="false"
-          color="red"
-          placeholder="write a number..."
-          inputType="number"
-        />
-        <FormField
-          id="4"
-          labelLine="false"
-          color="red"
-          placeholder="Look ma, no label!"
-          inputType="text"
-        />
-        <FormField
-          id="5"
-          label="Checkbox input"
-          labelLine="true"
-          color="light"
-          text="Do you feel it now?"
-          inputType="checkbox"
-          placeholder="Do you feel it now?"
-        />
-        <FormField
-          id="6"
-          label="Select input"
-          labelLine="true"
-          color="light"
-          placeholder="Your car preference"
-          inputType="select"
-          items={[
-            { label: 'Ferrari', value: 'ferrari' },
-            { label: 'Buggati', value: 'buggati' },
-            { label: 'Porsche', value: 'porsche' },
-          ]}
-        />
-        <DateFormField />
-      </ScrollView>
-    </StoryWrapper>
-  ))
-  .add('Substep List', () => (
-    <StoryWrapper>
-      <SubstepListFormField />
-    </StoryWrapper>
-  ));
+storiesOf('Form Field input', module).add('Default', () => (
+  <StoryWrapper>
+    <ScrollView>
+      <FormField
+        id="1"
+        label="Text input"
+        color="light"
+        placeholder="write something"
+        inputType="text"
+      />
+      <FormField
+        id="2"
+        label="Text input, green"
+        color="green"
+        placeholder="write something else"
+        inputType="text"
+      />
+      <FormField
+        id="3"
+        label="Number input"
+        labelLine="false"
+        color="red"
+        placeholder="write a number..."
+        inputType="number"
+      />
+      <FormField
+        id="4"
+        labelLine="false"
+        color="red"
+        placeholder="Look ma, no label!"
+        inputType="text"
+      />
+      <FormField
+        id="5"
+        label="Checkbox input"
+        labelLine="true"
+        color="light"
+        text="Do you feel it now?"
+        inputType="checkbox"
+        placeholder="Do you feel it now?"
+      />
+      <FormField
+        id="6"
+        label="Select input"
+        labelLine="true"
+        color="light"
+        placeholder="Your car preference"
+        inputType="select"
+        items={[
+          { label: 'Ferrari', value: 'ferrari' },
+          { label: 'Buggati', value: 'buggati' },
+          { label: 'Porsche', value: 'porsche' },
+        ]}
+      />
+      <DateFormField />
+    </ScrollView>
+  </StoryWrapper>
+));

--- a/source/components/molecules/ImageUploader/ImageUploader.js
+++ b/source/components/molecules/ImageUploader/ImageUploader.js
@@ -7,7 +7,7 @@ import styled from 'styled-components/native';
 import { Heading, Text, Button, Icon } from 'app/components/atoms';
 import { ScreenWrapper } from 'app/components/molecules';
 import uploadFile from 'app/helpers/FileUpload';
-import { excludePropetiesWithKey } from 'app/helpers/Objects';
+import { excludePropetiesWithKey } from '../../../helpers/Objects';
 
 const Wrapper = styled(ScreenWrapper)`
   padding-left: 0;

--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { LayoutAnimation } from 'react-native';
 import { Button, Text } from '../../atoms';
 import RepeaterFieldListItem from './RepeaterFieldListItem';
 import Fieldset from '../../atoms/Fieldset/Fieldset';
@@ -45,6 +46,7 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
   };
 
   const addAnswer = () => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setLocalAnswers(prev => [...prev, {}]);
   };
 

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -60,7 +60,7 @@ function Step({
   onFieldChange,
   isBackBtnVisible,
   updateCaseInContext,
-  stepNumber,
+  currentPosition,
   totalStepNumber,
 }) {
   const {
@@ -80,19 +80,21 @@ function Step({
   useEffect(() => {
     handleSetStatus('idle');
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stepNumber]);
+  }, [currentPosition]);
 
   const closeForm = () => {
     if (status === 'ongoing') {
       if (onFieldChange) onFieldChange(answers);
-      if (updateCaseInContext) updateCaseInContext(answers, 'ongoing', stepNumber);
+      if (updateCaseInContext)
+        updateCaseInContext(answers, 'ongoing', currentPosition.currentMainStep);
     }
     if (formNavigation.close) formNavigation.close(() => {});
   };
   return (
     <StepContainer bg={theme.step.bg}>
       <StepBackNavigation
-        isBackBtnVisible={isBackBtnVisible}
+        showBackButton={isBackBtnVisible}
+        showCloseButton={currentPosition.level === 0}
         onBack={formNavigation.back}
         onClose={closeForm}
       />
@@ -103,7 +105,11 @@ function Step({
         showsHorizontalScrollIndicator={false}
       >
         {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
-          <StepBanner stepNumber={stepNumber} totalStepNumber={totalStepNumber} {...banner} />
+          <StepBanner
+            currentPosition={currentPosition}
+            totalStepNumber={totalStepNumber}
+            {...banner}
+          />
         )}
         <StepBody>
           {(isResolved || isIdle) && (
@@ -151,8 +157,8 @@ function Step({
             caseStatus={status}
             background={footerBg}
             answers={answers}
-            stepNumber={stepNumber}
             formNavigation={formNavigation}
+            currentPosition={currentPosition}
             onUpdate={onFieldChange}
             updateCaseInContext={updateCaseInContext}
           />
@@ -245,8 +251,12 @@ Step.propTypes = {
       }),
     }),
   }),
-  /** The steps number in the form */
-  stepNumber: PropTypes.number,
+  /** The current position in the form */
+  currentPosition: PropTypes.shape({
+    index: PropTypes.number,
+    level: PropTypes.number,
+    currentMainStep: PropTypes.number,
+  }),
   /** Total number of steps in the form */
   totalStepNumber: PropTypes.number,
 };

--- a/source/components/organisms/SummaryList/SummaryList.stories.js
+++ b/source/components/organisms/SummaryList/SummaryList.stories.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react-native';
+import StoryWrapper from '../../molecules/StoryWrapper';
+import SummaryList from './SummaryList';
+import { Input, FieldLabel, Text } from '../../atoms';
+
+const stories = storiesOf('Summary List', module);
+
+const items = [
+  { id: 'f1', type: 'text', title: 'favoritfrukt', category: 'fruit' },
+  { id: 'f2', type: 'text', title: 'grönsak', category: 'vegetable' },
+];
+
+const categories = [
+  { category: 'fruit', description: 'Frukt' },
+  { category: 'vegetable', description: 'Grönsak' },
+];
+
+const SummaryStory = () => {
+  const [state, setState] = useState({});
+  return (
+    <>
+      <FieldLabel>
+        <Text>Frukt</Text>
+      </FieldLabel>
+      <Input
+        value={state.f1}
+        onChangeText={text => {
+          setState(s => {
+            s.f1 = text;
+            return { ...s };
+          });
+        }}
+      />
+      <FieldLabel>
+        <Text>Grönsak</Text>
+      </FieldLabel>
+      <Input
+        value={state.f2}
+        onChangeText={text => {
+          setState(s => {
+            s.f2 = text;
+            return { ...s };
+          });
+        }}
+      />
+      <SummaryList
+        heading="Sammanfattning"
+        items={items}
+        categories={categories}
+        addButtonText="Add something"
+        color="light"
+        onChange={(answer, id) => {
+          setState(s => {
+            s[id] = answer;
+            return { ...s };
+          });
+        }}
+        d
+        answers={state}
+      />
+    </>
+  );
+};
+
+stories.add('default', () => (
+  <StoryWrapper>
+    <SummaryStory />
+  </StoryWrapper>
+));

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import GroupedList from '../../molecules/GroupedList/GroupedList';
-import SummaryListItem from './SummaryListItem';
+import SummaryListItemComponent from './SummaryListItem';
 
-export interface Item {
+export interface SummaryListItem {
   title: string;
   id: string;
   type: 'number' | 'text' | 'date' | 'arrayNumber' | 'arrayText' | 'arrayDate';
@@ -18,7 +18,7 @@ interface SummaryListCategory {
 
 interface Props {
   heading: string;
-  items: Item[];
+  items: SummaryListItem[];
   categories?: SummaryListCategory[];
   onChange: (answers: Record<string, any> | string | number, fieldId: string) => void;
   color: string;
@@ -36,7 +36,7 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
    * @param item The list item
    * @param index The index, when summarizing a repeater field with multiple answers
    */
-  const changeFromInput = (item: Item, index?: number) => (text: string) => {
+  const changeFromInput = (item: SummaryListItem, index?: number) => (text: string) => {
     if (
       ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
       typeof index !== 'undefined' &&
@@ -55,7 +55,7 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
    * @param item The list item
    * @param index The index, when summarizing a repeater field with multiple answers
    */
-  const removeListItem = (item: Item, index?: number) => () => {
+  const removeListItem = (item: SummaryListItem, index?: number) => () => {
     if (typeof index !== 'undefined') {
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
       oldAnswer.splice(index, 1);
@@ -67,13 +67,13 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
 
   /** Generates a list item */
   const generateListItem = (
-    item: Item,
+    item: SummaryListItem,
     value: string | number | Record<string, any>,
     index?: number
   ) => ({
     category: item.category,
     component: (
-      <SummaryListItem
+      <SummaryListItemComponent
         item={item}
         index={index ? index + 1 : undefined}
         value={value}

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import GroupedList from '../../molecules/GroupedList/GroupedList';
+import SummaryListItem from './SummaryListItem';
+
+export interface Item {
+  title: string;
+  id: string;
+  type: 'number' | 'text' | 'date' | 'arrayNumber' | 'arrayText' | 'arrayDate';
+  category?: string;
+  inputId?: string;
+}
+
+interface Category {
+  category: string;
+  description: string;
+}
+
+interface Props {
+  heading: string;
+  items: Item[];
+  categories?: Category[];
+  onChange: (answers: Record<string, any> | string | number, fieldId: string) => void;
+  color: string;
+  answers: Record<string, any>;
+}
+/**
+ * Summary list, that is linked and summarizes values from other input components.
+ * The things to summarize is specified in the items prop.
+ * The things are grouped into categories, as specified by the categories props.
+ */
+const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, color, answers }) => {
+  console.log(answers);
+  const changeFromInput = (item: Item, index?: number) => (text: string) => {
+    if (
+      ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
+      typeof index !== 'undefined' &&
+      item.inputId
+    ) {
+      const oldValue: Record<string, string | number>[] = answers[item.id];
+      oldValue[index][item.inputId] = text;
+      onChange(oldValue, item.id);
+    } else {
+      onChange(text, item.id);
+    }
+  };
+
+  const removeItem = (item: Item, index?: number) => () => {
+    if (typeof index !== 'undefined') {
+      const oldValue: Record<string, string | number>[] = answers[item.id];
+      oldValue.splice(index, 1);
+      onChange(oldValue, item.id);
+    } else {
+      onChange(undefined, item.id);
+    }
+  };
+
+  const listItems = [];
+  items
+    .filter(item => {
+      const val = answers[item.id];
+      return typeof val !== 'undefined';
+    })
+    .forEach(item => {
+      if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {
+        const values: Record<string, string | number>[] = answers[item.id];
+        if (values && values?.length > 0) {
+          values.forEach((v, index) => {
+            listItems.push({
+              category: item.category,
+              component: (
+                <SummaryListItem
+                  item={item}
+                  index={index + 1}
+                  value={v[item?.inputId || item.id]}
+                  changeFromInput={changeFromInput(item, index)}
+                  removeItem={removeItem(item, index)}
+                  color={color}
+                />
+              ),
+            });
+          });
+        }
+      } else {
+        listItems.push({
+          category: item.category,
+          component: (
+            <SummaryListItem
+              item={item}
+              value={answers[item.id]}
+              changeFromInput={changeFromInput(item)}
+              removeItem={removeItem(item)}
+              color={color}
+            />
+          ),
+        });
+      }
+    });
+  return <GroupedList heading={heading} items={listItems} categories={categories} color={color} />;
+};
+
+SummaryList.propTypes = {
+  /**
+   * The header text of the list.
+   */
+  heading: PropTypes.string,
+  /**
+   * List of all items, corresponding to all subforms
+   */
+  items: PropTypes.array,
+  /**
+   * The categories of the grouping
+   */
+  categories: PropTypes.array,
+  /**
+   * What should happen to update the values
+   */
+  onChange: PropTypes.func,
+  /**
+   * Sets the color scheme of the list. default is red.
+   */
+  color: PropTypes.string,
+  /**
+   * Message to display before anything has been added to the list.
+   */
+  answers: PropTypes.object,
+};
+
+SummaryList.defaultProps = {
+  items: [],
+  color: 'red',
+  onChange: () => {},
+};
+export default SummaryList;

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -30,7 +30,6 @@ interface Props {
  * The things are grouped into categories, as specified by the categories props.
  */
 const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, color, answers }) => {
-  console.log(answers);
   const changeFromInput = (item: Item, index?: number) => (text: string) => {
     if (
       ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
@@ -96,7 +95,11 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
         });
       }
     });
-  return <GroupedList heading={heading} items={listItems} categories={categories} color={color} />;
+  return (
+    listItems.length > 0 && (
+      <GroupedList heading={heading} items={listItems} categories={categories} color={color} />
+    )
+  );
 };
 
 SummaryList.propTypes = {

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import GroupedList from '../../molecules/GroupedList/GroupedList';
-import SummaryListItemComponent from './SummaryListItem';
+import React from "react";
+import PropTypes from "prop-types";
+import GroupedList from "../../molecules/GroupedList/GroupedList";
+import SummaryListItemComponent from "./SummaryListItem";
 
 export interface SummaryListItem {
   title: string;
   id: string;
-  type: 'number' | 'text' | 'date' | 'arrayNumber' | 'arrayText' | 'arrayDate';
+  type: "number" | "text" | "date" | "arrayNumber" | "arrayText" | "arrayDate";
   category?: string;
   inputId?: string;
 }
@@ -20,7 +20,10 @@ interface Props {
   heading: string;
   items: SummaryListItem[];
   categories?: SummaryListCategory[];
-  onChange: (answers: Record<string, any> | string | number, fieldId: string) => void;
+  onChange: (
+    answers: Record<string, any> | string | number,
+    fieldId: string
+  ) => void;
   color: string;
   answers: Record<string, any>;
 }
@@ -29,17 +32,26 @@ interface Props {
  * The things to summarize is specified in the items prop.
  * The things are grouped into categories, as specified by the categories props.
  */
-const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, color, answers }) => {
+const SummaryList: React.FC<Props> = ({
+  heading,
+  items,
+  categories,
+  onChange,
+  color,
+  answers,
+}) => {
   /**
    * Given an item, and possibly an index in the case of repeater fields, this generates a function that
    * updates the form data from the input.
    * @param item The list item
    * @param index The index, when summarizing a repeater field with multiple answers
    */
-  const changeFromInput = (item: SummaryListItem, index?: number) => (text: string) => {
+  const changeFromInput = (item: SummaryListItem, index?: number) => (
+    text: string
+  ) => {
     if (
-      ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
-      typeof index !== 'undefined' &&
+      ["arrayNumber", "arrayText", "arrayDate"].includes(item.type) &&
+      typeof index !== "undefined" &&
       item.inputId
     ) {
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
@@ -56,7 +68,7 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
    * @param index The index, when summarizing a repeater field with multiple answers
    */
   const removeListItem = (item: SummaryListItem, index?: number) => () => {
-    if (typeof index !== 'undefined') {
+    if (typeof index !== "undefined") {
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
       oldAnswer.splice(index, 1);
       onChange(oldAnswer, item.id);
@@ -86,16 +98,18 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
 
   const listItems = [];
   items
-    .filter(item => {
-      const val = answers[item.id];
-      return typeof val !== 'undefined';
+    .filter((item) => {
+      const answer = answers[item.id];
+      return typeof answer !== "undefined";
     })
-    .forEach(item => {
-      if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {
+    .forEach((item) => {
+      if (["arrayNumber", "arrayText", "arrayDate"].includes(item.type)) {
         const values: Record<string, string | number>[] = answers[item.id];
         if (values && values?.length > 0) {
           values.forEach((v, index) => {
-            listItems.push(generateListItem(item, v[item?.inputId || item.id], index));
+            listItems.push(
+              generateListItem(item, v[item?.inputId || item.id], index)
+            );
           });
         }
       } else {
@@ -104,7 +118,12 @@ const SummaryList: React.FC<Props> = ({ heading, items, categories, onChange, co
     });
   return (
     listItems.length > 0 && (
-      <GroupedList heading={heading} items={listItems} categories={categories} color={color} />
+      <GroupedList
+        heading={heading}
+        items={listItems}
+        categories={categories}
+        color={color}
+      />
     )
   );
 };
@@ -138,7 +157,7 @@ SummaryList.propTypes = {
 
 SummaryList.defaultProps = {
   items: [],
-  color: 'red',
+  color: "red",
   onChange: () => {},
 };
 export default SummaryList;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable no-nested-ternary */
-import React from 'react';
-import { View } from 'react-native';
-import { TouchableHighlight } from 'react-native-gesture-handler';
-import styled from 'styled-components/native';
-import PropTypes from 'prop-types';
-import { Input, Text, Icon } from '../../atoms';
-import colors from '../../../styles/colors';
-import { SummaryListItem as SummaryListItemType } from './SummaryList';
-import DateTimePickerForm from '../../molecules/DateTimePicker/DateTimePickerForm';
+import React from "react";
+import { View } from "react-native";
+import { TouchableHighlight } from "react-native-gesture-handler";
+import styled from "styled-components/native";
+import PropTypes from "prop-types";
+import { Input, Text, Icon } from "../../atoms";
+import colors from "../../../styles/colors";
+import { SummaryListItem as SummaryListItemType } from "./SummaryList";
+import DateTimePickerForm from "../../molecules/DateTimePicker/DateTimePickerForm";
 
 const SummaryListItemWrapper = styled(View)`
   flex-direction: row;
@@ -49,12 +49,12 @@ const dateStyle = {
   height: 40,
   paddingTop: 8,
   paddingBottom: 2,
-  backgroundColor: 'transparent',
+  backgroundColor: "transparent",
   borderTopWidth: 0,
   borderStartWidth: 0,
   borderEndWidth: 0,
   borderBottomWidth: 1,
-  borderColor: 'black',
+  borderColor: "black",
 };
 
 interface Props {
@@ -66,11 +66,22 @@ interface Props {
   color: string;
 }
 
-const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput, removeItem, color }) => {
+/**
+ * A component for rendering an singel item in a SummaryList Component.
+ * Each summary item contains input fields with a descriptive label, the ability to clear the inputs and .
+ */
+const SummaryListItem: React.FC<Props> = ({
+  item,
+  value,
+  index,
+  changeFromInput,
+  removeItem,
+  color,
+}) => {
   const inputComponent = (input: SummaryListItemType) => {
     switch (input.type) {
-      case 'text':
-      case 'arrayText':
+      case "text":
+      case "arrayText":
         return (
           <SummaryListSmallInput
             textAlign="right"
@@ -78,8 +89,8 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
             onChangeText={changeFromInput}
           />
         );
-      case 'number':
-      case 'arrayNumber':
+      case "number":
+      case "arrayNumber":
         return (
           <SummaryListSmallInput
             textAlign="right"
@@ -88,13 +99,13 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
             onChangeText={changeFromInput}
           />
         );
-      case 'date':
-      case 'arrayDate':
+      case "date":
+      case "arrayDate":
         return (
           <DateTimePickerForm
             value={value as string}
             mode="date"
-            selectorProps={{ locale: 'sv' }}
+            selectorProps={{ locale: "sv" }}
             onSelect={changeFromInput}
             color={color}
             style={dateStyle}
@@ -112,10 +123,11 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
   };
   return (
     <SummaryListItemWrapper key={`${item.title}`}>
-      <SummaryListSmallText>{`${item.title}`}{index ? ` ${index}`: null}</SummaryListSmallText>
-      <SummaryListInputWrapper>
-        {inputComponent(item)}
-      </SummaryListInputWrapper>
+      <SummaryListSmallText>
+        {`${item.title}`}
+        {index ? ` ${index}` : null}
+      </SummaryListSmallText>
+      <SummaryListInputWrapper>{inputComponent(item)}</SummaryListInputWrapper>
       <TouchableHighlight activeOpacity={1} onPress={removeItem}>
         <SummaryListDeleteButton name="clear" />
       </TouchableHighlight>
@@ -143,6 +155,6 @@ SummaryListItem.propTypes = {
   color: PropTypes.string,
 };
 SummaryListItem.defaultProps = {
-  color: 'light',
+  color: "light",
 };
 export default SummaryListItem;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -1,0 +1,147 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react';
+import { View } from 'react-native';
+import { TouchableHighlight } from 'react-native-gesture-handler';
+import styled from 'styled-components/native';
+import PropTypes from 'prop-types';
+import { Input, Text, Icon } from '../../atoms';
+import colors from '../../../styles/colors';
+import { Item } from './SummaryList';
+import DateTimePickerForm from '../../molecules/DateTimePicker/DateTimePickerForm';
+
+const ItemWrapper = styled(View)`
+  flex-direction: row;
+  align-items: flex-end;
+  height: 46px;
+`;
+const InputWrapper = styled.View`
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1;
+  padding-left: 50px;
+`;
+const SmallInput = styled(Input)`
+  height: 40px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  background-color: transparent;
+  border: none;
+  border-bottom-width: 1px;
+  border-color: black;
+`;
+const SmallText = styled(Text)`
+  height: 40px;
+  font-size: 14px;
+  padding-top: 11px;
+  padding-bottom: 8px;
+  padding-left: 17px;
+`;
+const DeleteButton = styled(Icon)`
+  padding-top: 5px;
+  padding-left: 0px;
+  padding-right: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  margin-bottom: 15px;
+  color: black;
+`;
+const dateStyle = {
+  height: 40,
+  paddingTop: 8,
+  paddingBottom: 2,
+  backgroundColor: 'transparent',
+  borderTopWidth: 0,
+  borderStartWidth: 0,
+  borderEndWidth: 0,
+  borderBottomWidth: 1,
+  borderColor: 'black',
+};
+
+interface Props {
+  item: Item;
+  value: Record<string, any> | string | number;
+  index?: number;
+  changeFromInput: (text: string | number) => void;
+  removeItem: () => void;
+  color: string;
+}
+
+const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput, removeItem, color }) => {
+  const inputComponent = (input: Item) => {
+    switch (input.type) {
+      case 'text':
+      case 'arrayText':
+        return (
+          <SmallInput
+            textAlign="right"
+            value={value}
+            onChangeText={changeFromInput}
+          />
+        );
+      case 'number':
+      case 'arrayNumber':
+        return (
+          <SmallInput
+            textAlign="right"
+            keyboardType="numeric"
+            value={value}
+            onChangeText={changeFromInput}
+          />
+        );
+      case 'date':
+      case 'arrayDate':
+        return (
+          <DateTimePickerForm
+            value={value as string}
+            mode="date"
+            selectorProps={{ locale: 'sv' }}
+            onSelect={changeFromInput}
+            color={color}
+            style={dateStyle}
+          />
+        );
+      default:
+        return (
+          <SmallInput
+            textAlign="right"
+            value={value}
+            onChangeText={changeFromInput}
+          />
+        );
+    }
+  };
+  return (
+    <ItemWrapper key={`${item.title}`}>
+      <SmallText>{`${item.title}`}{index ? ` ${index}`: null}</SmallText>
+      <InputWrapper>
+        {inputComponent(item)}
+      </InputWrapper>
+      <TouchableHighlight activeOpacity={1} onPress={removeItem}>
+        <DeleteButton name="clear" />
+      </TouchableHighlight>
+    </ItemWrapper>
+  );
+};
+SummaryListItem.propTypes = {
+  /**
+   * The header text of the list.
+   */
+  item: PropTypes.any,
+  /**
+   * The values of the entire list object
+   */
+  value: PropTypes.any,
+  /**
+   * What should happen to update the values
+   */
+  changeFromInput: PropTypes.func,
+  removeItem: PropTypes.func,
+  /**
+   * Sets the color scheme of the list. default is red.
+   */
+  color: PropTypes.string,
+};
+SummaryListItem.defaultProps = {
+  color: 'light',
+};
+export default SummaryListItem;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -6,21 +6,21 @@ import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import { Input, Text, Icon } from '../../atoms';
 import colors from '../../../styles/colors';
-import { Item } from './SummaryList';
+import { SummaryListItem as SummaryListItemType } from './SummaryList';
 import DateTimePickerForm from '../../molecules/DateTimePicker/DateTimePickerForm';
 
-const ItemWrapper = styled(View)`
+const SummaryListItemWrapper = styled(View)`
   flex-direction: row;
   align-items: flex-end;
   height: 46px;
 `;
-const InputWrapper = styled.View`
+const SummaryListInputWrapper = styled.View`
   align-items: center;
   justify-content: flex-end;
   flex: 1;
   padding-left: 50px;
 `;
-const SmallInput = styled(Input)`
+const SummaryListSmallInput = styled(Input)`
   height: 40px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -29,14 +29,14 @@ const SmallInput = styled(Input)`
   border-bottom-width: 1px;
   border-color: black;
 `;
-const SmallText = styled(Text)`
+const SummaryListSmallText = styled(Text)`
   height: 40px;
   font-size: 14px;
   padding-top: 11px;
   padding-bottom: 8px;
   padding-left: 17px;
 `;
-const DeleteButton = styled(Icon)`
+const SummaryListDeleteButton = styled(Icon)`
   padding-top: 5px;
   padding-left: 0px;
   padding-right: 0px;
@@ -58,7 +58,7 @@ const dateStyle = {
 };
 
 interface Props {
-  item: Item;
+  item: SummaryListItemType;
   value: Record<string, any> | string | number;
   index?: number;
   changeFromInput: (text: string | number) => void;
@@ -67,12 +67,12 @@ interface Props {
 }
 
 const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput, removeItem, color }) => {
-  const inputComponent = (input: Item) => {
+  const inputComponent = (input: SummaryListItemType) => {
     switch (input.type) {
       case 'text':
       case 'arrayText':
         return (
-          <SmallInput
+          <SummaryListSmallInput
             textAlign="right"
             value={value}
             onChangeText={changeFromInput}
@@ -81,7 +81,7 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
       case 'number':
       case 'arrayNumber':
         return (
-          <SmallInput
+          <SummaryListSmallInput
             textAlign="right"
             keyboardType="numeric"
             value={value}
@@ -102,7 +102,7 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
         );
       default:
         return (
-          <SmallInput
+          <SummaryListSmallInput
             textAlign="right"
             value={value}
             onChangeText={changeFromInput}
@@ -111,15 +111,15 @@ const SummaryListItem: React.FC<Props> = ({ item, value, index, changeFromInput,
     }
   };
   return (
-    <ItemWrapper key={`${item.title}`}>
-      <SmallText>{`${item.title}`}{index ? ` ${index}`: null}</SmallText>
-      <InputWrapper>
+    <SummaryListItemWrapper key={`${item.title}`}>
+      <SummaryListSmallText>{`${item.title}`}{index ? ` ${index}`: null}</SummaryListSmallText>
+      <SummaryListInputWrapper>
         {inputComponent(item)}
-      </InputWrapper>
+      </SummaryListInputWrapper>
       <TouchableHighlight activeOpacity={1} onPress={removeItem}>
-        <DeleteButton name="clear" />
+        <SummaryListDeleteButton name="clear" />
       </TouchableHighlight>
-    </ItemWrapper>
+    </SummaryListItemWrapper>
   );
 };
 SummaryListItem.propTypes = {
@@ -135,9 +135,10 @@ SummaryListItem.propTypes = {
    * What should happen to update the values
    */
   changeFromInput: PropTypes.func,
+  /** function to remove the item from the list */
   removeItem: PropTypes.func,
   /**
-   * Sets the color scheme of the list. default is red.
+   * Sets the color scheme of the list. default is light.
    */
   color: PropTypes.string,
 };

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -42,7 +42,7 @@ const Form: React.FC<Props> = ({
   status,
   updateCaseInContext,
 }) => {
-  const currentPosition = { index: startAt, level: 0 };
+  const currentPosition = { index: startAt, level: 0, currentMainStep: 1 };
   const initialState = {
     submitted: false,
     currentPosition,
@@ -79,9 +79,12 @@ const Form: React.FC<Props> = ({
         onSubmit={() => handleSubmit(onSubmit)}
         onFieldChange={handleInputChange}
         updateCaseInContext={updateCaseInContext}
-        stepNumber={0} // TO FIX!! NEED TO THINK ABOUT
-        totalStepNumber={formState.steps.length}
-        isBackBtnVisible
+        currentPosition={formState.currentPosition}
+        totalStepNumber={formState.numberOfMainSteps}
+        isBackBtnVisible={
+          formState.currentPosition.currentMainStep > 1 &&
+          formState.currentPosition.currentMainStep < formState.numberOfMainSteps
+        }
       />
     )
   );

--- a/source/containers/Form/hooks/formReducer.ts
+++ b/source/containers/Form/hooks/formReducer.ts
@@ -8,11 +8,15 @@ import {
   startForm,
   submitForm,
   updateAnswer,
+  computeNumberMainSteps,
 } from './formActions';
 
 type Action =
   | {
       type: 'REPLACE_MARKDOWN_TEXT';
+    }
+  | {
+      type: 'COUNT_MAIN_STEPS';
     }
   | {
       type: 'GO_NEXT';
@@ -55,6 +59,13 @@ function formReducer(state: FormReducerState, action: Action) {
      */
     case 'REPLACE_MARKDOWN_TEXT': {
       return replaceMarkdownText(state);
+    }
+
+    /**
+     * Counts the number of main steps and saves it in the state.
+     */
+    case 'COUNT_MAIN_STEPS': {
+      return computeNumberMainSteps(state);
     }
 
     /**

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -5,7 +5,7 @@ import { User } from '../../../types/UserTypes';
 
 export interface FormReducerState {
   submitted: boolean;
-  currentPosition: { index: number; level: number };
+  currentPosition: { index: number; level: number; currentMainStep: number };
   steps: Step[];
   user: User;
   connectivityMatrix: StepperActions[][];
@@ -35,6 +35,9 @@ function useForm(initialState: FormReducerState) {
     console.log('number of main steps:', computeNumberMainSteps(formState.connectivityMatrix));
     dispatch({
       type: 'REPLACE_MARKDOWN_TEXT',
+    });
+    dispatch({
+      type: 'COUNT_MAIN_STEPS',
     });
   }, [formState.connectivityMatrix]);
 

--- a/source/helpers/FileUpload.js
+++ b/source/helpers/FileUpload.js
@@ -50,7 +50,6 @@ const uploadFile = async (endpoint, fileName, fileType, fileData, headers = {}) 
     });
     // return the url and filename on server to the uploaded file.
     return { url: putResponse.url, uploadedFileName };
-
   } catch (error) {
     console.log('axios error', error);
     return { error: true, message: error.message, ...error.response };

--- a/source/navigator/RootNavigator.js
+++ b/source/navigator/RootNavigator.js
@@ -22,7 +22,13 @@ const RootStack = () => (
       component={BottomBarNavigator}
       options={{ cardStyleInterpolator: forFade }}
     />
-    <Stack.Screen name="Form" component={FormCaseScreen} />
+    <Stack.Screen
+      name="Form"
+      component={FormCaseScreen}
+      options={{
+        gestureEnabled: false,
+      }}
+    />
   </Stack.Navigator>
 );
 

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -69,7 +69,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       {form?.steps ? (
         <Form
           steps={form.steps}
-          startAt={caseData?.currentStep || initialCase?.currentStep || 1}
+          startAt={caseData?.currentStep || initialCase?.currentStep || 0}
           connectivityMatrix={form.connectivityMatrix}
           user={user}
           onClose={handleCloseForm}

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -39,6 +39,7 @@ function loadStories() {
 	require('../source/components/organisms/FormList/FormList.stories');
 	require('../source/components/organisms/Step/Step.stories');
 	require('../source/components/organisms/SubstepList/SubstepList.stories');
+	require('../source/components/organisms/SummaryList/SummaryList.stories');
 	require('../source/components/organisms/WatsonAgent/WatsonAgent.stories');
 }
 
@@ -78,6 +79,7 @@ const stories = [
 	'../source/components/organisms/FormList/FormList.stories',
 	'../source/components/organisms/Step/Step.stories',
 	'../source/components/organisms/SubstepList/SubstepList.stories',
+	'../source/components/organisms/SummaryList/SummaryList.stories',
 	'../source/components/organisms/WatsonAgent/WatsonAgent.stories'
 ];
 


### PR DESCRIPTION
## Feature description
Adds a smooth animation when things in the form are added or removed, so that things don't jump so suddenly.

## Solution description
Uses the react-native built in layout animation with easeInEaseOut preset, see https://reactnative.dev/docs/layoutanimation , to add animations that make form fields appear or hide smoothly. 
I'm applying an app-wide setting in App.js, which in the long run maybe should be moved somewhere else, but I don't see anywhere else that is natural to put it right now. Maybe we should have a different file where we set global settings like this. 

Here I'm just applying one of their presets, which looks okay, but the exact animation behavior can be tuned in various ways. 

## What areas is affected by these changes?
The form field component and the repeater field.

## How to test the fix?
Go into the form and test toggling a checkbox that hides inputs (like the 'Jag har ingen inkomst'), or go into the story for repeater field and test adding/removing input fields there. 

## Is there any existing behaviour change of other features due to this code change?
No.

## Covered unit tests cases / E2E test cases?
No.

## Are your code structured in a way so that reviewers can understand it?
Yes.

## Was this feature tested in the following environments?
- [x] On a iOS device/simulator.
