### PR TITLE
Style/substep animation

### DIFF
--- a/source/components/molecules/Modal/Modal.js
+++ b/source/components/molecules/Modal/Modal.js
@@ -8,33 +8,37 @@ const ModalContainer = styled(RnModal)`
   margin-left: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
-  margin-top: 24px;
+  margin-top: 30px;
   border-top-left-radius: 17.5px;
   border-top-right-radius: 17.5px;
 `;
 
-const ModalWrapper = styled.View({
-  backgroundColor: '#00213F',
-  flexGrow: 1,
-});
+const ModalWrapper = styled.View`
+  background-color: yellow;
+  flex-grow: 1;
+`;
+const ModalFooter = styled.View`
+  background-color: #00213f;
+  flex-grow: 1000;
+`;
 
-const Content = styled.ScrollView``;
-
+const Content = styled.ScrollView`
+  flex-direction: column;
+`;
+// swipeDirection="down"
 const Modal = ({ visible, children, ...other }) => (
   <ModalContainer
-    animationInTiming={400}
-    animationOutTiming={400}
-    backdropOpacity={0}
+    animationInTiming={500}
+    animationOutTiming={500}
     propagateSwipe
     swipeDirection="down"
     isVisible={visible}
     {...other}
   >
-    <ModalWrapper>
-      <Content>
-        <TouchableOpacity activeOpacity={1}>{children}</TouchableOpacity>
-      </Content>
-    </ModalWrapper>
+    <Content>
+      <TouchableOpacity activeOpacity={1}>{children}</TouchableOpacity>
+    </Content>
+    <ModalFooter />
   </ModalContainer>
 );
 

--- a/source/components/molecules/Modal/Modal.js
+++ b/source/components/molecules/Modal/Modal.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity } from 'react-native';
 import RnModal from 'react-native-modal';
 import styled from 'styled-components/native';
 
@@ -11,34 +10,19 @@ const ModalContainer = styled(RnModal)`
   margin-top: 30px;
   border-top-left-radius: 17.5px;
   border-top-right-radius: 17.5px;
-`;
-
-const ModalWrapper = styled.View`
-  background-color: yellow;
-  flex-grow: 1;
-`;
-const ModalFooter = styled.View`
   background-color: #00213f;
-  flex-grow: 1000;
 `;
 
-const Content = styled.ScrollView`
-  flex-direction: column;
-`;
-// swipeDirection="down"
 const Modal = ({ visible, children, ...other }) => (
   <ModalContainer
     animationInTiming={500}
     animationOutTiming={500}
     propagateSwipe
-    swipeDirection="down"
     isVisible={visible}
+    transparent
     {...other}
   >
-    <Content>
-      <TouchableOpacity activeOpacity={1}>{children}</TouchableOpacity>
-    </Content>
-    <ModalFooter />
+    {children}
   </ModalContainer>
 );
 

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import Step from '../../components/organisms/Step/Step';
@@ -6,6 +6,7 @@ import { Step as StepType, StepperActions } from '../../types/FormTypes';
 import { CaseStatus } from '../../types/CaseType';
 import { User } from '../../types/UserTypes';
 import useForm from './hooks/useForm';
+import Modal from '../../components/molecules/Modal';
 
 const FormContainer = styled.View`
   flex: 1;
@@ -42,7 +43,12 @@ const Form: React.FC<Props> = ({
   status,
   updateCaseInContext,
 }) => {
-  const currentPosition = { index: startAt, level: 0, currentMainStep: 1 };
+  const currentPosition = {
+    index: startAt,
+    level: 0,
+    currentMainStep: 1,
+    currentMainStepIndex: startAt,
+  };
   const initialState = {
     submitted: false,
     currentPosition,
@@ -90,8 +96,16 @@ const Form: React.FC<Props> = ({
       />
     )
   );
-
-  return <FormContainer>{stepComponents[formState.currentPosition.index]}</FormContainer>;
+  return (
+    <>
+      <FormContainer>
+        {stepComponents[formState.currentPosition.currentMainStepIndex]}
+      </FormContainer>
+      <Modal visible={formState.currentPosition.level > 0}>
+        {stepComponents[formState.currentPosition.index]}
+      </Modal>
+    </>
+  );
 };
 
 Form.propTypes = {

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import Step from '../../components/organisms/Step/Step';

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -82,6 +82,7 @@ export function goNext(state: FormReducerState) {
         level: currentPosition.level,
         currentMainStep:
           state.currentPosition.currentMainStep + (currentPosition.level === 0 ? 1 : 0),
+        currentMainStepIndex: currentPosition.level === 0 ? nextIndex : currentPosition.currentMainStepIndex,
       },
     };
   }
@@ -107,6 +108,7 @@ export function goBack(state: FormReducerState) {
         index: backIndex,
         currentMainStep:
           state.currentPosition.currentMainStep - (currentPosition.level === 0 ? 1 : 0),
+        currentMainStepIndex: currentPosition.level === 0 ? backIndex : currentPosition.currentMainStepIndex,
       },
     };
   }

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -5,7 +5,12 @@ import { User } from '../../../types/UserTypes';
 
 export interface FormReducerState {
   submitted: boolean;
-  currentPosition: { index: number; level: number; currentMainStep: number };
+  currentPosition: {
+    index: number;
+    level: number;
+    currentMainStep: number;
+    currentMainStepIndex: number;
+  };
   steps: Step[];
   user: User;
   connectivityMatrix: StepperActions[][];
@@ -112,7 +117,7 @@ function useForm(initialState: FormReducerState) {
   // const closeForm = (callback: (s: { state: FormReducerState }, isLastStep: boolean) => any) =>
   //   callback({ state: formState }, isLastStep());
 
-  function closeForm() { }
+  function closeForm() {}
   /**
    * Function for updating answer.
    */


### PR DESCRIPTION
## Explain the changes you’ve made

Change the form rendering so that we show substeps in a modal above the main form.

## Explain why these changes are made

To follow the design more closely.

## Explain your solution

I add an additional variable to the currentPosition object in the formState, that keeps track of the current main step index, so that I can show the right step behind the modal. 
Then I add some logic that keeps this updated as we move back and forward in the form.
Then in the Form component I change the return value so that a modal shows up whenever we are in a substep. 

I also change and simplify how the modal renders its content. This was a bit troublesome, and the current solution is not ideal, but I think it works for now. The issue was to correctly have a transparent background at the same time as the footer extends all the way to the bottom, while keeping the modal swipable. 

## How to test the changes?

Load a form that has substeps, and check out how they open and look, like the löpande ansökan form. We currently lack a story that demonstrate this.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
