### PR TITLE
Add a simple progress bar atom component

### DIFF
--- a/source/components/atoms/Progressbar/Progressbar.stories.js
+++ b/source/components/atoms/Progressbar/Progressbar.stories.js
@@ -1,0 +1,34 @@
+import { storiesOf } from '@storybook/react-native';
+import React, { useState } from 'react';
+import { View } from 'react-native';
+import StoryWrapper from '../../molecules/StoryWrapper';
+import Progressbar from './Progressbar';
+import Button from '../Button/Button';
+import Text from '../Text/Text';
+
+storiesOf('Progressbar', module).add('Default', props => (
+  <StoryWrapper {...props}>
+    <ProgressBar />
+  </StoryWrapper>
+));
+
+const ProgressBar = () => {
+  const [currentStep, setCurrentStep] = useState(1);
+  const totalSteps = 10;
+  const takeStep = () => {
+    let nextStep = currentStep + 1;
+    if (nextStep > totalSteps) nextStep = 1;
+    setCurrentStep(nextStep);
+  };
+  return (
+    <View style={{ paddingTop: 20 }}>
+      <Progressbar currentStep={currentStep} totalStepNumber={totalSteps} />
+      <Button style={{ marginTop: 20 }} onClick={takeStep}>
+        <Text>Take step</Text>
+      </Button>
+      <Text>
+        Step {currentStep}/{totalSteps}
+      </Text>
+    </View>
+  );
+};

--- a/source/components/atoms/Progressbar/Progressbar.tsx
+++ b/source/components/atoms/Progressbar/Progressbar.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View } from 'react-native';
+import styled from 'styled-components';
+
+const ProgressbarBox = styled(View)<{ percentage: number }>`
+  height: 3px;
+  background-color: ${props => props.theme.colors.neutrals[2]};
+  opacity: 2;
+  width: ${props => props.percentage}%;
+`;
+const ProgressbarBackground = styled(View)`
+  height: 3px;
+  background-color: ${props => props.theme.colors.neutrals[0]}1F;
+  width: 100%;
+`;
+
+interface Props {
+  currentStep: number;
+  totalStepNumber: number;
+}
+
+/** Simple progressbar, fills out a grey box to show the completed percentage */
+const Progressbar: React.FC<Props> = ({ currentStep, totalStepNumber }) => {
+  const percentage = (100 * currentStep) / totalStepNumber;
+  return (
+    <ProgressbarBackground>
+      <ProgressbarBox percentage={percentage} />
+    </ProgressbarBackground>
+  );
+};
+
+Progressbar.propTypes = {
+  /** Current step in the main flow */
+  currentStep: PropTypes.number.isRequired,
+  /** Total number of steps in the main flow */
+  totalStepNumber: PropTypes.number.isRequired,
+};
+
+export default Progressbar;

--- a/source/components/atoms/Progressbar/index.js
+++ b/source/components/atoms/Progressbar/index.js
@@ -1,0 +1,1 @@
+export { default } from './Progressbar';

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -8,6 +8,7 @@ import BackNavigation from '../../molecules/BackNavigation/BackNavigation';
 import Banner from './StepBanner/StepBanner';
 import FooterAction from './FooterAction/FooterAction';
 import StepDescription from './StepDescription/StepDescription';
+import Progressbar from '../../atoms/Progressbar/Progressbar';
 
 const StepContainer = styled.View`
   background: ${props => props.theme.colors.neutrals[7]};
@@ -109,6 +110,12 @@ function Step({
             currentPosition={currentPosition}
             totalStepNumber={totalStepNumber}
             {...banner}
+          />
+        )}
+        {currentPosition.level === 0 && (
+          <Progressbar
+            currentStep={currentPosition.currentMainStep}
+            totalStepNumber={totalStepNumber}
           />
         )}
         <StepBody>

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -11,6 +11,7 @@ function loadStories() {
 	require('../source/components/atoms/Icon/Icon.stories');
 	require('../source/components/atoms/Input/Input.stories');
 	require('../source/components/atoms/Label/Label.stories');
+	require('../source/components/atoms/Progressbar/Progressbar.stories');
 	require('../source/components/atoms/RadioButton/RadioButton.stories');
 	require('../source/components/atoms/Select/Select.stories');
 	require('../source/components/atoms/Text/Text.stories');
@@ -45,6 +46,7 @@ const stories = [
 	'../source/components/atoms/Icon/Icon.stories',
 	'../source/components/atoms/Input/Input.stories',
 	'../source/components/atoms/Label/Label.stories',
+	'../source/components/atoms/Progressbar/Progressbar.stories',
 	'../source/components/atoms/RadioButton/RadioButton.stories',
 	'../source/components/atoms/Select/Select.stories',
 	'../source/components/atoms/Text/Text.stories',


### PR DESCRIPTION
## Explain the changes you’ve made

Add a simple progress bar, that just shows a gray box across the screen showing where you are in the form, according to the design. Added this to the step component, if you are in a main-step (i.e. level 0). 

## Explain why these changes are made

Following the design, to give the user a clear indication of how much is left. 

## Explain your solution

Added a simple component, and put it into the step between the banner and body, with a check if we are at level 0. 
Also added a small story to illustrate the look and functionality of the component. 

## How to test the changes?

Either load any form and click around between the steps, or load the storybook and look at the Progressbar story, click the button there a few times. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
