### PR TITLE
Move step indicator text into the tagline in StepDescription

### DIFF
--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -105,16 +105,19 @@ function Step({
         showsHorizontalScrollIndicator={false}
       >
         {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
-          <StepBanner
-            currentPosition={currentPosition}
-            totalStepNumber={totalStepNumber}
-            {...banner}
-          />
+          <StepBanner {...banner} />
         )}
         <StepBody>
           {(isResolved || isIdle) && (
             <>
-              <StepDescription theme={theme} {...description} />
+              <StepDescription
+                theme={theme}
+                currentStep={
+                  currentPosition.level === 0 ? currentPosition.currentMainStep : undefined
+                }
+                totalStepNumber={totalStepNumber}
+                {...description}
+              />
               {questions && (
                 <StepFieldListWrapper>
                   {questions.map(field => (

--- a/source/components/organisms/Step/StepBanner/StepBanner.js
+++ b/source/components/organisms/Step/StepBanner/StepBanner.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Image } from 'react-native';
 import styled from 'styled-components/native';
-import { Text } from 'source/components/atoms';
 import PropTypes from 'prop-types';
 import icons from 'source/helpers/Icons';
 
@@ -17,12 +16,6 @@ const BannerWrapper = styled.View`
   justify-content: flex-end;
 `;
 
-const ProgressCounterText = styled(Text)`
-  position: absolute;
-  bottom: -37px;
-  right: 32px;
-`;
-
 const BannerImageWrapper = styled.View`
   height: 256px;
 `;
@@ -31,33 +24,17 @@ const BannerImage = styled(Image)`
   height: 100%;
 `;
 
-const StepBanner = ({ style, currentPosition, totalStepNumber, imageSrc, colorSchema }) => (
+const StepBanner = ({ style, imageSrc, colorSchema }) => (
   <BannerWrapper style={style} image={imageSrc} colorSchema={colorSchema}>
     {Object.prototype.hasOwnProperty.call(icons, imageSrc) ? (
       <BannerImageWrapper>
         <BannerImage resizeMode="contain" source={icons[imageSrc]} />
       </BannerImageWrapper>
     ) : null}
-    {/*
-        TODO: Move ProgressCounterText component out of the banner component.
-        Could be rendered as a child in the Banner instead where it's needed. ie in a Step.
-      */}
-    {totalStepNumber > 1 && currentPosition.level === 0 && (
-      <ProgressCounterText>
-        Steg {currentPosition.currentMainStep}/{totalStepNumber}
-      </ProgressCounterText>
-    )}
   </BannerWrapper>
 );
 
 StepBanner.propTypes = {
-  /** The current position in the form */
-  currentPosition: PropTypes.shape({
-    index: PropTypes.number,
-    level: PropTypes.number,
-    currentMainStep: PropTypes.number,
-  }),
-  totalStepNumber: PropTypes.number,
   /**
    * The source to a image to render as a background in the banner.
    */

--- a/source/components/organisms/Step/StepDescription/StepDescription.js
+++ b/source/components/organisms/Step/StepDescription/StepDescription.js
@@ -24,11 +24,23 @@ const StepDescriptionText = styled(Text)`
   margin-top: 16px;
 `;
 
-function StepDescription({ style, tagline, heading, text, colorSchema }) {
+function StepDescription({
+  style,
+  tagline,
+  heading,
+  text,
+  colorSchema,
+  currentStep,
+  totalStepNumber,
+}) {
   return (
     <StepDescriptionWrapper style={style}>
       {tagline.length !== 0 && (
-        <StepDescriptionTagline colorSchema={colorSchema}>{tagline}</StepDescriptionTagline>
+        <StepDescriptionTagline colorSchema={colorSchema}>
+          {tagline}
+          {tagline && currentStep && totalStepNumber && ' • '}
+          {currentStep && totalStepNumber && `${currentStep} / ${totalStepNumber}`}
+        </StepDescriptionTagline>
       )}
       <Heading>{heading}</Heading>
       {text.length !== 0 && <StepDescriptionText>{text}</StepDescriptionText>}
@@ -41,6 +53,10 @@ StepDescription.propTypes = {
   tagline: PropTypes.string,
   heading: PropTypes.string.isRequired,
   text: PropTypes.string,
+  /** Current main step in the form */
+  currentStep: PropTypes.number,
+  /** Total number of main steps in the form */
+  totalStepNumber: PropTypes.number,
   /**
    * The color schema for the description,
    */

--- a/source/components/organisms/Step/StepDescription/StepDescription.stories.js
+++ b/source/components/organisms/Step/StepDescription/StepDescription.stories.js
@@ -35,6 +35,8 @@ storiesOf('StepDescription', module)
         tagline="Green tagline"
         colorSchema="green"
         heading="Step Description Heading"
+        currentStep={2}
+        totalStepNumber={5}
       />
     </StoryWrapper>
   ))
@@ -49,6 +51,8 @@ storiesOf('StepDescription', module)
         tagline="Step Description Tagline"
         text={lorem}
         heading="Step Description Heading"
+        currentStep={4}
+        totalStepNumber={8}
       />
     </StoryWrapper>
   ))


### PR DESCRIPTION
## Explain the changes you’ve made

Move the step indicator text (the 3/8 text etc.) into the step description tagline, removing it from the banner.

## Explain why these changes are made

To follow the MVP design. 

## Explain your solution

Simply remove the text from the banner, and add it to the tagline, with some checks so that it's rendered correctly in the different scenarios like empty tagline or no currentStep prop etc. 
Also add a check inside Step so that this step indicator only is rendered when in the main flow (level === 0). 
Added some examples in the StepDescription story.

## How to test the changes?

Go into any form and check the tagline text. 
Also check that it's not rendered when on a substep. 
Or check the StepDescription story, there's also examples of how it looks there. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

