### PR TITLE
Fix/android fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:3.5.3')
+        classpath('com.android.tools.build:gradle:3.6.1')
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Nov 03 14:17:53 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/source/components/atoms/Text/Text.js
+++ b/source/components/atoms/Text/Text.js
@@ -18,7 +18,7 @@ const Text = styled(RNText)`
   ${({ strong }) =>
     strong &&
     `
-      font-weight: 900;
+      font-weight: bold;
     `}
 `;
 

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -121,6 +121,8 @@ function EditableList({
             </EditableListItemLabelWrapper>
             <EditableListItemInputWrapper>
               <EditableListItemInput
+                multiline /** Temporary fix to make field scrollable inside scrollview */
+                numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
                 colorSchema={colorSchema}
                 editable={editable}
                 onChangeText={text => onChange(input.key, text)}

--- a/source/components/molecules/GroupedList/GroupedList.js
+++ b/source/components/molecules/GroupedList/GroupedList.js
@@ -84,16 +84,14 @@ const GroupedList = ({ heading, items, categories, onEdit, color }) => {
         ) : null}
       </ListHeader>
       <ListBody>
-        {Object.keys(groupedItems)
-          .sort((a, _b) => (a === 'sum' ? 1 : -1))
-          .map((key, index) => (
-            <View key={`${index}-${key}`}>
-              <ListBodyFieldLabel underline>
-                {categories.find(c => c.category === key).description}
-              </ListBodyFieldLabel>
-              {groupedItems[key].map(item => item.component)}
-            </View>
-          ))}
+        {Object.keys(groupedItems).map((key, index) => (
+          <View key={`${index}-${key}`}>
+            <ListBodyFieldLabel underline>
+              {categories.find(c => c.category === key).description}
+            </ListBodyFieldLabel>
+            {groupedItems[key].map(item => item.component)}
+          </View>
+        ))}
       </ListBody>
     </ListWrapper>
   );

--- a/source/components/molecules/GroupedList/GroupedList.js
+++ b/source/components/molecules/GroupedList/GroupedList.js
@@ -40,7 +40,7 @@ const HeaderTitleWrapper = styled.View`
 `;
 
 const HeaderTitle = styled(Text)`
-  font-weight: 900;
+  font-weight: bold;
   font-size: 14px;
   letter-spacing: 0.8px;
   text-transform: uppercase;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -9,6 +9,14 @@ import colors from "../../../styles/colors";
 import { Item } from "./SummaryList";
 import DateTimePickerForm from "../../molecules/DateTimePicker/DateTimePickerForm";
 
+/**
+ * Fixes a bug in React Native that makes input fields not scrollable inside ScrollViews on Android
+ * Issue: https://github.com/facebook/react-native/issues/25594
+ * @param props
+ */
+const SmallInputRight = (props) =>
+  <Input {...props} multiline={true} numberOfLines={1} textAlign="right" />;
+
 const ItemWrapper = styled(View)`
   flex-direction: row;
   align-items: flex-end;
@@ -20,7 +28,7 @@ const InputWrapper = styled.View`
   flex: 1;
   padding-left: 50px;
 `;
-const SmallInput = styled(Input)`
+const SmallInput = styled(SmallInputRight)`
   height: 40px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -80,7 +88,6 @@ const SummaryListItem: React.FC<Props> = ({
       case "arrayText":
         return (
           <SmallInput
-            textAlign="right"
             value={value}
             onChangeText={changeFromInput}
           />
@@ -89,7 +96,6 @@ const SummaryListItem: React.FC<Props> = ({
       case "arrayNumber":
         return (
           <SmallInput
-            textAlign="right"
             keyboardType="numeric"
             value={value}
             onChangeText={changeFromInput}
@@ -110,7 +116,6 @@ const SummaryListItem: React.FC<Props> = ({
       default:
         return (
           <SmallInput
-            textAlign="right"
             value={value}
             onChangeText={changeFromInput}
           />


### PR DESCRIPTION
## Explain the changes you’ve made

- Fixed a bug that is caused by React Native that makes input fields not scrollable inside ScrollViews on Android.
- Fixed font weights. For example we cannot use value 900 on Android.
- Changed the order of categories inside summary lists to follow the order that is defined in form builder. 

## Explain why these changes are made

Wanted to fix the most obvious bugs on Android when I compared with the iOS version. 

## Explain your solution

To fix the broken Scrollviews on android i needed to do add these props: "multiline={true} numberOfLines={1}"  to all input fields that has textAlign: center or right. 

## How to test the changes?

Bug one: Start a form and slide/scroll the screen up and down when hovering over an input field. It should now work as expected, before you could not scroll the screen. 
Bug two: Start a form and compare font weights in iOS and Android, they should now be pretty similar. Android and iOS renders fonts slightly different so they will never be exactly the same. 
Bug/Feature? three: The order of categories inside a summary list was reversed on Android when comparing to iOS. Now it should display the same order on both OSs. 

## Was this feature tested in the following environments?
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.