### PR TITLE
rename prop to fix back button showing in helper modal

### DIFF
--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -88,11 +88,13 @@ const HelpButton = props => {
       <Modal
         visible={modalVisible}
         animationType="slide"
-        onRequestClose={() => setModalVisible(false)}
+        onRequestClose={() => {
+          setModalVisible(false);
+        }}
         presentationStyle="pageSheet"
       >
         <ModalContainer>
-          <CloseModal isBackBtnVisible={false} onClose={() => setModalVisible(false)} />
+          <CloseModal showBackButton={false} onClose={() => setModalVisible(false)} />
           <BannerWrapper>
             <BannerIcon resizeMode="contain" source={icons.ICON_HELP} />
           </BannerWrapper>


### PR DESCRIPTION
Renaming of a prop in help button modal, that was forgotten in an earlier refactoring, leading to the back button being displayed inside the helper modal. 