### PR TITLE
Configured xCode project as a release build

### DIFF
--- a/ios/MittHelsingborg.xcodeproj/xcshareddata/xcschemes/MittHelsingborg.xcscheme
+++ b/ios/MittHelsingborg.xcodeproj/xcshareddata/xcschemes/MittHelsingborg.xcscheme
@@ -78,9 +78,9 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
This commit prepares the project for live demos on iPhone. No setup will be required before the deploy. 

Testing
Can be tested by running the project from xCode (build and run play button) in simulator or iPhone.

Changes
Scheme -> Run -> Build configured as "Relese" and Debug executable disabled.