### PR TITLE
Make the editable list handle validation

### DIFF
--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { LayoutAnimation } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import { Text, Button, Fieldset } from '../../atoms';
@@ -20,6 +21,8 @@ const EditableListItem = styled.View`
   background-color: transparent;
   border-radius: 4.5px;
   margin-bottom: 10px;
+  ${({ theme, error }) =>
+    error?.isValid || !error ? '' : `border: solid 1px ${theme.colors.primary.red[0]}`}
   ${props =>
     props.editable
       ? `
@@ -67,11 +70,22 @@ const getInitialState = (inputs, value) => {
   return inputs.reduce((prev, current) => ({ ...prev, [current.key]: current.value }), {});
 };
 
-function EditableList({ colorSchema, title, inputs, value, onInputChange, inputIsEditable }) {
+function EditableList({
+  colorSchema,
+  title,
+  inputs,
+  value,
+  onInputChange,
+  inputIsEditable,
+  error,
+}) {
   const [editable, setEditable] = useState(false);
   const [state, setState] = useState(getInitialState(inputs, value));
 
-  const changeEditable = () => setEditable(!editable);
+  const changeEditable = () => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setEditable(!editable);
+  };
 
   const onChange = (key, text) => {
     const updatedState = JSON.parse(JSON.stringify(state));
@@ -83,7 +97,7 @@ function EditableList({ colorSchema, title, inputs, value, onInputChange, inputI
   return (
     <Fieldset
       colorSchema={colorSchema}
-      legend={title}
+      legend={title || ''}
       onIconPress={() => console.log('Icon is pressed')}
       iconName="help-outline"
       renderHeaderActions={() =>
@@ -96,7 +110,12 @@ function EditableList({ colorSchema, title, inputs, value, onInputChange, inputI
     >
       <EditableListBody>
         {inputs.map(input => (
-          <EditableListItem colorSchema={colorSchema} editable={editable} key={input.key}>
+          <EditableListItem
+            colorSchema={colorSchema}
+            editable={editable}
+            key={input.key}
+            error={error[input.key]}
+          >
             <EditableListItemLabelWrapper>
               <EditableListItemLabel>{input.label}</EditableListItemLabel>
             </EditableListItemLabelWrapper>
@@ -144,6 +163,9 @@ EditableList.propTypes = {
    * Decides of the inputs are editable or not
    */
   inputIsEditable: PropTypes.bool,
+
+  /** Validation error object */
+  error: PropTypes.object,
 
   /**
    * The color schema/theme of the component

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -114,7 +114,7 @@ function EditableList({
             colorSchema={colorSchema}
             editable={editable}
             key={input.key}
-            error={error[input.key]}
+            error={error ? error[input.key] : undefined}
           >
             <EditableListItemLabelWrapper>
               <EditableListItemLabel>{input.label}</EditableListItemLabel>

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -22,7 +22,7 @@ const EditableListItem = styled.View`
   border-radius: 4.5px;
   margin-bottom: 10px;
   ${({ theme, error }) =>
-    error?.isValid || !error ? '' : `border: solid 1px ${theme.colors.primary.red[0]}`}
+    !(error?.isValid || !error) && `border: solid 1px ${theme.colors.primary.red[0]}`}
   ${props =>
     props.editable
       ? `

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -232,9 +232,8 @@ export function validateAnswer(
   }
   if (['editableList'].includes(question.type)) {
     const validationResults = {};
-
     question.inputs.forEach(input => {
-      if (input.validation) {
+      if (input.validation && answer[questionId][input.key] !== undefined) {
         const [isValid, validationMessage] = validateInput(
           answer[questionId][input.key],
           input.validation.rules
@@ -242,6 +241,7 @@ export function validateAnswer(
         validationResults[input.key] = { isValid, validationMessage };
       }
     });
+
     return {
       ...state,
       validations: {

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -2,7 +2,6 @@ import { StepperActions } from '../../../types/FormTypes';
 import { replaceMarkdownTextInSteps } from './textReplacement';
 import { FormReducerState } from './useForm';
 import { validateInput } from '../../../helpers/ValidationHelper';
-import EditableList from '../../../components/molecules/EditableList/EditableList';
 
 /**
  * Action for replacing title markdown in steps.

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -1,26 +1,41 @@
-export interface SubstepItem {
+import { ValidationObject } from './Validation';
+
+export interface SummaryItem {
   category: string;
   title: string;
   formId: string;
   loadPrevious?: string[];
+  validation?: ValidationObject;
 }
 export interface ListInput {
   type: 'text' | 'number';
   key: string;
   label: string;
   loadPrevious?: string[];
+  validation?: ValidationObject;
 }
+
+export type FormInputType =
+  | 'text'
+  | 'number'
+  | 'date'
+  | 'editableList'
+  | 'checkbox'
+  | 'summaryList'
+  | 'repeaterField';
+
 export interface Question {
   label: string;
-  type: string;
+  type: FormInputType;
   id: string;
   description?: string;
   conditionalOn?: string;
   placeholder?: string;
   explainer?: string;
   loadPrevious?: string[];
-  items?: SubstepItem[];
+  items?: SummaryItem[];
   inputs?: ListInput[];
+  validation?: ValidationObject;
 }
 
 export interface Action {

--- a/source/types/UserTypes.ts
+++ b/source/types/UserTypes.ts
@@ -1,14 +1,13 @@
-export interface User {
-    firstName: string;
-    lastName: string;
-    mobilePhone: string;
-    email: string;
-    civilStatus: string; //might not actually be a string...
-    address: Address;
-}
-
 export interface Address {
-    street: string;
-    postalCode: string;
-    city: string;
+  street: string;
+  postalCode: string;
+  city: string;
+}
+export interface User {
+  firstName: string;
+  lastName: string;
+  mobilePhone: string;
+  email: string;
+  civilStatus: string; // might not actually be a string...
+  address: Address;
 }

--- a/source/types/Validation.ts
+++ b/source/types/Validation.ts
@@ -1,0 +1,28 @@
+export type ValidatorMethod =
+  | 'isEmpty'
+  | 'isEmail'
+  | 'isUrl'
+  | 'isPostalCode'
+  | 'isNumeric'
+  | 'isAfter'
+  | 'isBefore'
+  | 'isBoolean'
+  | 'isMobilePhone'
+  | 'isPhone'
+  | 'isLength'
+  | 'isInt';
+
+export interface ValidationRule {
+  method: ValidatorMethod;
+  validWhen: boolean;
+  args?: {
+    options?: Record<string, string | boolean | number>;
+    locale?: string;
+  };
+  message: string;
+}
+
+export interface ValidationObject {
+  isRequired: boolean;
+  rules: ValidationRule[];
+}


### PR DESCRIPTION
## Feature description
Enables validation handling on the inputs inside the editable list component.

## Solution description
Changes the code in form actions to act differently depending on the type of the input, and adds the needed behaviour in the case of editableList. We will need to take care of the other 'advanced' input types here as well. 
Also adds some logic to the editable list component to handle the resulting error object, showing a red border around the whole item when the input is invalid. 

Added some types concerning input types and validation as well. 

## How to test the fix?
There is a test form in the dev database, with an editable list with some validation rules, so that's a good place to test it, or make a form with a validation object on an editable list input on your local environment and test there. 
There's no story for this, since the validation logic lives in formActions and it would take some work to set up.

## Is there any existing behaviour change of other features due to this code change?
No.

## Covered unit tests cases / E2E test cases?
No.

## Are your code structured in a way so that reviewers can understand it?
Yes.

## Was this feature tested in the following environments?
- [x] On a iOS device/simulator.
