### PR TITLE
Fix fontweight from number to string, which caused a crash

### DIFF
--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -51,7 +51,7 @@ const SmallInput = styled.TextInput`
   min-width: 80%;
   font-weight: 500;
   padding: 6px;
-`;
+  `;
 const LabelWrapper = styled.View`
   flex: 4;
   justify-content: center;
@@ -79,8 +79,8 @@ const DeleteButtonHighligth = styled(TouchableHighlight)`
 const dateStyle: CSSProp = {
   textAlign: 'right',
   minWidth: '80%',
-  fontWeight: 500,
   padding: 6,
+  fontWeight: '500',
 };
 
 interface Props {


### PR DESCRIPTION
## Explain why these changes are made

Fix a bug: fontweight should be a string rather than a number, which was causing a crash for dates in the summary list.


## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
