### PR TITLE
style: the banner component now supports colorSchema as a prop

### DIFF
--- a/source/components/molecules/Banner/Banner.js
+++ b/source/components/molecules/Banner/Banner.js
@@ -31,7 +31,7 @@ const BannerImage = styled(Image)`
   height: 100%;
 `;
 
-const Banner = ({ style, currentPosition, totalStepNumber, imageSrc, iconSrc, colorSchema }) => (
+const Banner = ({ style, currentPosition, totalStepNumber, imageSrc, colorSchema }) => (
   <BannerWrapper style={style} image={imageSrc} colorSchema={colorSchema}>
     {Object.prototype.hasOwnProperty.call(icons, imageSrc) ? (
       <BannerImageWrapper>

--- a/source/components/molecules/Banner/Banner.js
+++ b/source/components/molecules/Banner/Banner.js
@@ -9,16 +9,12 @@ const BannerWrapper = styled.View`
   margin: 0;
   padding: 0;
   min-height: ${props => (props.image ? '256px' : '192px')};
-  background: ${props => props.backgroundColor};
+  background-color: ${props =>
+    props.backgroundColor
+      ? props.backgroundColor
+      : props.theme.colors.complementary[props.colorSchema][0]};
   position: relative;
   justify-content: flex-end;
-`;
-
-const BannerImageIcon = styled(Image)`
-  width: 72px;
-  position: absolute;
-  bottom: -37px;
-  left: 32px;
 `;
 
 const ProgressCounterText = styled(Text)`
@@ -35,28 +31,17 @@ const BannerImage = styled(Image)`
   height: 100%;
 `;
 
-const Banner = ({
-  currentPosition,
-  totalStepNumber,
-  imageSrc,
-  iconSrc,
-  backgroundColor,
-  style,
-}) => (
-  <BannerWrapper
-    image={imageSrc}
-    style={style}
-    backgroundColor={backgroundColor && backgroundColor !== '' ? backgroundColor : 'white'}
-  >
+const Banner = ({ style, currentPosition, totalStepNumber, imageSrc, iconSrc, colorSchema }) => (
+  <BannerWrapper style={style} image={imageSrc} colorSchema={colorSchema}>
     {Object.prototype.hasOwnProperty.call(icons, imageSrc) ? (
       <BannerImageWrapper>
         <BannerImage resizeMode="contain" source={icons[imageSrc]} />
       </BannerImageWrapper>
     ) : null}
-
-    {Object.prototype.hasOwnProperty.call(icons, iconSrc) ? (
-      <BannerImageIcon source={icons[iconSrc]} />
-    ) : null}
+    {/*
+        TODO: Move ProgressCounterText component out of the banner component.
+        Could be rendered as a child in the Banner instead where it's needed. ie in a Step.
+      */}
     {totalStepNumber > 1 && currentPosition.level === 0 && (
       <ProgressCounterText>
         Steg {currentPosition.currentMainStep}/{totalStepNumber}
@@ -73,13 +58,22 @@ Banner.propTypes = {
     currentMainStep: PropTypes.number,
   }),
   totalStepNumber: PropTypes.number,
+  /**
+   * The source to a image to render as a background in the banner.
+   */
   imageSrc: PropTypes.string,
-  iconSrc: PropTypes.string.isRequired,
-  backgroundColor: PropTypes.string,
-  style: PropTypes.array.isRequired,
+  /**
+   * The React Native style property. This is optional and might override the colorSchema.
+   */
+  style: PropTypes.string,
+  /**
+   * The color schema that the component should apply, colors are retrived from ThemeProvider
+   */
+  colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
 };
 Banner.defaultProps = {
   imageSrc: undefined,
-  backgroundColor: '#FBF7F0',
+  colorSchema: 'blue',
+  style: {},
 };
 export default Banner;

--- a/source/components/molecules/Banner/Banner.stories.js
+++ b/source/components/molecules/Banner/Banner.stories.js
@@ -19,8 +19,28 @@ storiesOf('Banner', module)
       <Banner imageSrc={ILLU_EXPENSES} iconSrc={ICON_EXPENSES} />
     </StoryWrapper>
   ))
-  .add('Background', props => (
+  .add('Custom Styling', props => (
     <StoryWrapper {...props}>
-      <Banner backgroundColor="#75C9A8" iconSrc={ICON_INCOME} />
+      <Banner style={{ backgroundColor: 'yellow' }} colorSchema="blue" iconSrc={ICON_INCOME} />
+    </StoryWrapper>
+  ))
+  .add('Color Schema Blue', props => (
+    <StoryWrapper {...props}>
+      <Banner colorSchema="blue" iconSrc={ICON_INCOME} />
+    </StoryWrapper>
+  ))
+  .add('Color Schema Red', props => (
+    <StoryWrapper {...props}>
+      <Banner colorSchema="red" iconSrc={ICON_INCOME} />
+    </StoryWrapper>
+  ))
+  .add('Color Schema Green', props => (
+    <StoryWrapper {...props}>
+      <Banner colorSchema="green" iconSrc={ICON_INCOME} />
+    </StoryWrapper>
+  ))
+  .add('Color Schema Purple', props => (
+    <StoryWrapper {...props}>
+      <Banner colorSchema="purple" iconSrc={ICON_INCOME} />
     </StoryWrapper>
   ));

--- a/source/components/molecules/Banner/Banner.stories.js
+++ b/source/components/molecules/Banner/Banner.stories.js
@@ -4,43 +4,35 @@ import StoryWrapper from '../StoryWrapper';
 import Banner from './Banner';
 
 const ILLU_EXPENSES = require('source/assets/images/illustrations/illu_utgifter_margins_1x.png');
-const ICON_INCOME = require('source/assets/images/icons/icn_inkomster_1x.png');
-const ICON_EKB = require('source/assets/images/icons/icn_Main_ekonomiskt-bistand_1x.png');
-const ICON_EXPENSES = require('source/assets/images/icons/icn_utgifter_1x.png');
 
 storiesOf('Banner', module)
-  .add('Icon', props => (
+  .add('Image', props => (
     <StoryWrapper {...props}>
-      <Banner iconSrc={ICON_EKB} />
-    </StoryWrapper>
-  ))
-  .add('Icon & Image', props => (
-    <StoryWrapper {...props}>
-      <Banner imageSrc={ILLU_EXPENSES} iconSrc={ICON_EXPENSES} />
+      <Banner imageSrc={ILLU_EXPENSES} />
     </StoryWrapper>
   ))
   .add('Custom Styling', props => (
     <StoryWrapper {...props}>
-      <Banner style={{ backgroundColor: 'yellow' }} colorSchema="blue" iconSrc={ICON_INCOME} />
+      <Banner style={{ backgroundColor: 'yellow' }} colorSchema="blue" />
     </StoryWrapper>
   ))
   .add('Color Schema Blue', props => (
     <StoryWrapper {...props}>
-      <Banner colorSchema="blue" iconSrc={ICON_INCOME} />
+      <Banner colorSchema="blue" />
     </StoryWrapper>
   ))
   .add('Color Schema Red', props => (
     <StoryWrapper {...props}>
-      <Banner colorSchema="red" iconSrc={ICON_INCOME} />
+      <Banner colorSchema="red" />
     </StoryWrapper>
   ))
   .add('Color Schema Green', props => (
     <StoryWrapper {...props}>
-      <Banner colorSchema="green" iconSrc={ICON_INCOME} />
+      <Banner colorSchema="green" />
     </StoryWrapper>
   ))
   .add('Color Schema Purple', props => (
     <StoryWrapper {...props}>
-      <Banner colorSchema="purple" iconSrc={ICON_INCOME} />
+      <Banner colorSchema="purple" />
     </StoryWrapper>
   ));

--- a/source/styles/theme.js
+++ b/source/styles/theme.js
@@ -122,9 +122,6 @@ const theme = {
       footer: {
         bg: baseTheme.colors.neutrals[6],
       },
-      banner: {
-        bg: baseTheme.colors.neutrals[5],
-      },
     },
   },
   // DEPRECATED THEME SETTINGS


### PR DESCRIPTION
This changes makes it possible to choose from four defined color schemas on the banner blue, red, purple and green. This is done by passing down one of the colors to the prop colorSchema on the component.

When the property colorSchema is used on the component colors is retrieved from the styled-component theme context.

You can test this by opening the storybook and go to the Banner Story.