### PR TITLE
feat: new button variant link

### DIFF
--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -25,6 +25,12 @@ Styles.outlined = css`
   ${Styles.elevation[0]}
 `;
 
+Styles.link = css`
+  padding: 6px 10px;
+  justify-content: flex-end;
+  background-color: ${props => props.theme.colors.complementary[props.colorSchema][1]};
+`;
+
 Styles.contained = css``;
 
 /* Styles for size variants */
@@ -63,6 +69,8 @@ const ButtonBase = styled.View`
     ${props => props.size === 'medium' && Styles.medium}
     ${props => props.size === 'large' && Styles.large}
 
+    ${props => props.size === 'large' && Styles.large}
+
     ${props => Styles.elevation[props.elevation]}
     shadow-color: ${props => props.theme.button[props.colorSchema].shadow};
 
@@ -74,6 +82,11 @@ const ButtonText = styled(Text)`
   font-weight: ${props => props.theme.fontWeights[1]};
   color: ${props =>
     props.variant === 'outlined' ? props.theme.colors.neutrals[1] : props.theme.colors.neutrals[7]};
+  ${props =>
+    props.variant === 'link' &&
+    `
+    color: ${props.theme.colors.primary[props.colorSchema][1]};
+  `}
 `;
 const ButtonIcon = styled(Icon)`
   color: ${props =>
@@ -84,6 +97,16 @@ const ButtonIcon = styled(Icon)`
   height: 26px;
   width: 26px;
   line-height: 26px;
+  ${props =>
+    props.variant === 'link' &&
+    `
+    height: 20px;
+    width: 18px;
+    font-size: 20px;
+    line-height: 20px;
+    margin-left: 10px;
+    color: ${props.theme.colors.primary[props.colorSchema][1]};
+  `}
 `;
 
 const LeftButtonIcon = styled(ButtonIcon)`
@@ -176,6 +199,9 @@ const Button = props => {
           variant={variant}
         >
           {children || (value ? <ButtonText>{value}</ButtonText> : null)}
+          {variant === 'link' ? (
+            <ButtonIcon colorSchema={colorSchema} variant={variant} name="arrow-forward" />
+          ) : null}
         </ButtonBase>
       </ButtonTouchable>
     </ButtonWrapper>
@@ -186,7 +212,7 @@ Button.propTypes = {
   /**
    * The button layout variant to use.
    */
-  variant: PropTypes.oneOf(['outlined', 'contained']),
+  variant: PropTypes.oneOf(['outlined', 'contained', 'link']),
   /**
    * If true, the button will take up the full width of its container.
    */

--- a/source/components/atoms/Button/Button.stories.js
+++ b/source/components/atoms/Button/Button.stories.js
@@ -25,6 +25,11 @@ storiesOf('Button', module)
       <ButtonColors variant="outlined" />
     </StoryWrapper>
   ))
+  .add('Link Buttons', props => (
+    <StoryWrapper {...props}>
+      <ButtonColors variant="link" />
+    </StoryWrapper>
+  ))
   .add('Sizes', props => (
     <StoryWrapper {...props}>
       <ButtonSizes />


### PR DESCRIPTION
## Explain the changes you’ve made
I've added support for a new Button variant with the name of link.

## Explain why these changes are made

Theses changes have been added in order to fulllfill the design for the ui. 

## Explain your solution

This includes adding new styles to the Button component and rendering of a arrow icon when the value of the variant prop is "link".

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command`yarn ios`
4. ...etc

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [ ] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.

## Screenshots (optional)
<img width="361" alt="Screen Shot 2020-11-18 at 11 16 06" src="https://user-images.githubusercontent.com/11438902/99517472-b5144a00-298f-11eb-9150-cdb3cc7b1d8d.png">

![image](https://user-images.githubusercontent.com/11438902/99517630-e260f800-298f-11eb-84d5-66a0ed78741e.png)


## Anyhting else? (optional)
The Button component needs a overlook since it's starting to become unnecessary complex due to many design variations.
Shadows in the Button component is also acting weird since you can't via props make them disappear. A rewrite of this old component might be necessary.
