### PR TITLE
Update so that we save the entire current position

### DIFF
--- a/__tests__/Form.test.js
+++ b/__tests__/Form.test.js
@@ -47,13 +47,18 @@ it('Starts the form and moves to the next step', async () => {
       firstName: 'Gandalf Ståhl',
     },
     formAnswers: {},
-    currentStep: 1,
+    currentStep: {
+      index: 0,
+      level: 0,
+      currentMainStep: 1,
+      currentMainStepIndex: 0,
+    },
   };
 
   const { getByText, findByText } = render(
     <Form
       steps={mockForm.steps}
-      startAt={mockForm.currentStep}
+      initialPosition={mockForm.currentStep}
       firstName={mockForm.user.firstName}
       onClose={mockFn}
       onStart={mockFn}

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -79,8 +79,7 @@ function Step({
   const closeForm = () => {
     if (status === 'ongoing') {
       if (onFieldChange) onFieldChange(answers);
-      if (updateCaseInContext)
-        updateCaseInContext(answers, 'ongoing', currentPosition.currentMainStep);
+      if (updateCaseInContext) updateCaseInContext(answers, 'ongoing', currentPosition);
     }
     if (formNavigation?.close) formNavigation.close(() => {});
   };

--- a/source/components/organisms/Step/StepFooter/StepFooter.js
+++ b/source/components/organisms/Step/StepFooter/StepFooter.js
@@ -35,8 +35,7 @@ const StepFooter = ({
   useEffect(() => {
     const signCase = () => {
       if (onUpdate) onUpdate(answers);
-      if (updateCaseInContext)
-        updateCaseInContext(answers, 'submitted', currentPosition.currentMainStep);
+      if (updateCaseInContext) updateCaseInContext(answers, 'submitted', currentPosition);
       if (formNavigation.next) formNavigation.next();
     };
 
@@ -69,7 +68,7 @@ const StepFooter = ({
         return () => {
           if (onUpdate && caseStatus === 'ongoing') onUpdate(answers);
           if (updateCaseInContext && caseStatus === 'ongoing')
-            updateCaseInContext(answers, 'ongoing', currentPosition.currentMainStep);
+            updateCaseInContext(answers, 'ongoing', currentPosition);
           if (formNavigation.next) formNavigation.next();
         };
       }

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -5,9 +5,8 @@ import Step from '../../components/organisms/Step/Step';
 import { Step as StepType, StepperActions } from '../../types/FormTypes';
 import { CaseStatus } from '../../types/CaseType';
 import { User } from '../../types/UserTypes';
-import useForm, { FormReducerState } from './hooks/useForm';
+import useForm, { FormReducerState, FormPosition } from './hooks/useForm';
 import Modal from '../../components/molecules/Modal';
-
 
 const FormContainer = styled.View`
   flex: 1;
@@ -15,7 +14,7 @@ const FormContainer = styled.View`
 `;
 
 interface Props {
-  startAt: number;
+  initialPosition?: FormPosition;
   steps: StepType[];
   connectivityMatrix: StepperActions[][];
   user: User;
@@ -24,7 +23,11 @@ interface Props {
   onClose: () => void;
   onSubmit: () => void;
   onStart: () => any;
-  updateCaseInContext: (data: Record<string, any>, status: CaseStatus, currentStep: number) => void;
+  updateCaseInContext: (
+    data: Record<string, any>,
+    status: CaseStatus,
+    currentPosition: FormPosition
+  ) => void;
 }
 
 /**
@@ -33,7 +36,7 @@ interface Props {
  * data and modify the data in your application.
  */
 const Form: React.FC<Props> = ({
-  startAt,
+  initialPosition,
   steps,
   connectivityMatrix,
   user,
@@ -44,15 +47,15 @@ const Form: React.FC<Props> = ({
   status,
   updateCaseInContext,
 }) => {
-  const currentPosition = {
-    index: startAt,
+  const defaultInitialPosition: FormPosition = {
+    index: 0,
     level: 0,
     currentMainStep: 1,
-    currentMainStepIndex: startAt,
+    currentMainStepIndex: 0,
   };
   const initialState: FormReducerState = {
     submitted: false,
-    currentPosition,
+    currentPosition: initialPosition || defaultInitialPosition,
     steps,
     user,
     formAnswers: initialAnswers,
@@ -112,9 +115,14 @@ const Form: React.FC<Props> = ({
 
 Form.propTypes = {
   /**
-   * Number that decides which step to start on in the form.
+   * FormPosition object that determines where to start the form.
    */
-  startAt: PropTypes.number,
+  initialPosition: PropTypes.shape({
+    index: PropTypes.number,
+    level: PropTypes.number,
+    currentMainStep: PropTypes.number,
+    currentMainStepIndex: PropTypes.number,
+  }),
   /**
    * Function to handle a close action in the form.
    */
@@ -151,7 +159,6 @@ Form.propTypes = {
 };
 
 Form.defaultProps = {
-  startAt: 1,
   initialAnswers: {},
 };
 

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -3,14 +3,15 @@ import formReducer from './formReducer';
 import { Question, Step, StepperActions } from '../../../types/FormTypes';
 import { User } from '../../../types/UserTypes';
 
+export interface FormPosition {
+  index: number;
+  level: number;
+  currentMainStep: number;
+  currentMainStepIndex: number;
+}
 export interface FormReducerState {
   submitted: boolean;
-  currentPosition: {
-    index: number;
-    level: number;
-    currentMainStep: number;
-    currentMainStepIndex: number;
-  };
+  currentPosition: FormPosition;
   steps: Step[];
   allQuestions: Question[];
   user: User;

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -58,10 +58,10 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
     navigation.navigate('UserEvents', { screen: 'CaseOverview' });
   }
 
-  const updateCaseContext = (data, status, currentStep) => {
+  const updateCaseContext = (data, status, currentPosition) => {
     // If the case is submitted, we should not actually update its data...
     if (initialCase.status === 'ongoing') {
-      updateCase(initialCase.id, data, status, currentStep, formQuestions);
+      updateCase(initialCase.id, data, status, currentPosition, formQuestions);
     }
   };
   /*
@@ -84,7 +84,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
         <Form
           steps={form.steps}
           connectivityMatrix={form.connectivityMatrix}
-          startAt={caseData?.currentStep || initialCase?.currentStep || 0}
+          initialPosition={caseData?.currentStep || initialCase?.currentStep}
           user={user}
           onClose={handleCloseForm}
           onStart={handleStartForm}

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -37,7 +37,7 @@ const colorSchema = 'red';
  */
 const computeCaseComponent = (status, latestCase, form, caseType, navigation, createCase) => {
   const updatedAt = latestCase?.updatedAt ? formatUpdatedAt(latestCase.updatedAt) : '';
-  const currentStep = latestCase?.currentStep || '';
+  const currentStep = latestCase?.currentStep?.currentMainStep || '';
   const totalSteps = form?.stepStructure ? form.stepStructure.length : 0;
 
   switch (status) {

--- a/source/store/CaseContext.js
+++ b/source/store/CaseContext.js
@@ -44,8 +44,8 @@ function CaseProvider({ children, initialState = defaultInitialState }) {
     dispatch(await create(form, user, Object.values(state.cases), callback));
   }
 
-  async function updateCase(caseId, data, status, currentStep, form) {
-    dispatch(await update(caseId, data, status, currentStep, form));
+  async function updateCase(caseId, data, status, currentPosition, form) {
+    dispatch(await update(caseId, data, status, currentPosition, form));
   }
 
   function getCase(caseId) {

--- a/source/store/actions/CaseActions.js
+++ b/source/store/actions/CaseActions.js
@@ -10,13 +10,13 @@ export const actionTypes = {
   apiError: 'API_ERROR',
 };
 
-export async function updateCase(caseId, data, status, currentStep, formQuestions, callback) {
+export async function updateCase(caseId, data, status, currentPosition, formQuestions, callback) {
   const answers = convertAnswersToArray(data, formQuestions);
 
   const body = {
     status,
     answers,
-    currentStep,
+    currentStep: currentPosition,
   };
 
   try {
@@ -47,7 +47,12 @@ export async function createCase(form, user, cases, callback) {
     formId: form.id,
     provider: 'VIVA',
     status: 'ongoing',
-    currentStep: 0,
+    currentStep: {
+      index: 0,
+      level: 0,
+      currentMainStep: 1,
+      currentMainStepIndex: 0,
+    },
     details: {
       period: {
         startDate: 1601994748326,

--- a/source/types/CaseType.ts
+++ b/source/types/CaseType.ts
@@ -1,9 +1,11 @@
+import { FormPosition } from '../containers/Form/hooks/useForm';
+
 export type CaseStatus = 'ongoing' | 'submitted';
 
 interface CaseWithoutAnswers {
   createdAt: number;
   updatedAt: number;
-  currentStep: number;
+  currentStep: FormPosition;
   formId: string;
   id: string;
   type: string;


### PR DESCRIPTION
## Explain the changes you’ve made

Changed what we save in the case data to reflect the new step logic. This fixes so that we save the entire position object, which contains the current index, level, currentMainStep and currentMainStepIndex, to the case data, and then use this when resuming.

## Explain why these changes are made

So that we can properly resume a started form, and end up at the correct place in the form, even if we for some reason quit while in a subform or something. Also needed for correctly showing progressbars outside the form. 

## Explain your solution

Instead of saving just a number, I save the entire position object. 
This requires a few changes (mostly just changing the names) in multiple places, but there's nothing complicated happening anywhere. 

Currently I have not changed anything on the backend, so the position object is still saved as 'currentStep'. This will be fixed in a minimal change to the API, which will require like two namechanges in the app as well, but for now we can test it like this to see that the logic works.

## How to test the changes?
Go into the Löpande form, navigate to some page, and then quit. Resume by using the case view, and check that you end up in the correct place. Try that a few times, especially going to pages at the 'back' of the form, because earlier it broke as soon as you went past the first substep. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
