### PR TITLE
Feat/card progressbar

### DIFF
--- a/source/components/atoms/Progressbar/Progressbar.stories.js
+++ b/source/components/atoms/Progressbar/Progressbar.stories.js
@@ -1,16 +1,33 @@
 import { storiesOf } from '@storybook/react-native';
 import React, { useState } from 'react';
 import { View } from 'react-native';
+import styled from 'styled-components/native';
 import StoryWrapper from '../../molecules/StoryWrapper';
 import Progressbar from './Progressbar';
 import Button from '../Button/Button';
 import Text from '../Text/Text';
 
-storiesOf('Progressbar', module).add('Default', props => (
-  <StoryWrapper {...props}>
-    <ProgressBar />
-  </StoryWrapper>
-));
+storiesOf('Progressbar', module)
+  .add('Default', props => (
+    <StoryWrapper {...props}>
+      <ProgressBar />
+    </StoryWrapper>
+  ))
+  .add('Rounded', props => (
+    <StoryWrapper {...props}>
+      <Progressbar rounded currentStep={3} totalStepNumber={6} />
+    </StoryWrapper>
+  ))
+  .add('Color schemas', props => (
+    <StoryWrapper {...props}>
+      <ColorSchemas />
+    </StoryWrapper>
+  ));
+
+const Title = styled(Text)`
+  padding-top: 8px;
+  padding-bottom: 8px;
+`;
 
 const ProgressBar = () => {
   const [currentStep, setCurrentStep] = useState(1);
@@ -32,3 +49,18 @@ const ProgressBar = () => {
     </View>
   );
 };
+
+const ColorSchemas = () => (
+  <>
+    <Title type="h5">Neutral</Title>
+    <Progressbar colorSchema="neutral" currentStep={1} totalStepNumber={2} />
+    <Title type="h5">Red</Title>
+    <Progressbar colorSchema="red" currentStep={1} totalStepNumber={2} />
+    <Title type="h5">Green</Title>
+    <Progressbar colorSchema="green" currentStep={1} totalStepNumber={2} />
+    <Title type="h5">Blue</Title>
+    <Progressbar colorSchema="blue" currentStep={1} totalStepNumber={2} />
+    <Title type="h5">Purple</Title>
+    <Progressbar colorSchema="purple" currentStep={1} totalStepNumber={2} />
+  </>
+);

--- a/source/components/atoms/Progressbar/Progressbar.tsx
+++ b/source/components/atoms/Progressbar/Progressbar.tsx
@@ -3,15 +3,24 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import styled from 'styled-components';
 
-const ProgressbarBox = styled(View)<{ percentage: number }>`
-  height: 3px;
-  background-color: ${props => props.theme.colors.neutrals[2]};
+const ProgressbarBox = styled(View) <{ percentage: number, rounded: boolean, colorSchema: string }>`
+  ${({ rounded }) => rounded && `border-radius: 50px;`}
+  height: 100%;
+  background-color: ${props =>
+    props.colorSchema === 'neutral'
+      ? props.theme.colors.neutrals[2]
+      : props.theme.colors.primary[props.colorSchema][3]};
   opacity: 2;
   width: ${props => props.percentage}%;
 `;
-const ProgressbarBackground = styled(View)`
+
+const ProgressbarBackground = styled(View) <{ rounded: boolean, colorSchema: string }>`
+  ${({ rounded }) => rounded && `border-radius: 50px;`}
+  background-color: ${props =>
+    props.colorSchema === 'neutral'
+      ? `${props.theme.colors.neutrals[0]}1F`
+      : props.theme.colors.complementary[props.colorSchema][3]};
   height: 3px;
-  background-color: ${props => props.theme.colors.neutrals[0]}1F;
   width: 100%;
 `;
 
@@ -21,11 +30,11 @@ interface Props {
 }
 
 /** Simple progressbar, fills out a grey box to show the completed percentage */
-const Progressbar: React.FC<Props> = ({ currentStep, totalStepNumber }) => {
+const Progressbar: React.FC<Props> = ({ currentStep, colorSchema, totalStepNumber, ...props }) => {
   const percentage = (100 * currentStep) / totalStepNumber;
   return (
-    <ProgressbarBackground>
-      <ProgressbarBox percentage={percentage} />
+    <ProgressbarBackground colorSchema={colorSchema} {...props}>
+      <ProgressbarBox colorSchema={colorSchema} percentage={percentage} {...props} />
     </ProgressbarBackground>
   );
 };
@@ -35,6 +44,12 @@ Progressbar.propTypes = {
   currentStep: PropTypes.number.isRequired,
   /** Total number of steps in the main flow */
   totalStepNumber: PropTypes.number.isRequired,
+  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
 };
+
+Progressbar.defaultProps = {
+  colorSchema: 'neutral',
+};
+
 
 export default Progressbar;

--- a/source/components/atoms/index.js
+++ b/source/components/atoms/index.js
@@ -8,3 +8,4 @@ export { default as Text } from './Text';
 export { default as Checkbox } from './Checkbox';
 export { default as Label } from './Label';
 export { default as Select } from './Select';
+export { default as Progressbar } from './Progressbar';

--- a/source/components/molecules/Card/Card.js
+++ b/source/components/molecules/Card/Card.js
@@ -85,6 +85,10 @@ const CardImage = styled.Image`
   ${({ circle }) => circle && `border-radius: 50px;`}
 `;
 
+const CardProgressbar = styled(Progressbar)`
+  height: 7px;
+`;
+
 const BodyImageContainer = styled.View`
   padding-right: 24px;
 `;
@@ -210,9 +214,9 @@ Card.Image = ({ children, firstChild, lastChild, ...props }) => (
  * Renders a progress bar
  * @param {props} props
  */
-Card.Progressbar = ({ children, firstChild, lastChild, ...props }) => (
+Card.Progressbar = ({ children, firstChild, lastChild, colorSchema, ...props }) => (
   <Outset lastChild={lastChild} firstChild={firstChild}>
-    <Progressbar {...props} />
+    <CardProgressbar rounded colorSchema={colorSchema} {...props} />
   </Outset>
 );
 

--- a/source/components/molecules/Card/Card.js
+++ b/source/components/molecules/Card/Card.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Button, Text, Heading } from 'app/components/atoms';
+import { Button, Text, Heading, Progressbar } from 'app/components/atoms';
 
 const Container = styled.View`
   display: flex;
@@ -203,6 +203,16 @@ Card.Button = ({ children, colorSchema, firstChild, lastChild, ...props }) => {
 Card.Image = ({ children, firstChild, lastChild, ...props }) => (
   <Outset lastChild={lastChild} firstChild={firstChild}>
     <CardImage {...props} />
+  </Outset>
+);
+
+/**
+ * Renders a progress bar
+ * @param {props} props
+ */
+Card.Progressbar = ({ children, firstChild, lastChild, ...props }) => (
+  <Outset lastChild={lastChild} firstChild={firstChild}>
+    <Progressbar {...props} />
   </Outset>
 );
 

--- a/source/components/molecules/Card/Card.stories.js
+++ b/source/components/molecules/Card/Card.stories.js
@@ -120,6 +120,14 @@ const ChildComponents = () => (
         </Card.Button>
       </Card.Body>
     </Card>
+
+    <Title>Progressbar</Title>
+    <Prop>Prop: currentStep, totalStepNumber</Prop>
+    <Card>
+      <Card.Body shadow>
+        <Card.Progressbar currentStep={0} totalStepNumber={2} />
+      </Card.Body>
+    </Card>
   </FlexContainer>
 );
 

--- a/source/components/molecules/Card/Card.stories.js
+++ b/source/components/molecules/Card/Card.stories.js
@@ -18,6 +18,7 @@ const Title = styled(Text)`
   margin-top: 20px;
   margin-bottom: 6px;
 `;
+
 const Prop = styled(Text)`
   font-size: 14px;
   margin-bottom: 6px;
@@ -122,10 +123,9 @@ const ChildComponents = () => (
     </Card>
 
     <Title>Progressbar</Title>
-    <Prop>Prop: currentStep, totalStepNumber</Prop>
-    <Card>
-      <Card.Body shadow>
-        <Card.Progressbar currentStep={0} totalStepNumber={2} />
+    <Card colorSchema="neutral">
+      <Card.Body shadow color="neutral">
+        <Card.Progressbar currentStep={2} totalStepNumber={5} />
       </Card.Body>
     </Card>
   </FlexContainer>
@@ -207,7 +207,8 @@ const CardExamples = () => (
       <Card.Body shadow color="neutral">
         <Card.Image source={ILLU_INCOME} />
         <Card.Title>Ekonomiskt bistånd</Card.Title>
-        <Card.SubTitle>Ofullständig</Card.SubTitle>
+        <Card.SubTitle>Steg 3 / 7</Card.SubTitle>
+        <Card.Progressbar currentStep={3} totalStepNumber={7} />
         <Card.Button>
           <Text>Ange hyra</Text>
           <Icon name="arrow-forward" />


### PR DESCRIPTION
## Explain the changes you’ve made

Added **colorSchema**  and **rounded** prop to Progressbar component to make it more flexible.
Then I implemenetd the Progressbar as a child into the Card component with some minor additional styling.

## Explain why these changes are made

To make the Card component more complete. 

## Explain your solution

Extended the current Progressbar component with new prop features.

## How to test the changes?

Check these parts in Storybook:
Progressbar => Rounded
Progressbar => Color schemas
Card => Child components (scroll down to Progressbar)
Card => Example combinations (too see a real working example)

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

Card progressbar child component (default styling)
<img width="335" alt="Screenshot 2020-11-20 at 11 59 05" src="https://user-images.githubusercontent.com/21363149/99793131-76fe5e00-2b28-11eb-9df9-94b233480759.png">

Real Card example with red color schema
<img width="345" alt="Screenshot 2020-11-20 at 11 58 45" src="https://user-images.githubusercontent.com/21363149/99793138-7a91e500-2b28-11eb-8284-b5731cf0a72c.png">

Progressbar with **rounded** prop
<img width="429" alt="Screenshot 2020-11-20 at 11 59 18" src="https://user-images.githubusercontent.com/21363149/99793148-7d8cd580-2b28-11eb-9610-612aaed374c8.png">

Progressbar with different **colorSchema** prop
<img width="425" alt="Screenshot 2020-11-20 at 11 59 31" src="https://user-images.githubusercontent.com/21363149/99793156-8087c600-2b28-11eb-9247-662ce23a1445.png">
