### PR TITLE
Style/navigation button group

### DIFF
--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
@@ -5,7 +5,7 @@ import { Button, Icon, Text } from '../../atoms';
 import Box from '../../atoms/Box/Box';
 
 const ButtonFieldWrapper = styled(Box).attrs({
-  m: "2px",
+  m: '2px',
 })`
   flex: 1;
 `;
@@ -18,7 +18,7 @@ export type NavigationActionType =
 
 export interface Props {
   iconName: string;
-  text: string;
+  text?: string;
   colorSchema: string;
   navigationType: NavigationActionType;
   formNavigation: {
@@ -31,13 +31,13 @@ export interface Props {
 
 // TODO: Move navigation logic to a smart container component,
 // this dumb component do not need to know about how formNavigation is handled.
-// Only that an onClick event should be triggerd.
+// Only that an onClick event should be triggered.
 const NavigationButtonField: React.FC<Props> = ({
   iconName,
   text,
   navigationType,
   formNavigation,
-  colorSchema
+  colorSchema,
 }) => {
   const onClick = () => {
     // This logic could be broken out and placed elsewhere.
@@ -58,14 +58,13 @@ const NavigationButtonField: React.FC<Props> = ({
       default:
         break;
     }
-  }
+  };
 
-  console.log(iconName)
   return (
     <ButtonFieldWrapper>
       <Button variant="outlined" onClick={onClick} colorSchema={colorSchema}>
         {iconName.length ? <Icon name={iconName} /> : null}
-        <Text>{text}</Text>
+        {text && <Text>{text}</Text>}
       </Button>
     </ButtonFieldWrapper>
   );

--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
@@ -17,9 +17,9 @@ export type NavigationActionType =
   | { type: 'navigateBack' };
 
 export interface Props {
-  iconName: string;
+  iconName?: string;
   text?: string;
-  colorSchema: string;
+  colorSchema?: string;
   navigationType: NavigationActionType;
   formNavigation: {
     next: () => void;

--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import { Button, Icon, Text } from '../../atoms';
-import theme from '../../../styles/theme';
+import Box from '../../atoms/Box/Box';
 
-const ButtonFieldWrapper = styled.View`
+const ButtonFieldWrapper = styled(Box).attrs({
+  m: "2px",
+})`
   flex: 1;
-  margin: 2px;
 `;
 
 export type NavigationActionType =
@@ -18,7 +19,7 @@ export type NavigationActionType =
 export interface Props {
   iconName: string;
   text: string;
-  color: string;
+  colorSchema: string;
   navigationType: NavigationActionType;
   formNavigation: {
     next: () => void;
@@ -31,9 +32,9 @@ export interface Props {
 const NavigationButtonField: React.FC<Props> = ({
   iconName,
   text,
-  color,
   navigationType,
   formNavigation,
+  colorSchema
 }) => {
   let onClick = (targetId?: string) => {};
   switch (navigationType.type) {
@@ -52,11 +53,13 @@ const NavigationButtonField: React.FC<Props> = ({
 
     default:
   }
+
+  console.log(iconName)
   return (
     <ButtonFieldWrapper>
-      <Button onClick={onClick} color={color} block>
-        <Text>{text}</Text>
+      <Button variant="outlined" onClick={onClick} colorSchema={colorSchema}>
         {iconName.length ? <Icon name={iconName} /> : null}
+        <Text>{text}</Text>
       </Button>
     </ButtonFieldWrapper>
   );
@@ -75,16 +78,16 @@ NavigationButtonField.propTypes = {
    */
   navigationType: PropTypes.any,
   /**
-   * Color of the button
+   * Color schema of the button
    */
-  color: PropTypes.oneOf(Object.keys(theme.button)),
+  colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
   formNavigation: PropTypes.any,
 };
 
 NavigationButtonField.defaultProps = {
-  iconName: '',
+  iconName: 'add',
   text: '',
-  color: 'white',
+  colorSchema: 'blue',
 };
 
 export default NavigationButtonField;

--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
@@ -29,7 +29,9 @@ export interface Props {
   };
 }
 
-// TODO: Move navigation logic outside of component
+// TODO: Move navigation logic to a smart container component,
+// this dumb component do not need to know about how formNavigation is handled.
+// Only that an onClick event should be triggerd.
 const NavigationButtonField: React.FC<Props> = ({
   iconName,
   text,
@@ -38,6 +40,7 @@ const NavigationButtonField: React.FC<Props> = ({
   colorSchema
 }) => {
   const onClick = () => {
+    // This logic could be broken out and placed elsewhere.
     switch (navigationType.type) {
       case 'navigateDown':
         formNavigation.down(navigationType.stepId);
@@ -67,6 +70,7 @@ const NavigationButtonField: React.FC<Props> = ({
     </ButtonFieldWrapper>
   );
 };
+
 NavigationButtonField.propTypes = {
   /**
    * Name of the icon to be displayed
@@ -84,6 +88,9 @@ NavigationButtonField.propTypes = {
    * Color schema of the button
    */
   colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
+  /**
+   * Object with navigation event for a form.
+   */
   formNavigation: PropTypes.any,
 };
 

--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
@@ -29,6 +29,7 @@ export interface Props {
   };
 }
 
+// TODO: Move navigation logic outside of component
 const NavigationButtonField: React.FC<Props> = ({
   iconName,
   text,
@@ -36,22 +37,24 @@ const NavigationButtonField: React.FC<Props> = ({
   formNavigation,
   colorSchema
 }) => {
-  let onClick = (targetId?: string) => {};
-  switch (navigationType.type) {
-    case 'navigateDown':
-      onClick = () => formNavigation.down(navigationType.stepId);
-      break;
-    case 'navigateUp':
-      onClick = () => formNavigation.up();
-      break;
-    case 'navigateNext':
-      onClick = formNavigation.next;
-      break;
-    case 'navigateBack':
-      onClick = formNavigation.back;
-      break;
+  const onClick = () => {
+    switch (navigationType.type) {
+      case 'navigateDown':
+        formNavigation.down(navigationType.stepId);
+        break;
+      case 'navigateUp':
+        formNavigation.up();
+        break;
+      case 'navigateNext':
+        formNavigation.next();
+        break;
+      case 'navigateBack':
+        formNavigation.back();
+        break;
 
-    default:
+      default:
+        break;
+    }
   }
 
   console.log(iconName)


### PR DESCRIPTION
## Explain the changes you’ve made

Updated the Navigation Button Component to match design from Figma.

## Explain why these changes are made

The design was not considered when doing the first implementation of this component. Therefore a update to the design was nessecary.

## Explain your solution

The solution was to change the way that the Button component is rendered in the Navigation Button Component. So that the correct props is passed and so that children are passed in the correct way. 

Passing the children in the right order id important since we want the first child to be and icon and thereby display on the left side in the button content.

## How to test the changes?

1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command`yarn ios`
4. Go to the NavigationButton Story.
5. Swap the application back to building the actual app.
6. Start a form with a navigation button group component.

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.

## Anyhting else? (optional)

There are a few additional comments added in the component that concerns the responsibility of navigation in a form, i think this could be simplified. 

My suggestion is to add a ButtonGroup component that can render one or more Buttons in vertical or horizontal manner. This component can be used to create a component that is smart and handels form navigation logics.
