### PR TITLE
Add checkbox as an option to summary list

### DIFF
--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -131,7 +131,6 @@ function EditableList({
     }
   };
 
-  console.log('inputs', inputs);
   return (
     <Fieldset
       colorSchema={colorSchema}

--- a/source/components/organisms/SummaryList/SummaryList.stories.js
+++ b/source/components/organisms/SummaryList/SummaryList.stories.js
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react-native';
 import StoryWrapper from '../../molecules/StoryWrapper';
 import SummaryList from './SummaryList';
 import { Input, Label, Text } from '../../atoms';
+import CheckboxField from '../../molecules/CheckboxField/CheckboxField';
 import Form from '../../../containers/Form/Form';
 
 const stories = storiesOf('Summary List', module);
@@ -13,6 +14,7 @@ const items = [
   { id: 'f2', type: 'text', title: 'grönsak', category: 'vegetable' },
   { id: 'pris1', type: 'number', title: 'pris1', category: 'fruit' },
   { id: 'pris2', type: 'number', title: 'pris2', category: 'vegetable' },
+  { id: 'box1', type: 'checkbox', title: 'Checkbox', category: 'vegetable' },
 ];
 
 const categories = [
@@ -72,6 +74,19 @@ const SummaryStory = () => {
             return { ...oldState };
           });
         }}
+      />
+      <CheckboxField
+        text="Do you feel it?"
+        color="blue"
+        size="small"
+        value={state.box1}
+        onChange={() => {
+          setState(oldState => {
+            oldState.box1 = !oldState.box1;
+            return { ...oldState };
+          });
+        }}
+        help={{ text: 'some other helper text' }}
       />
       <SummaryList
         heading="Sammanfattning"

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -36,7 +36,7 @@ const SumContainer = styled.View<{ colorSchema: string }>`
 export interface SummaryListItem {
   title: string;
   id: string;
-  type: 'number' | 'text' | 'date' | 'arrayNumber' | 'arrayText' | 'arrayDate';
+  type: 'number' | 'text' | 'date' | 'checkbox' | 'arrayNumber' | 'arrayText' | 'arrayDate';
   category?: string;
   inputId?: string;
 }
@@ -50,7 +50,7 @@ interface Props {
   heading: string;
   items: SummaryListItem[];
   categories?: SummaryListCategory[];
-  onChange: (answers: Record<string, any> | string | number, fieldId: string) => void;
+  onChange: (answers: Record<string, any> | string | number | boolean, fieldId: string) => void;
   color: string;
   answers: Record<string, any>;
   validationErrors?: Record<
@@ -82,17 +82,17 @@ const SummaryList: React.FC<Props> = ({
    * @param item The list item
    * @param index The index, when summarizing a repeater field with multiple answers
    */
-  const changeFromInput = (item: SummaryListItem, index?: number) => (text: string) => {
+  const changeFromInput = (item: SummaryListItem, index?: number) => (value: string | number | boolean) => {
     if (
       ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
       typeof index !== 'undefined' &&
       item.inputId
     ) {
-      const oldAnswer: Record<string, string | number>[] = answers[item.id];
-      oldAnswer[index][item.inputId] = text;
+      const oldAnswer: Record<string, string | number | boolean>[] = answers[item.id];
+      oldAnswer[index][item.inputId] = value;
       onChange(oldAnswer, item.id);
     } else {
-      onChange(text, item.id);
+      onChange(value, item.id);
     }
   };
   /**

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -4,7 +4,7 @@ import { View, TextInput } from "react-native";
 import { TouchableHighlight } from "react-native-gesture-handler";
 import styled from "styled-components/native";
 import PropTypes from "prop-types";
-import { Text, Icon } from "../../atoms";
+import { Text, Icon, Checkbox } from "../../atoms";
 import { SummaryListItem as SummaryListItemType } from "./SummaryList";
 import DateTimePickerForm from "../../molecules/DateTimePicker/DateTimePickerForm";
 import { colorPalette } from '../../../styles/palette';
@@ -96,10 +96,10 @@ const dateStyle: CSSProp = {
 
 interface Props {
   item: SummaryListItemType;
-  value: Record<string, any> | string | number;
+  value: Record<string, any> | string | number | boolean;
   index?: number;
   editable?: boolean;
-  changeFromInput: (text: string | number) => void;
+  changeFromInput: (value: string | number | boolean) => void;
   removeItem: () => void;
   color: string;
   validationError?: { isValid: boolean; message: string };
@@ -149,6 +149,11 @@ const SummaryListItem: React.FC<Props> = ({
             editable={editable}
           />
         );
+      case 'checkbox':
+        const checked = value as boolean;
+        return (
+          <Checkbox checked={checked} color={color} disabled={!editable} onChange={() => changeFromInput(!checked)} />
+        )
       default:
         return (
           <SmallInput


### PR DESCRIPTION
## Explain the changes you’ve made

Add the option to display checkboxes in the summary list. 

## Explain your solution

I added 'checkbox' as a possible input type in the Summary list, and at the same time expanded the allowed types of values to include boolean. Then added the Checkbox case in the SummaryListItem, and added a checkbox to the story so that I could test it. 

Next is to add this to the formbuilder so that it can be used. 

## How to test the changes?

Checkout the branch, load the storybook, and check the SummaryList default story, where there's a checkbox that can be toggled. Note that toggling it in the summaryList works differently compared to removing it, which I think is how it should work. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
