### PR TITLE
Add option for editableList to start editable or not

### DIFF
--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -78,9 +78,10 @@ function EditableList({
   value,
   onInputChange,
   inputIsEditable,
+  startEditable,
   error,
 }) {
-  const [editable, setEditable] = useState(false);
+  const [editable, setEditable] = useState(startEditable);
   const [state, setState] = useState(getInitialState(inputs, value));
 
   const changeEditable = () => {
@@ -204,10 +205,10 @@ EditableList.propTypes = {
    * Decides of the inputs are editable or not
    */
   inputIsEditable: PropTypes.bool,
-
+  /** Whether the inputs starts editable or not */
+  startEditable: PropTypes.bool,
   /** Validation error object */
   error: PropTypes.object,
-
   /**
    * The color schema/theme of the component
    */
@@ -216,6 +217,7 @@ EditableList.propTypes = {
 
 EditableList.defaultProps = {
   inputIsEditable: true,
+  startEditable: false,
   inputs: [],
   colorSchema: 'blue',
 };

--- a/source/components/molecules/EditableList/EditableList.stories.js
+++ b/source/components/molecules/EditableList/EditableList.stories.js
@@ -57,7 +57,10 @@ storiesOf('EditableList', module).add('Default', () => (
 
 storiesOf('EditableList', module).add('Input is editable', () => (
   <StoryWrapper>
-    <EditableList onInputChange={() => {}} inputs={inputs} title="Editable List" />
+    <ScrollView>
+      <EditableList onInputChange={() => {}} inputs={inputs} title="Editable List" />
+      <EditableList onInputChange={() => {}} inputs={inputs} title="Start editable" startEditable />
+    </ScrollView>
   </StoryWrapper>
 ));
 


### PR DESCRIPTION
## Explain the changes you’ve made

As requested by design, we want the option to decide whether the editableList starts in edit mode or not, so I added that. 

## Explain your solution

Just add a simple prop that regulates this, works the same way as for SummaryList. 
It will be added as an option to the Formbuilder. 

## How to test the changes?

Load the 'Input is editable' story for Editable List and check that the first list starts locked while the second is editable. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.