### PR TITLE
style: step description now supports the prop colorSchema

### DIFF
--- a/source/components/atoms/Heading/Heading.js
+++ b/source/components/atoms/Heading/Heading.js
@@ -19,7 +19,7 @@ Heading.propTypes = {
 
 Heading.defaultProps = {
   type: 'h2',
-  marginBottom: 0,
+  marginBottom: '0',
   align: 'left',
 };
 

--- a/source/components/molecules/StepDescription/StepDescription.js
+++ b/source/components/molecules/StepDescription/StepDescription.js
@@ -14,7 +14,7 @@ const StepDescriptionTagline = styled(Text)`
   font-size: ${props => props.theme.typography[props.type].fontSize}px;
   font-weight: bold;
   margin-bottom: 10px;
-  color: ${props => props.theme.step.description.tagline.color};
+  color: ${props => props.theme.colors.primary[props.colorSchema][1]};
   line-height: ${props => props.theme.typography[props.type].lineHeight}px;
   letter-spacing: 0.5px;
 `;
@@ -24,10 +24,12 @@ const StepDescriptionText = styled(Text)`
   margin-top: 16px;
 `;
 
-function StepDescription({ style, tagline, heading, text }) {
+function StepDescription({ style, tagline, heading, text, colorSchema }) {
   return (
     <StepDescriptionWrapper style={style}>
-      {tagline.length !== 0 && <StepDescriptionTagline>{tagline}</StepDescriptionTagline>}
+      {tagline.length !== 0 && (
+        <StepDescriptionTagline colorSchema={colorSchema}>{tagline}</StepDescriptionTagline>
+      )}
       <Heading>{heading}</Heading>
       {text.length !== 0 && <StepDescriptionText>{text}</StepDescriptionText>}
     </StepDescriptionWrapper>
@@ -39,11 +41,17 @@ StepDescription.propTypes = {
   tagline: PropTypes.string,
   heading: PropTypes.string.isRequired,
   text: PropTypes.string,
+  /**
+   * The color schema for the description,
+   */
+  colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
 };
 
 StepDescription.defaultProps = {
   tagline: '',
   text: '',
+  colorSchema: 'blue',
+  style: {},
 };
 
 export default StepDescription;

--- a/source/components/molecules/StepDescription/StepDescription.stories.js
+++ b/source/components/molecules/StepDescription/StepDescription.stories.js
@@ -24,7 +24,18 @@ storiesOf('StepDescription', module)
   ))
   .add('Tagline', () => (
     <StoryWrapper>
-      <StepDescription tagline="Step Description Tagline" heading="Step Description Heading" />
+      <StepDescription tagline="Blue tagline" heading="Step Description Heading" />
+      <StepDescription tagline="Red tagline" colorSchema="red" heading="Step Description Heading" />
+      <StepDescription
+        tagline="Purple tagline"
+        colorSchema="purple"
+        heading="Step Description Heading"
+      />
+      <StepDescription
+        tagline="Green tagline"
+        colorSchema="green"
+        heading="Step Description Heading"
+      />
     </StoryWrapper>
   ))
   .add('Desciprtive Text', () => (


### PR DESCRIPTION
The changes made in this pull request affects styling of step description and more specific the tagline/overline text. The applied styling is the addition of a colorSchema property for reading colors from the theme context (blue, red, purple, green).