### PR TITLE
refactor: changed name on component FooterAction to StepFooter

### DIFF
--- a/source/components/organisms/Step/FooterAction/index.js
+++ b/source/components/organisms/Step/FooterAction/index.js
@@ -1,1 +1,0 @@
-export { default } from './FooterAction';

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -1,12 +1,12 @@
-import React, {useContext, useEffect} from 'react';
+import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import AuthContext from 'app/store/AuthContext';
-import {Text} from 'react-native';
-import {AuthLoading, FormField} from 'app/components/molecules';
+import { Text } from 'react-native';
+import { AuthLoading, FormField } from 'app/components/molecules';
 import BackNavigation from '../../molecules/BackNavigation/BackNavigation';
 import Banner from './StepBanner/StepBanner';
-import FooterAction from './FooterAction/FooterAction';
+import StepFooter from './StepFooter/StepFooter';
 import StepDescription from './StepDescription/StepDescription';
 import Progressbar from '../../atoms/Progressbar/Progressbar';
 
@@ -35,12 +35,6 @@ const StepFieldListWrapper = styled.View`
   margin: 24px;
 `;
 
-const StepFooter = styled(FooterAction)`
-  background: ${props => props.theme.colors.neutrals[6]}
-  position: absolute;
-  bottom: 0;
-`;
-
 const SignStepWrapper = styled.View`
   padding: 48px 24px 24px 24px;
 `;
@@ -48,7 +42,6 @@ const SignStepWrapper = styled.View`
 function Step({
   theme,
   banner,
-  footerBg,
   description,
   questions,
   actions,
@@ -167,7 +160,6 @@ function Step({
           <StepFooter
             actions={actions}
             caseStatus={status}
-            background={footerBg}
             answers={answers}
             formNavigation={formNavigation}
             currentPosition={currentPosition}

--- a/source/components/organisms/Step/StepFooter/StepFooter.js
+++ b/source/components/organisms/Step/StepFooter/StepFooter.js
@@ -9,15 +9,13 @@ const ActionContainer = styled.View(props => ({
   backgroundColor: props.theme.colors.neutrals[5],
 }));
 const Flex = styled.View`
-  position: absolute;
-  bottom: 0;
   padding: 5px;
   align-items: flex-end;
-  padding-right: 10px;
 `;
 const ButtonWrapper = styled.View`
-  margin-top: 5%;
-  margin-bottom: 5%;
+  margin-top: 32px;
+  margin-bottom: 49px;
+  margin-right: 32px;
 `;
 
 const StepFooter = ({
@@ -97,6 +95,7 @@ const StepFooter = ({
         onClick={actionMap(action.type)}
         color={action.color}
         disabled={checkCondition(action.conditionalOn)}
+        z={0}
       >
         <Text>{action.label}</Text>
       </Button>

--- a/source/components/organisms/Step/StepFooter/StepFooter.js
+++ b/source/components/organisms/Step/StepFooter/StepFooter.js
@@ -6,9 +6,11 @@ import { Button, Text } from '../../../atoms';
 
 const ActionContainer = styled.View(props => ({
   flex: 1,
-  backgroundColor: props.background,
+  backgroundColor: props.theme.colors.neutrals[5],
 }));
 const Flex = styled.View`
+  position: absolute;
+  bottom: 0;
   padding: 5px;
   align-items: flex-end;
   padding-right: 10px;
@@ -18,7 +20,7 @@ const ButtonWrapper = styled.View`
   margin-bottom: 5%;
 `;
 
-const FooterAction = ({
+const StepFooter = ({
   actions,
   caseStatus,
   background,
@@ -111,7 +113,7 @@ const FooterAction = ({
   );
 };
 
-FooterAction.propTypes = {
+StepFooter.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
 
   /**
@@ -169,7 +171,7 @@ FooterAction.propTypes = {
   }),
 };
 
-FooterAction.defaultProps = {
+StepFooter.defaultProps = {
   background: '#00213F',
 };
-export default FooterAction;
+export default StepFooter;

--- a/source/components/organisms/Step/StepFooter/StepFooter.stories.js
+++ b/source/components/organisms/Step/StepFooter/StepFooter.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/react-native';
 import React from 'react';
 import StoryWrapper from '../../../molecules/StoryWrapper';
-import FooterAction from './FooterAction';
+import StepFooter from './StepFooter';
 
 const actions1 = [
   {
@@ -32,8 +32,8 @@ const actions3 = [
 
 storiesOf('Footer', module).add('Forward/ Cancel', props => (
   <StoryWrapper {...props}>
-    <FooterAction actions={actions1} />
-    <FooterAction actions={actions2} background="#FFAA9B" />
-    <FooterAction actions={actions3} />
+    <StepFooter actions={actions1} />
+    <StepFooter actions={actions2} background="#FFAA9B" />
+    <StepFooter actions={actions3} />
   </StoryWrapper>
 ));

--- a/source/components/organisms/Step/StepFooter/index.js
+++ b/source/components/organisms/Step/StepFooter/index.js
@@ -1,0 +1,1 @@
+export { default } from './StepFooter';

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -31,10 +31,10 @@ function loadStories() {
 	require('../source/components/molecules/RepeaterField/RepeaterField.stories');
 	require('../source/components/molecules/ToastNotification/ToastNotifications.stories');
 	require('../source/components/organisms/FormList/FormList.stories');
-	require('../source/components/organisms/Step/FooterAction/FooterAction.stories');
 	require('../source/components/organisms/Step/Step.stories');
 	require('../source/components/organisms/Step/StepBanner/StepBanner.stories');
 	require('../source/components/organisms/Step/StepDescription/StepDescription.stories');
+	require('../source/components/organisms/Step/StepFooter/StepFooter.stories');
 	require('../source/components/organisms/SummaryList/SummaryList.stories');
 }
 
@@ -66,10 +66,10 @@ const stories = [
 	'../source/components/molecules/RepeaterField/RepeaterField.stories',
 	'../source/components/molecules/ToastNotification/ToastNotifications.stories',
 	'../source/components/organisms/FormList/FormList.stories',
-	'../source/components/organisms/Step/FooterAction/FooterAction.stories',
 	'../source/components/organisms/Step/Step.stories',
 	'../source/components/organisms/Step/StepBanner/StepBanner.stories',
 	'../source/components/organisms/Step/StepDescription/StepDescription.stories',
+	'../source/components/organisms/Step/StepFooter/StepFooter.stories',
 	'../source/components/organisms/SummaryList/SummaryList.stories'
 ];
 


### PR DESCRIPTION
## Explain the changes you’ve made

I've added support for theming the background color in a form steps footer, so that it always defaults to a shade of grey. 
In addition to this i've also renamed the component to StepFooter from FooterAction.

For more background, see [clickup task](https://app.clickup.com/t/fmrkhq)

## Explain why these changes are made

These changes are a move towards using theming in the application that is set in a higher context than the individually component.

The renaming of the component was done due to that the component is only used together with a step in a form. Thereby the name StepFooter feels more natural than FooterAction.

For more background, see [clickup task](https://app.clickup.com/t/fmrkhq)


## Explain your solution

The solution for adding the theme is to use the ThemeContext provided through Styled-components and retreive the color data from that context.


## How to test the changes?

1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command`yarn ios`
4. Go to the story Footer.

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.


## Anyhting else? (optional)

The Footer should according to design be able to change color based on where in a Form you are, this functionality is not adressed here. Would need to have another round with the design team to check how important this aspect is right now.
