### PR TITLE
Checks for handling missing question ID

### DIFF
--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -211,7 +211,10 @@ export function validateAnswer(
 ) {
   const { questions } = state.steps[state.currentPosition.index];
 
-  const { validation } = questions.find(question => question.id === questionId);
+  // Return if question or question ID undefined.
+  if (!questions || !questionId) return state;
+
+  const { validation } = questions?.find(question => question.id === questionId);
 
   if (validation) {
     const [isValid, validationMessage] = validateInput(answer[questionId], validation.rules);


### PR DESCRIPTION
Added checks for missing question ID.
Test by stepping through a form (ex. Ekonomiskt bistånd löpande ansökan, nya steg-logiken). The form will crash before this fix on the first quintet. 