### PR TITLE
fix: support for dynamic icon rendering on button variant link

### DIFF
--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components/native';
 import SHADOW from '../../../styles/shadow';
 import Text from '../Text';
 import Icon from '../Icon';
+import { startForm } from '../../../containers/Form/hooks/formActions';
 
 /** Button styles */
 const Styles = { elevation: SHADOW };
@@ -27,7 +28,7 @@ Styles.outlined = css`
 
 Styles.link = css`
   padding: 6px 10px;
-  justify-content: flex-end;
+  justify-content: space-between;
   background-color: ${props => props.theme.colors.complementary[props.colorSchema][1]};
 `;
 

--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -104,7 +104,6 @@ const ButtonIcon = styled(Icon)`
     width: 18px;
     font-size: 20px;
     line-height: 20px;
-    margin-left: 10px;
     color: ${props.theme.colors.primary[props.colorSchema][1]};
   `}
 `;
@@ -199,9 +198,6 @@ const Button = props => {
           variant={variant}
         >
           {children || (value ? <ButtonText>{value}</ButtonText> : null)}
-          {variant === 'link' ? (
-            <ButtonIcon colorSchema={colorSchema} variant={variant} name="arrow-forward" />
-          ) : null}
         </ButtonBase>
       </ButtonTouchable>
     </ButtonWrapper>

--- a/source/components/atoms/Button/Button.stories.js
+++ b/source/components/atoms/Button/Button.stories.js
@@ -34,7 +34,7 @@ storiesOf('Button', module)
           </Button>
         </Flex>
         <Flex>
-          <Button colorSchema="green" variant="link">
+          <Button colorSchema="green" block variant="link">
             <Text>Icon right</Text>
             <Icon name="arrow-forward" />
           </Button>

--- a/source/components/atoms/Button/Button.stories.js
+++ b/source/components/atoms/Button/Button.stories.js
@@ -27,7 +27,30 @@ storiesOf('Button', module)
   ))
   .add('Link Buttons', props => (
     <StoryWrapper {...props}>
-      <ButtonColors variant="link" />
+      <FlexContainer>
+        <Flex>
+          <Button colorSchema="purple" variant="link">
+            <Icon name="arrow-forward" />
+          </Button>
+        </Flex>
+        <Flex>
+          <Button colorSchema="green" variant="link">
+            <Text>Icon right</Text>
+            <Icon name="arrow-forward" />
+          </Button>
+        </Flex>
+        <Flex>
+          <Button colorSchema="blue" variant="link">
+            <Icon name="arrow-back" />
+            <Text>Icon left</Text>
+          </Button>
+        </Flex>
+        <Flex>
+          <Button variant="link" colorSchema="red" rounded>
+            <Text>No icon</Text>
+          </Button>
+        </Flex>
+      </FlexContainer>
     </StoryWrapper>
   ))
   .add('Sizes', props => (


### PR DESCRIPTION
## Explain the changes you’ve made

Fix for passing Icon as child to the button komponent with altered styles if prop variant is link.

## Explain why these changes are made

These changes was a request to have more control of icons from outside of the button component.

## Explain your solution

When an icon is passed as a child to the Button component and the value of the variant prop is "link" we change the rendering of the icon styles in the button component to match the expected design from Figma.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command`yarn ios`
4. Navigate to the Button -> Link Buttons

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [ ] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.
