### PR TITLE
Add RadioGroup option to FormField

### DIFF
--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -9,6 +9,7 @@ import NavigationButtonGroup from '../NavigationButtonGroup/NavigationButtonGrou
 import SummaryList from '../../organisms/SummaryList/SummaryList';
 import RepeaterField from '../RepeaterField/RepeaterField';
 import theme from '../../../styles/theme';
+import RadioGroup from '../RadioGroup/RadioGroup';
 
 const inputTypes = {
   text: {
@@ -55,6 +56,11 @@ const inputTypes = {
   select: {
     component: Select,
     changeEvent: 'onValueChange',
+    props: {},
+  },
+  radioGroup: {
+    component: RadioGroup,
+    changeEvent: 'onSelect',
     props: {},
   },
   avatarList: {
@@ -104,7 +110,6 @@ const FormField = ({
     value === '' && Object.prototype.hasOwnProperty.call(input, 'initialValue')
       ? input.initialValue
       : value;
-
   const inputCompProps = {
     color,
     value: initialValue,

--- a/source/components/molecules/FormField/FormField.stories.js
+++ b/source/components/molecules/FormField/FormField.stories.js
@@ -29,6 +29,15 @@ const items = [
   },
 ];
 
+const radioChoices = [
+  { displayText: 'Choice 1', value: '1' },
+  { displayText: 'Choice 2', value: '2' },
+  {
+    displayText: 'Choice 3',
+    value: '3',
+  },
+];
+
 const DateFormField = () => {
   const [date, setDate] = useState({ 7: '' });
   return (
@@ -43,7 +52,20 @@ const DateFormField = () => {
     />
   );
 };
-
+const RadioGroupFormField = () => {
+  const [value, setValue] = useState({ 8: '' });
+  return (
+    <FormField
+      id="8"
+      label="Radio group"
+      labelLine
+      choices={radioChoices}
+      onChange={choice => setValue(choice)}
+      value={value[8]}
+      inputType="radioGroup"
+    />
+  );
+};
 storiesOf('Form Field input', module).add('Default', () => (
   <StoryWrapper>
     <ScrollView>
@@ -99,6 +121,7 @@ storiesOf('Form Field input', module).add('Default', () => (
         ]}
       />
       <DateFormField />
+      <RadioGroupFormField />
     </ScrollView>
   </StoryWrapper>
 ));


### PR DESCRIPTION
Add the RadioGroup input option to the FormField, so that we can use it inside forms. 
Also adds it to the FormField default story. 

To test it , one can check that it works in the FormField story, or check in the Test form in the develop database, where it has just been added on the bottom. 