### PR TITLE
feat: updated styles for button atom component

### DIFF
--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -156,7 +156,7 @@ const Button = props => {
       return React.createElement(ButtonText, {
         ...child.props,
         colorSchema,
-        buttonSize: size,
+        size,
         variant,
       });
     }
@@ -190,8 +190,6 @@ Button.propTypes = {
   colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
   icon: PropTypes.bool,
   onClick: PropTypes.func,
-  pill: PropTypes.bool,
-  sharp: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'medium']),
   style: PropTypes.array,
   value: PropTypes.string,

--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -6,68 +6,80 @@ import Text from '../Text';
 import Icon from '../Icon';
 import theme from '../../../styles/theme';
 
-/** Button modifiers */
-const CSS = { z: SHADOW };
+/** Button styles */
+const Styles = { elevation: SHADOW };
 
-CSS.buttonRounded = css`
-  border-radius: 17.5px;
+/* Styles common to all buttons */
+Styles.buttonbase = css`
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  max-width: 100%;
+  border-radius: 4.5px;
+  background-color: ${props => props.theme.colors.primary[props.colorSchema][0]};
 `;
 
-CSS.buttonPill = css`
-  border-radius: 24.5px;
+/* Styles for different button variants outlined, contained etc */
+Styles.outlined = css`
+  border: 2px solid ${props => props.theme.colors.primary[props.colorSchema][1]};
+  background-color: ${props => props.theme.colors.complementary[props.colorSchema][1]};
+  ${Styles.elevation[0]}
+`;
+Styles.contained = css``;
+
+/* Styles for size variants */
+Styles.small = css`
+  font-size: 14px;
+  padding: 4px 8px;
+  min-width: 10px;
 `;
 
-CSS.buttonSharp = css`
-  border-radius: 0px;
+Styles.medium = css`
+  font-size: 16px;
+  padding: 10px 32px;
+  min-width: 10px;
 `;
 
-CSS.buttonSmall = css`
-  padding: 8px 12px;
-  min-height: 36px;
-  min-width: 74px;
+Styles.fullWidth = css`
+  width: 100%;
 `;
 
-CSS.disabled = css`
+/* Styles for a disabled button */
+Styles.disabled = css`
   opacity: 0.2;
+  background-color: #e5e5e5;
 `;
 
 const ButtonBase = styled.View`
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-
-    max-width: 100%;
-    min-height: 56px;
-
-    border-radius: 4.5px;
+    ${Styles.buttonbase};
 
     padding: ${props => (!props.icon ? '12px 20px' : '16px 16px')};
     min-width: ${props => (!props.icon ? '124px' : '169px')};
-    background-color: ${props => props.theme.colors.primary[props.colorSchema][0]};
 
-    ${props => (props.rounded ? CSS.buttonRounded : null)}
-    ${props => (props.pill ? CSS.buttonPill : null)}
-    ${props => (props.sharp ? CSS.buttonSharp : null)}
-    ${props => (props.disabled ? CSS.disabled : null)}
+    ${props => props.disabled && Styles.disabled}
+    ${props => props.fullWidth && Styles.fullWidth}
 
-    ${props => (props.buttonSize === 'small' ? CSS.buttonSmall : null)}
-    ${props => (props.buttonSize === 'xsmall' ? CSS.buttonSmall : null)}
+    ${props => props.size === 'small' && Styles.small}
+    ${props => props.size === 'medium' && Styles.medium}
+    ${props => props.size === 'large' && Styles.large}
 
-    ${props => CSS.z[props.z]}
+    ${props => Styles.elevation[props.elevation]}
     shadow-color: ${props => props.theme.button[props.colorSchema].shadow};
+
+    ${props => Styles[props.variant]}
 `;
 
 /** Button child component overrides */
 const ButtonText = styled(Text)`
-  font-size: ${props => (props.buttonSize === 'small' ? '14px' : '16px')};
   font-weight: ${props => props.theme.fontWeights[1]};
-  color: ${props => props.theme.colors.complementary[props.colorSchema][3]};
-
-  ${props => (props.buttonSize === 'small' ? 'font-weight: bold;' : null)};
+  color: ${props =>
+    props.variant === 'outlined' ? props.theme.colors.neutrals[1] : props.theme.colors.neutrals[7]};
 `;
-
 const ButtonIcon = styled(Icon)`
-  color: ${props => props.theme.colors.neutrals[7]};
+  color: ${props =>
+    props.variant === 'outlined'
+      ? props.theme.colors.primary[props.colorSchema][1]
+      : props.theme.colors.neutrals[7]};
   font-size: 26px;
   height: 26px;
   width: 26px;
@@ -91,7 +103,7 @@ const ButtonWrapper = styled.View`
 
 const ButtonTouchable = styled.TouchableOpacity`
     ${props => (props.block ? 'flex: 1;' : null)};
-    ${props => CSS.z[props.z]}
+    ${props => Styles.elevation[props.elevation]}
     shadow-color: ${props => props.theme.shadow.default};
 `;
 
@@ -103,13 +115,11 @@ const Button = props => {
     color,
     colorSchema,
     block,
-    rounded,
-    pill,
-    sharp,
     icon,
-    z: shadow,
+    z: elevation,
     size,
     disabled,
+    variant,
     ...other
   } = props;
 
@@ -137,6 +147,7 @@ const Button = props => {
         ...child.props,
         size: 32,
         colorSchema,
+        variant,
       });
     }
 
@@ -146,6 +157,7 @@ const Button = props => {
         ...child.props,
         colorSchema,
         buttonSize: size,
+        variant,
       });
     }
 
@@ -154,17 +166,15 @@ const Button = props => {
 
   return (
     <ButtonWrapper>
-      <ButtonTouchable disabled={disabled} onPress={onClick} block={block} z={shadow}>
+      <ButtonTouchable disabled={disabled} onPress={onClick} block={block} elevation={elevation}>
         <ButtonBase
           colorSchema={colorSchema}
-          buttonSize={size}
-          rounded={rounded}
-          pill={pill}
+          size={size}
           style={style}
           icon={iconComponentsTotal === 1 && childrenTotal === 1 ? true : icon}
-          z={shadow}
-          shrarp={sharp}
+          elevation={elevation}
           disabled={disabled}
+          variant={variant}
         >
           {children || (value ? <ButtonText>{value}</ButtonText> : null)}
         </ButtonBase>
@@ -174,15 +184,15 @@ const Button = props => {
 };
 
 Button.propTypes = {
+  variant: PropTypes.oneOf(['outlined', 'contained']),
   block: PropTypes.bool,
   color: PropTypes.oneOf(Object.keys(theme.button)),
   colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
   icon: PropTypes.bool,
   onClick: PropTypes.func,
   pill: PropTypes.bool,
-  rounded: PropTypes.bool,
   sharp: PropTypes.bool,
-  size: PropTypes.string,
+  size: PropTypes.oneOf(['small', 'medium']),
   style: PropTypes.array,
   value: PropTypes.string,
   disabled: PropTypes.bool,
@@ -192,13 +202,11 @@ Button.propTypes = {
 Button.defaultProps = {
   color: 'light',
   colorSchema: 'blue',
-  rounded: false,
-  pill: false,
   icon: false,
-  sharp: false,
   z: 1,
   size: 'medium',
   disabled: false,
+  variant: 'contained',
 };
 
 export default Button;

--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -4,7 +4,6 @@ import styled, { css } from 'styled-components/native';
 import SHADOW from '../../../styles/shadow';
 import Text from '../Text';
 import Icon from '../Icon';
-import theme from '../../../styles/theme';
 
 /** Button styles */
 const Styles = { elevation: SHADOW };
@@ -112,7 +111,6 @@ const Button = props => {
     value,
     onClick,
     style,
-    color,
     colorSchema,
     block,
     icon,
@@ -186,7 +184,6 @@ const Button = props => {
 Button.propTypes = {
   variant: PropTypes.oneOf(['outlined', 'contained']),
   block: PropTypes.bool,
-  color: PropTypes.oneOf(Object.keys(theme.button)),
   colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
   icon: PropTypes.bool,
   onClick: PropTypes.func,
@@ -198,7 +195,6 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  color: 'light',
   colorSchema: 'blue',
   icon: false,
   z: 1,

--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -24,6 +24,7 @@ Styles.outlined = css`
   background-color: ${props => props.theme.colors.complementary[props.colorSchema][1]};
   ${Styles.elevation[0]}
 `;
+
 Styles.contained = css``;
 
 /* Styles for size variants */
@@ -182,14 +183,38 @@ const Button = props => {
 };
 
 Button.propTypes = {
+  /**
+   * The button layout variant to use.
+   */
   variant: PropTypes.oneOf(['outlined', 'contained']),
+  /**
+   * If true, the button will take up the full width of its container.
+   */
   block: PropTypes.bool,
+  /**
+   * The color schema of the component. colors is defined in the application theme.
+   */
   colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
+  /**
+   * If true button will display Icon component passed as children.
+   */
   icon: PropTypes.bool,
   onClick: PropTypes.func,
+  /**
+   * The size of the button. small is equivalent to the dense button styling.
+   */
   size: PropTypes.oneOf(['small', 'medium']),
+  /**
+   * Override or extend the styles applied to the component.
+   */
   style: PropTypes.array,
+  /**
+   * The text value to display in the button.
+   */
   value: PropTypes.string,
+  /**
+   * If true, the button will be disabled.
+   */
   disabled: PropTypes.bool,
   z: PropTypes.oneOf(Object.keys(SHADOW).map(number => parseInt(number))),
 };

--- a/source/components/atoms/Button/Button.stories.js
+++ b/source/components/atoms/Button/Button.stories.js
@@ -15,32 +15,28 @@ const FlexContainer = styled.View`
 `;
 
 storiesOf('Button', module)
-  .add('Default', props => (
+  .add('Contained Buttons', props => (
     <StoryWrapper {...props}>
       <ButtonColors />
     </StoryWrapper>
   ))
-  .add('Small', props => (
+  .add('Outlined Buttons', props => (
     <StoryWrapper {...props}>
-      <ButtonColors size="small" />
+      <ButtonColors variant="outlined" />
     </StoryWrapper>
   ))
-  .add('Rounded', props => (
+  .add('Sizes', props => (
     <StoryWrapper {...props}>
-      <ButtonColors rounded />
-    </StoryWrapper>
-  ))
-  .add('Pill', props => (
-    <StoryWrapper {...props}>
-      <ButtonColors pill />
+      <ButtonSizes />
     </StoryWrapper>
   ))
   .add('Block', props => (
     <StoryWrapper {...props}>
       <ButtonColors block />
+      <ButtonColors block variant="outlined" />
     </StoryWrapper>
   ))
-  .add('with icon', props => (
+  .add('Icon', props => (
     <StoryWrapper {...props}>
       <FlexContainer>
         <Flex>
@@ -60,10 +56,27 @@ storiesOf('Button', module)
             <Text>Skriv en fråga</Text>
           </Button>
         </Flex>
+        <Flex>
+          <Button variant="outlined" colorSchema="purple" rounded>
+            <Icon name="arrow-upward" pill />
+          </Button>
+        </Flex>
+        <Flex>
+          <Button variant="outlined" colorSchema="purple" pill>
+            <Text>Icon right</Text>
+            <Icon name="arrow-upward" />
+          </Button>
+        </Flex>
+        <Flex>
+          <Button variant="outlined" colorSchema="blue" pill>
+            <Icon name="message" />
+            <Text>Skriv en fråga</Text>
+          </Button>
+        </Flex>
       </FlexContainer>
     </StoryWrapper>
   ))
-  .add('Shadows', props => (
+  .add('Elevation', props => (
     <StoryWrapper {...props}>
       <FlexContainer>
         <Flex>
@@ -104,22 +117,37 @@ const ButtonColors = injectProps => (
   <FlexContainer>
     <Flex>
       <Button colorSchema="blue" {...injectProps}>
-        <Text>Purple</Text>
-      </Button>
-    </Flex>
-    <Flex>
-      <Button colorSchema="red" {...injectProps}>
         <Text>Blue</Text>
       </Button>
     </Flex>
     <Flex>
+      <Button colorSchema="red" {...injectProps}>
+        <Text>Red</Text>
+      </Button>
+    </Flex>
+    <Flex>
       <Button colorSchema="purple" {...injectProps}>
-        <Text>Light</Text>
+        <Text>Purple</Text>
       </Button>
     </Flex>
     <Flex>
       <Button colorSchema="green" {...injectProps}>
-        <Text>Gray</Text>
+        <Text>Green</Text>
+      </Button>
+    </Flex>
+  </FlexContainer>
+);
+
+const ButtonSizes = injectProps => (
+  <FlexContainer>
+    <Flex>
+      <Button size="small" {...injectProps}>
+        <Text>Small</Text>
+      </Button>
+    </Flex>
+    <Flex>
+      <Button size="medium" {...injectProps}>
+        <Text>Medium</Text>
       </Button>
     </Flex>
   </FlexContainer>


### PR DESCRIPTION
## Feature description
Updates the Button atom component to follow the user interface design. This includes the option to render Contained buttons, Outlined Buttons and setting correct sizing 

Example of component usage:
```JSX 
<Button
      colorSchema="purple" // default value is blue. 
      variant="outlined" // default value is contained
      onClick={(event) => ...do something}
      size="small" // default value is medium
      disabled={false}
      z={1} // elevation of the button
    />
```
More examples can be found in our Storybook.

## How to test the feature?

1. Checkout branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command`yarn ios`
4. Look in the story named Button
5. Compare to design in Figma or look at attachement

<img width="893" alt="Screen Shot 2020-11-05 at 11 48 39" src="https://user-images.githubusercontent.com/11438902/98231586-e25b0400-1f5c-11eb-9275-f8f707476f6c.png">


## Is there any existing behaviour change of other features due to this code change?
No.

## Covered unit tests cases / E2E test cases?
No.

## Are your code structured in a way so that reviewers can understand it?
Yes.

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.