### PR TITLE
Add date input as an option for editable list

### DIFF
--- a/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
+++ b/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
@@ -33,32 +33,51 @@ const ButtonContainer = styled.View`
   margin: 0 auto;
   justify-content: center;
 `;
+const DateInput = styled(Input)<{ transparent: boolean }>`
+  ${({ transparent }) => transparent && 'background: transparent;'}
+  border: none;
+  text-align: right;
+  min-width: 80%;
+  font-weight: 500;
+  color: ${props => props.theme.colors.neutrals[1]};
+`;
 
 interface PropInterface {
   onSelect: (data: Date) => void;
   date: any;
+  editable?: boolean;
+  transparent?: boolean;
 }
-const CalendarPickerForm: React.FC<PropInterface> = ({ onSelect, date }) => {
+const CalendarPickerForm: React.FC<PropInterface> = ({
+  onSelect,
+  date,
+  editable = true,
+  transparent,
+}) => {
   const [isVisible, setIsVisible] = useState(false);
 
   // Handle selected date and hide calendar modal.
-  const handleCalendarDateChange = selectedDate => {
-    onSelect(selectedDate);
+  const handleCalendarDateChange = (selectedDate: moment.Moment) => {
+    onSelect(selectedDate.toDate());
     setIsVisible(!isVisible);
   };
 
   return (
     <View>
       <TouchableOpacity
+        disabled={!editable}
         onPress={() => {
           setIsVisible(!isVisible);
         }}
       >
-        <Input
+        <DateInput
           placeholder="Välj datum"
           value={date ? moment(date).format('Y-MM-DD') : undefined}
+          multiline /** Temporary fix to make field scrollable inside scrollview */
+          numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
           editable={false}
           pointerEvents="none"
+          transparent={transparent}
         />
       </TouchableOpacity>
 
@@ -114,6 +133,10 @@ CalendarPickerForm.propTypes = {
    * Date value. Used for storing and displaying date in components.
    */
   date: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.string]),
+  /** Turn the input field of. Defaults to true. */
+  editable: PropTypes.bool,
+  /** Turn the background of input field transparent */
+  transparent: PropTypes.bool,
 };
 
 export default CalendarPickerForm;

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -3,11 +3,7 @@ import { LayoutAnimation } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import { Text, Button, Fieldset } from '../../atoms';
-
-/**
- * EditableList
- * A Molecule Component to use for rendering a list with the possibility of editing the list values.
- */
+import CalendarPicker from '../CalendarPicker/CalendarPickerForm';
 
 const EditableListBody = styled.View`
   padding-top: 33px;
@@ -70,6 +66,10 @@ const getInitialState = (inputs, value) => {
   return inputs.reduce((prev, current) => ({ ...prev, [current.key]: current.value }), {});
 };
 
+/**
+ * EditableList
+ * A Molecule Component to use for rendering a list with the possibility of editing the list values.
+ */
 function EditableList({
   colorSchema,
   title,
@@ -93,7 +93,45 @@ function EditableList({
     onInputChange(updatedState);
     setState(updatedState);
   };
+  /** Switch between different input types */
+  const getInputComponent = input => {
+    switch (input.type) {
+      case 'number':
+        return (
+          <EditableListItemInput
+            multiline /** Temporary fix to make field scrollable inside scrollview */
+            numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
+            colorSchema={colorSchema}
+            editable={editable}
+            onChangeText={text => onChange(input.key, text)}
+            value={value && value !== '' ? value[input.key] : state[input.key]}
+            keyboardType="numeric"
+          />
+        );
+      case 'date':
+        return (
+          <CalendarPicker
+            date={value && value !== '' ? value[input.key] : state[input.key]}
+            onSelect={date => onChange(input.key, date)}
+            editable={editable}
+            transparent
+          />
+        );
+      default:
+        return (
+          <EditableListItemInput
+            multiline /** Temporary fix to make field scrollable inside scrollview */
+            numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
+            colorSchema={colorSchema}
+            editable={editable}
+            onChangeText={text => onChange(input.key, text)}
+            value={value && value !== '' ? value[input.key] : state[input.key]}
+          />
+        );
+    }
+  };
 
+  console.log('inputs', inputs);
   return (
     <Fieldset
       colorSchema={colorSchema}
@@ -119,16 +157,7 @@ function EditableList({
             <EditableListItemLabelWrapper>
               <EditableListItemLabel>{input.label}</EditableListItemLabel>
             </EditableListItemLabelWrapper>
-            <EditableListItemInputWrapper>
-              <EditableListItemInput
-                multiline /** Temporary fix to make field scrollable inside scrollview */
-                numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
-                colorSchema={colorSchema}
-                editable={editable}
-                onChangeText={text => onChange(input.key, text)}
-                value={value && value !== '' ? value[input.key] : state[input.key]}
-              />
-            </EditableListItemInputWrapper>
+            <EditableListItemInputWrapper>{getInputComponent(input)}</EditableListItemInputWrapper>
           </EditableListItem>
         ))}
       </EditableListBody>

--- a/source/components/molecules/EditableList/EditableList.stories.js
+++ b/source/components/molecules/EditableList/EditableList.stories.js
@@ -22,6 +22,12 @@ const inputs = [
     type: 'text',
     value: 'Helsingborgshem',
   },
+  {
+    key: 'key-4',
+    label: 'Inflyttningsdatum',
+    type: 'date',
+    value: '2020-12-24',
+  },
 ];
 
 storiesOf('EditableList', module).add('Default', () => (


### PR DESCRIPTION
## Explain the changes you’ve made

Add date as a possible input in the editableList component. 

## Explain your solution

I added some switch logic to the EditableList component, so that it can handle more than just text input. As a bonus, I discovered that it was not handling number input correctly, i.e. not showing the user a numeric keyboard, which this PR also fixes. The next step is to add support for dropdown menus, where this logic will also help. 

In addition, I added two optional props to the calendarPicker so that it can be disabled, and turned transparent, and changed some styling of its input field to match the overall design. 

## How to test the changes?

Go into the storybook and check the EditableList  - Input is editable story ; the last field uses the date option and shows the new CalendarPicker. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
