### PR TITLE
Add validation  to the repeater field

### DIFF
--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -18,19 +18,20 @@ interface Props {
   value: string | Record<string, string | number>[];
   onChange: (answers: Record<string, any> | string | number, fieldId?: string) => void;
   color: string;
+  error?: Record<string, {isValid: boolean, validationMessage: string}>[];
 }
 const emptyInput: Record<string, string | number>[] = [];
 
 function isRecordArray(value: string | Record<string,string|number>[]): value is Record<string, string | number>[] {
-    return typeof value !== 'string';
+  return typeof value !== 'string';
 }
 /**
  * Repeater field component, for adding multiple copies of a particular kind of input.
  * The input-prop specifies the form of each input-group.
  */
-const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChange, color, value }) => {
-    const [localAnswers, setLocalAnswers] = useState( isRecordArray(value) ? value : emptyInput);
-
+const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChange, color, value, error }) => {
+  const [localAnswers, setLocalAnswers] = useState( isRecordArray(value) ? value : emptyInput);
+  
   const changeFromInput = (index: number) => (input: InputRow) => (text: string) => {
     localAnswers[index][input.id] = text;
     onChange(localAnswers);
@@ -59,6 +60,7 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
         changeFromInput={changeFromInput(index)}
         color={color}
         removeItem={removeAnswer(index)}
+        error={error && error[index] ? error[index]: undefined}
       />
     );
   });

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -4,7 +4,6 @@ import { View } from 'react-native';
 import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import { Input, Text, Icon } from '../../atoms';
-import colors from '../../../styles/colors';
 import { InputRow } from './RepeaterField';
 import DateTimePickerForm from '../DateTimePicker/DateTimePickerForm';
 
@@ -31,11 +30,14 @@ const RemoveButton = styled.TouchableHighlight`
   border-bottom-right-radius: 6px;
   margin-left: 4px;
 `;
-const ItemWrapper = styled(View)`
+const ItemWrapper = styled(View)<{ error: { isValid: boolean; validationMessage: string } | undefined }>`
   flex-direction: row;
   align-items: flex-end;
+  border-radius: 3px;
   height: 46px;
   background-color: white;
+  ${({ theme, error }) =>
+    !(error?.isValid || !error) && `border: solid 2px ${theme.colors.primary.red[0]}`}
 `;
 const InputWrapper = styled.View`
   align-items: center;
@@ -81,6 +83,7 @@ const dateStyle = {
 interface Props {
   inputs: InputRow[];
   value: Record<string, string | number>;
+  error?: Record<string, {isValid: boolean, validationMessage: string}>;
   changeFromInput: (input: InputRow) => (text: string | number) => void;
   removeItem: () => void;
   color: string;
@@ -89,6 +92,7 @@ interface Props {
 const RepeaterFieldListItem: React.FC<Props> = ({
   inputs,
   value,
+  error,
   changeFromInput,
   removeItem,
   color,
@@ -137,6 +141,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
     <ItemWrapper
       key={`${input.title}.${index}`}
       style={index === inputs.length - 1 ? { marginBottom: 0 } : { marginBottom: 4 }}
+      error={error && error[input.id] ? error[input.id] : undefined}
     >
       <SmallText>{`${input.title}`}</SmallText>
       <InputWrapper>{inputComponent(input)}</InputWrapper>
@@ -146,7 +151,6 @@ const RepeaterFieldListItem: React.FC<Props> = ({
   return (
     <Base>
       <Inputs>{rows}</Inputs>
-
       <RemoveButton activeOpacity={1} onPress={removeItem}>
         <DeleteButton name="clear" />
       </RemoveButton>

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -170,6 +170,7 @@ RepeaterFieldListItem.propTypes = {
    * What should happen to update the values
    */
   changeFromInput: PropTypes.func,
+  /** Function to remove the item from the repeater */
   removeItem: PropTypes.func,
   /**
    * Sets the color scheme of the list. default is red.

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -211,7 +211,7 @@ export function validateAnswer(
 ) {
   const { questions } = state.steps[state.currentPosition.index];
 
-  // Return if question or question ID undefined.
+  // Return if question or question ID is undefined.
   if (!questions || !questionId) return state;
 
   const question = questions?.find(q => q.id === questionId);

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -230,8 +230,8 @@ export function validateAnswer(
       };
     }
   }
-  if (['editableList'].includes(question.type)) {
-    const validationResults = {};
+  if (question.type === 'editableList') {
+    const validationResults: Record<string, {isValid:boolean, validationMessage: string}> = {};
     question.inputs.forEach(input => {
       if (input.validation && answer[questionId][input.key] !== undefined) {
         const [isValid, validationMessage] = validateInput(
@@ -241,7 +241,6 @@ export function validateAnswer(
         validationResults[input.key] = { isValid, validationMessage };
       }
     });
-
     return {
       ...state,
       validations: {
@@ -250,6 +249,27 @@ export function validateAnswer(
       },
     };
   }
-
+  if (question.type === 'repeaterField') {
+    const validationResults: Record<string, {isValid:boolean, validationMessage: string}>[] = [];
+    if (answer[questionId]?.length > 0){
+      (answer[questionId] as Record<string, string>[]).forEach(a => {
+        const localValidationResults = {};
+        question.inputs.forEach(input => {
+          if(input.validation && a[input.id] !== undefined){
+            const [isValid, validationMessage] = validateInput(a[input.id], input.validation.rules);
+            localValidationResults[input.id] = { isValid, validationMessage};
+          }
+        });
+        validationResults.push(localValidationResults);
+      });
+    }
+    return {
+      ...state,
+      validations: {
+        ...state.validations,
+        [questionId]: validationResults,
+      },
+    };
+  }
   return state;
 }

--- a/source/store/CaseContext.js
+++ b/source/store/CaseContext.js
@@ -46,7 +46,7 @@ function CaseProvider({ children, initialState = defaultInitialState }) {
   const [state, dispatch] = useReducer(CaseReducer, initialState);
   const { user } = useContext(AuthContext);
   // console.log('reducer state', state);
-  async function createCase(formId, callback = response => {}) {
+  async function createCase(formId, callback = () => {}) {
     dispatch(await create(formId, user, state.cases, callback));
   }
 
@@ -97,7 +97,7 @@ function CaseProvider({ children, initialState = defaultInitialState }) {
   }
 
   async function deleteCase(caseId) {
-    dispatch(await remove(caseId));
+    dispatch(remove(caseId));
   }
 
   const fetchCases = useCallback(

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -8,8 +8,9 @@ export interface SummaryItem {
   validation?: ValidationObject;
 }
 export interface ListInput {
-  type: 'text' | 'number';
+  type: 'text' | 'number' | 'date';
   key: string;
+  id?: string;
   label: string;
   loadPrevious?: string[];
   validation?: ValidationObject;
@@ -64,10 +65,9 @@ export interface Step {
 export interface Form {
   name: string;
   description: string;
-  steps?: Step[];
+  steps: Step[];
   connectivityMatrix: StepperActions[][];
   id: string;
-  subform?: boolean;
   formType?: string;
   provider?: string;
 }


### PR DESCRIPTION
## Feature description
Enables validation handling on the inputs inside the repeater input component.

## Solution description
Adds logic inside the formActions to handle the repeater case. Adds logic for handling the error object in the repeater component, and some styling to show a red border on error to the RepeaterListItem component. 

## How to test the fix?
Load the test form, and enter wrong things inside the repeater inputs, i.e. characters inside the number field, or touching and then leaving the personalnumber field blank etc.

As a side note, the personal number rule as written doesn't work as intended, so we need to write a working rule for personal numbers.

## Is there any existing behaviour change of other features due to this code change?
No.

## Covered unit tests cases / E2E test cases?
No.

## Are your code structured in a way so that reviewers can understand it?
Yes.

## Was this feature tested in the following environments?
- [x] On a iOS device/simulator.
