### PR TITLE
Feature to show a sum at the bottom of the summary list

### DIFF
--- a/source/components/organisms/SummaryList/SummaryList.stories.js
+++ b/source/components/organisms/SummaryList/SummaryList.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ScrollView } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import StoryWrapper from '../../molecules/StoryWrapper';
 import SummaryList from './SummaryList';
@@ -9,6 +10,8 @@ const stories = storiesOf('Summary List', module);
 const items = [
   { id: 'f1', type: 'text', title: 'favoritfrukt', category: 'fruit' },
   { id: 'f2', type: 'text', title: 'grönsak', category: 'vegetable' },
+  { id: 'pris1', type: 'number', title: 'pris1', category: 'fruit' },
+  { id: 'pris2', type: 'number', title: 'pris2', category: 'vegetable' },
 ];
 
 const categories = [
@@ -19,9 +22,10 @@ const categories = [
 const SummaryStory = () => {
   const [state, setState] = useState({});
   return (
-    <>
+    <ScrollView>
+      <Text>Fyll i några fält för att visa sammanfattningen</Text>
       <Label>
-        <Text>Frukt</Text>
+        <Text>Favoritfrukt</Text>
       </Label>
       <Input
         value={state.f1}
@@ -33,7 +37,19 @@ const SummaryStory = () => {
         }}
       />
       <Label>
-        <Text>Grönsak</Text>
+        <Text>Fruktens pris</Text>
+      </Label>
+      <Input
+        value={state.pris1}
+        onChangeText={text => {
+          setState(s => {
+            s.pris1 = text;
+            return { ...s };
+          });
+        }}
+      />
+      <Label>
+        <Text>Favoritgrönsak</Text>
       </Label>
       <Input
         value={state.f2}
@@ -44,22 +60,33 @@ const SummaryStory = () => {
           });
         }}
       />
+      <Label>
+        <Text>Grönsakens pris</Text>
+      </Label>
+      <Input
+        value={state.pris2}
+        onChangeText={text => {
+          setState(s => {
+            s.pris2 = text;
+            return { ...s };
+          });
+        }}
+      />
       <SummaryList
         heading="Sammanfattning"
         items={items}
         categories={categories}
-        addButtonText="Add something"
-        color="light"
+        color="green"
         onChange={(answer, id) => {
           setState(s => {
             s[id] = answer;
             return { ...s };
           });
         }}
-        d
         answers={state}
+        showSum
       />
-    </>
+    </ScrollView>
   );
 };
 


### PR DESCRIPTION
## Feature description
Adds an option to the summary list to show a sum at the bottom.

## Implementation details
Adds some logic to the compute the sum, and some styled components to show it at the bottom, following the Figma design. 

Note that the current design implementation is a stop-gap solution, the sum-component should really be passed as a footer to the grouped list, and then to the FieldSet component. So when we have some Card component with support for a footer, this should be passed there. There is some brief discussion about this on the task in clickup. 

I also expanded the SummaryList story a bit to make this feature testable.

## How to test the feature?

Go into the SummaryList story and type in some prices. Or load the test form in develop, fill in some numbers, also from the repeater, and see the sum under the summary list there. 

## Is there any existing behaviour change of other features due to this code change?
No.

## Covered unit tests cases / E2E test cases?
No.

## Are your code structured in a way so that reviewers can understand it?
Yes.

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.