### PR TITLE
Add option for SummaryList to start in editable mode or not

### DIFF
--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -15,7 +15,7 @@ const ListBody = styled.View`
   height: auto;
 `;
 
-const ListBodyFieldLabel = styled(Heading) <{ colorSchema: string }>`
+const ListBodyFieldLabel = styled(Heading)<{ colorSchema: string }>`
   margin-top: 5px;
   margin-left: 3px;
   font-weight: ${props => props.theme.fontWeights[1]};
@@ -107,7 +107,7 @@ GroupedList.propTypes = {
   /**
    *  Controls the color scheme of the list
    */
-  color: PropTypes.oneOf(Object.keys(theme.groupedList)),
+  color: PropTypes.oneOf(Object.keys(theme.colors.primary)),
   /**
    * Whether or not to show the edit button
    */

--- a/source/components/organisms/SummaryList/SummaryList.stories.js
+++ b/source/components/organisms/SummaryList/SummaryList.stories.js
@@ -30,9 +30,9 @@ const SummaryStory = () => {
       <Input
         value={state.f1}
         onChangeText={text => {
-          setState(s => {
-            s.f1 = text;
-            return { ...s };
+          setState(oldState => {
+            oldState.f1 = text;
+            return { ...oldState };
           });
         }}
       />
@@ -42,9 +42,9 @@ const SummaryStory = () => {
       <Input
         value={state.pris1}
         onChangeText={text => {
-          setState(s => {
-            s.pris1 = text;
-            return { ...s };
+          setState(oldState => {
+            oldState.pris1 = text;
+            return { ...oldState };
           });
         }}
       />
@@ -54,9 +54,9 @@ const SummaryStory = () => {
       <Input
         value={state.f2}
         onChangeText={text => {
-          setState(s => {
-            s.f2 = text;
-            return { ...s };
+          setState(oldState => {
+            oldState.f2 = text;
+            return { ...oldState };
           });
         }}
       />
@@ -66,9 +66,9 @@ const SummaryStory = () => {
       <Input
         value={state.pris2}
         onChangeText={text => {
-          setState(s => {
-            s.pris2 = text;
-            return { ...s };
+          setState(oldState => {
+            oldState.pris2 = text;
+            return { ...oldState };
           });
         }}
       />
@@ -78,9 +78,9 @@ const SummaryStory = () => {
         categories={categories}
         color="green"
         onChange={(answer, id) => {
-          setState(s => {
-            s[id] = answer;
-            return { ...s };
+          setState(oldState => {
+            oldState[id] = answer;
+            return { ...oldState };
           });
         }}
         answers={state}
@@ -92,9 +92,9 @@ const SummaryStory = () => {
         categories={categories}
         color="blue"
         onChange={(answer, id) => {
-          setState(s => {
-            s[id] = answer;
-            return { ...s };
+          setState(oldState => {
+            oldState[id] = answer;
+            return { ...oldState };
           });
         }}
         answers={state}

--- a/source/components/organisms/SummaryList/SummaryList.stories.js
+++ b/source/components/organisms/SummaryList/SummaryList.stories.js
@@ -86,6 +86,21 @@ const SummaryStory = () => {
         answers={state}
         showSum
       />
+      <SummaryList
+        heading="Blå, ingen summa"
+        items={items}
+        categories={categories}
+        color="blue"
+        onChange={(answer, id) => {
+          setState(s => {
+            s[id] = answer;
+            return { ...s };
+          });
+        }}
+        answers={state}
+        showSum={false}
+        startEditable
+      />
     </ScrollView>
   );
 };

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -54,6 +54,7 @@ interface Props {
   color: string;
   answers: Record<string, any>;
   showSum: boolean;
+  startEditable?: boolean;
 }
 /**
  * Summary list, that is linked and summarizes values from other input components.
@@ -68,6 +69,7 @@ const SummaryList: React.FC<Props> = ({
   color,
   answers,
   showSum,
+  startEditable,
 }) => {
   /**
    * Given an item, and possibly an index in the case of repeater fields, this generates a function that
@@ -172,7 +174,7 @@ const SummaryList: React.FC<Props> = ({
           categories={categories}
           color={color}
           showEditButton
-          startEditable
+          startEditable={startEditable}
         />
         {showSum && (
           <SumContainer colorSchema={validColorSchema}>
@@ -214,6 +216,10 @@ SummaryList.propTypes = {
    * Whether or not to show a sum of all numeric values at the bottom. Defaults to true.
    */
   showSum: PropTypes.bool,
+  /**
+   * Whether to start in editable mode or not.
+   */
+  startEditable: PropTypes.bool,
 };
 
 SummaryList.defaultProps = {


### PR DESCRIPTION
## Explain the changes you’ve made

Add a prop to SummaryList so that we can control if it starts in editable mode or not. I will add this to the formbuilder as an option.

## Explain why these changes are made

So that we can get the desired behaviour in different places in the form.

## Explain your solution

The GroupedList already has the required prop, so I just add it to the SummaryList and pass it down. 
Also updated the story to demonstrate that this works. 
After this change, the default behaviour is to start in non-editable mode, and you have to toggle it on in the formbuilder to change this.

## How to test the changes?

In the storybook, note that the two copies have different initial state. Or open any form with a summary list and see that it starts as non-editable.

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
