### PR TITLE
Change top navigation buttons when in substeps

### DIFF
--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -12,6 +12,14 @@ const BackNavigationWrapper = styled.View({
   top: 0,
   zIndex: 999,
 });
+const BackNavigationSingleWrapper = styled.View({
+  flexDirection: 'row',
+  padding: 0,
+  margin: 0,
+  justifyContent: 'flex-end',
+  top: 0,
+  zIndex: 999,
+});
 
 const BackButton = styled.View(props => ({
   alignItems: 'center',
@@ -49,23 +57,40 @@ const BackNavigation = ({
   onClose,
   showBackButton,
   showCloseButton,
-}) => (
-  <BackNavigationWrapper style={style}>
-    {showBackButton ? (
-      <BackButton colorSchema={colorSchema} onStartShouldSetResponder={onBack}>
-        <BackButtonIcon name="keyboard-backspace" colorSchema={colorSchema} />
-      </BackButton>
-    ) : (
-      <View />
-    )}
+  inSubstep,
+}) =>
+  !inSubstep ? (
+    <BackNavigationWrapper style={style}>
+      {showBackButton ? (
+        <BackButton colorSchema={colorSchema} onStartShouldSetResponder={onBack}>
+          <BackButtonIcon name="keyboard-backspace" colorSchema={colorSchema} />
+        </BackButton>
+      ) : (
+        <View />
+      )}
 
-    {showCloseButton ? (
-      <CloseButton colorSchema={colorSchema} onStartShouldSetResponder={onClose}>
-        <CloseButtonIcon name="close" />
-      </CloseButton>
-    ) : null}
-  </BackNavigationWrapper>
-);
+      {showCloseButton ? (
+        <CloseButton colorSchema={colorSchema} onStartShouldSetResponder={onClose}>
+          <CloseButtonIcon name="close" />
+        </CloseButton>
+      ) : null}
+    </BackNavigationWrapper>
+  ) : (
+    <BackNavigationSingleWrapper style={style}>
+      <BackButton
+        colorSchema={colorSchema}
+        onStartShouldSetResponder={() => {
+          onBack();
+        }}
+      >
+        <BackButtonIcon
+          name="keyboard-backspace"
+          style={{ transform: [{ rotate: '-90deg' }] }}
+          colorSchema={colorSchema}
+        />
+      </BackButton>
+    </BackNavigationSingleWrapper>
+  );
 
 BackNavigation.propTypes = {
   style: PropTypes.array,
@@ -74,6 +99,7 @@ BackNavigation.propTypes = {
   onClose: PropTypes.func,
   showBackButton: PropTypes.bool,
   showCloseButton: PropTypes.bool,
+  inSubstep: PropTypes.bool,
 };
 
 BackNavigation.defaultProps = {

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -1,9 +1,9 @@
-import React, { useContext, useEffect } from 'react';
+import React, {useContext, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import AuthContext from 'app/store/AuthContext';
-import { Text } from 'react-native';
-import { AuthLoading, FormField } from 'app/components/molecules';
+import {Text} from 'react-native';
+import {AuthLoading, FormField} from 'app/components/molecules';
 import BackNavigation from '../../molecules/BackNavigation/BackNavigation';
 import Banner from './StepBanner/StepBanner';
 import FooterAction from './FooterAction/FooterAction';
@@ -95,6 +95,7 @@ function Step({
     <StepContainer>
       <StepBackNavigation
         showBackButton={isBackBtnVisible}
+        inSubstep={currentPosition.level !== 0}
         onBack={formNavigation?.back ? formNavigation.back : undefined}
         onClose={closeForm}
       />


### PR DESCRIPTION
## Explain the changes you’ve made

Added some logic for replacing the top navigation buttons inside a form depending on if you currently are in a substep or not.

## Explain why these changes are made

Hitting the x-button while in a substep, and closing the entire form is extremely annoying and easy to do. 
And it is according to the design.

## Explain your solution

Added a prop to the BackNavigation component that tells it if it is in a substep or not, and then send that from Step, using the currentPosition.level to see if we are at 'ground level' (===0) or not. 

I checked with Gustav, and he gave me the icon to use. 
He also wants the substep to slide in and end up as a sort of modal, but this is left as a future exercise (because it seems quite tricky, and not that highly prioritised).

## How to test the changes?

Open any form with a substep (like Löpande, presumably) and try it. There was a story testing the navigation, but I think it has been removed. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

