### PR TITLE
fix(api): updated forms api url

### DIFF
--- a/source/store/FormContext.js
+++ b/source/store/FormContext.js
@@ -17,7 +17,7 @@ export function FormProvider({ children }) {
       return formSummaries;
     }
     try {
-      const response = await get('/forms3', { 'x-api-key': env.MITTHELSINGBORG_IO_APIKEY });
+      const response = await get('/forms', { 'x-api-key': env.MITTHELSINGBORG_IO_APIKEY });
       if (response.data.data.forms) {
         setFormSummaries(response.data.data.forms);
         return response.data.data.forms;
@@ -33,7 +33,7 @@ export function FormProvider({ children }) {
       return forms[id];
     }
     try {
-      const response = await get(`/forms3/${id}`, { 'x-api-key': env.MITTHELSINGBORG_IO_APIKEY })
+      const response = await get(`/forms/${id}`, { 'x-api-key': env.MITTHELSINGBORG_IO_APIKEY })
         .then(res => {
           if (res && res.data) {
             setForms({ ...forms, [res.data.data.id]: res.data.data });


### PR DESCRIPTION
The endpoint from where we collect forms from the backend on aws have been updated from /forms3 to /forms. So without updating the endpoint in the app a request cannot be made. 

Changes to correct these new behavior in the api have been made in this PR