### PR TITLE
Feat/validation on blur

### DIFF
--- a/source/components/atoms/Input/Input.js
+++ b/source/components/atoms/Input/Input.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components/native';
+import styled, { useTheme } from 'styled-components/native';
 import Text from '../Text';
 
-const StyledInput = styled.TextInput`
+const StyledTextInput = styled.TextInput`
   width: 100%;
   font-weight: ${({ theme }) => theme.fontWeights[1]}
   background-color: ${({ theme, colorSchema }) => theme.colors.complementary[colorSchema][2]};
@@ -31,11 +31,19 @@ const StyledErrorText = styled(Text)`
 `;
 
 const Input = props => {
-  const { error } = props;
+  const { value, onBlur, error } = props;
 
+  const handleBlur = () => {
+    if (onBlur) onBlur(value);
+  };
+  const theme = useTheme();
   return (
     <>
-      <StyledInput {...props} />
+      <StyledTextInput
+        {...props}
+        onBlur={handleBlur}
+        placeholderTextColor={theme.colors.neutrals[1]}
+      />
       {error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
     </>
   );

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -97,7 +97,7 @@ function EditableList({
     setState(updatedState);
   };
   const onInputBlur = () => {
-    onBlur(state);
+    if (onBlur) onBlur(state);
   };
   /** Switch between different input types */
   const getInputComponent = input => {

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -77,6 +77,7 @@ function EditableList({
   inputs,
   value,
   onInputChange,
+  onBlur,
   inputIsEditable,
   startEditable,
   error,
@@ -95,6 +96,9 @@ function EditableList({
     onInputChange(updatedState);
     setState(updatedState);
   };
+  const onInputBlur = () => {
+    onBlur(state);
+  };
   /** Switch between different input types */
   const getInputComponent = input => {
     switch (input.type) {
@@ -106,6 +110,7 @@ function EditableList({
             colorSchema={colorSchema}
             editable={editable}
             onChangeText={text => onChange(input.key, text)}
+            onBlur={onInputBlur}
             value={value && value !== '' ? value[input.key] : state[input.key]}
             keyboardType="numeric"
           />
@@ -115,6 +120,7 @@ function EditableList({
           <CalendarPicker
             date={value && value !== '' ? value[input.key] : state[input.key]}
             onSelect={date => onChange(input.key, date)}
+            onBlur={onInputBlur}
             editable={editable}
             transparent
           />
@@ -122,6 +128,7 @@ function EditableList({
       case 'select':
         return (
           <Select
+            onBlur={onInputBlur}
             onValueChange={value => onChange(input.key, value)}
             value={value && value !== '' ? value[input.key] : state[input.key]}
             editable={editable}
@@ -137,6 +144,7 @@ function EditableList({
             colorSchema={colorSchema}
             editable={editable}
             onChangeText={text => onChange(input.key, text)}
+            onBlur={onInputBlur}
             value={value && value !== '' ? value[input.key] : state[input.key]}
           />
         );
@@ -185,7 +193,10 @@ EditableList.propTypes = {
    * Function for handling input events
    */
   onInputChange: PropTypes.func.isRequired,
-
+  /**
+   * Function for handling inputs losing focus
+   */
+  onBlur: PropTypes.func,
   /**
    * The title of the list
    */

--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -93,7 +93,7 @@ const FormField = ({
   color,
   id,
   onChange,
-  handleBlur,
+  onBlur,
   value,
   answers,
   validationErrors,
@@ -108,8 +108,8 @@ const FormField = ({
   const saveInput = (value, fieldId = id) => {
     if (onChange) onChange({ [fieldId]: value }, fieldId);
   };
-  const onBlur = (value, fieldId = id) => {
-    if (handleBlur) handleBlur({ [fieldId]: value }, fieldId);
+  const onInputBlur = (value, fieldId = id) => {
+    if (onBlur) onBlur({ [fieldId]: value }, fieldId);
   };
   if (!input) {
     return <Text>{`Invalid field type: ${inputType}`}</Text>;
@@ -131,7 +131,7 @@ const FormField = ({
   if (input?.props?.answers) inputCompProps.answers = answers;
   if (input?.props?.validation) inputCompProps.validationErrors = validationErrors;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;
-  if (input && input.blurEvent) inputCompProps[input.blurEvent] = onBlur;
+  if (input && input.blurEvent) inputCompProps[input.blurEvent] = onInputBlur;
 
   /** Checks if the field is conditional on another input, and if so,
    * evaluates whether this field should be active or not */
@@ -199,7 +199,7 @@ FormField.propTypes = {
    */
   onChange: PropTypes.func,
   /** What happens when an input field looses focus.  */
-  handleBlur: PropTypes.func,
+  onBlur: PropTypes.func,
   /**
    * sets the value, since the input field component should be managed.
    */

--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -15,9 +15,11 @@ const inputTypes = {
   text: {
     component: Input,
     changeEvent: 'onChangeText',
+    blurEvent: 'onBlur',
   },
   number: {
     component: Input,
+    blurEvent: 'onBlur',
     changeEvent: 'onChangeText',
     props: {
       keyboardType: 'numeric',
@@ -42,6 +44,7 @@ const inputTypes = {
   editableList: {
     component: EditableList,
     changeEvent: 'onInputChange',
+    blurEvent: 'onBlur',
     props: {},
     initialValue: {},
   },
@@ -72,10 +75,12 @@ const inputTypes = {
   summaryList: {
     component: SummaryList,
     changeEvent: 'onChange',
+    blurEvent: 'onBlur',
     props: { answers: true, validation: true },
   },
   repeaterField: {
     component: RepeaterField,
+    blurEvent: 'onBlur',
     changeEvent: 'onChange',
     props: {},
   },
@@ -88,6 +93,7 @@ const FormField = ({
   color,
   id,
   onChange,
+  handleBlur,
   value,
   answers,
   validationErrors,
@@ -101,6 +107,9 @@ const FormField = ({
   }
   const saveInput = (value, fieldId = id) => {
     if (onChange) onChange({ [fieldId]: value }, fieldId);
+  };
+  const onBlur = (value, fieldId = id) => {
+    if (handleBlur) handleBlur({ [fieldId]: value }, fieldId);
   };
   if (!input) {
     return <Text>{`Invalid field type: ${inputType}`}</Text>;
@@ -122,6 +131,7 @@ const FormField = ({
   if (input?.props?.answers) inputCompProps.answers = answers;
   if (input?.props?.validation) inputCompProps.validationErrors = validationErrors;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;
+  if (input && input.blurEvent) inputCompProps[input.blurEvent] = onBlur;
 
   /** Checks if the field is conditional on another input, and if so,
    * evaluates whether this field should be active or not */
@@ -188,6 +198,8 @@ FormField.propTypes = {
    * Should handle objects on the form { id : value }, where value is the new value and id is the uuid for the input-field.
    */
   onChange: PropTypes.func,
+  /** What happens when an input field looses focus.  */
+  handleBlur: PropTypes.func,
   /**
    * sets the value, since the input field component should be managed.
    */

--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -24,6 +24,7 @@ interface Props {
   inputs: InputRow[];
   value: string | Record<string, string | number>[];
   onChange: (answers: Record<string, any> | string | number, fieldId?: string) => void;
+  onBlur?: (answers: Record<string, any> | string | number, fieldId?: string) => void;
   color: string;
   error?: Record<string, {isValid: boolean, validationMessage: string}>[];
 }
@@ -36,13 +37,19 @@ function isRecordArray(value: string | Record<string,string|number>[]): value is
  * Repeater field component, for adding multiple copies of a particular kind of input.
  * The input-prop specifies the form of each input-group.
  */
-const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChange, color, value, error }) => {
+const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChange, onBlur, color, value, error }) => {
   const [localAnswers, setLocalAnswers] = useState( isRecordArray(value) ? value : emptyInput);
   
   const changeFromInput = (index: number) => (input: InputRow) => (text: string) => {
     localAnswers[index][input.id] = text;
     onChange(localAnswers);
     setLocalAnswers([...localAnswers]);
+  };
+
+  const onInputBlur = () => {
+    // localAnswers[index][input.id] = text;
+    if (onBlur) onBlur(localAnswers);
+    // setLocalAnswers([...localAnswers]);
   };
 
   const removeAnswer = (index: number) => () => {
@@ -69,6 +76,7 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
         inputs={inputs}
         value={answer}
         changeFromInput={changeFromInput(index)}
+        onBlur={onInputBlur}
         color={validColorSchema}
         removeItem={removeAnswer(index)}
         error={error && error[index] ? error[index]: undefined}

--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -47,15 +47,14 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
   };
 
   const onInputBlur = () => {
-    // localAnswers[index][input.id] = text;
     if (onBlur) onBlur(localAnswers);
-    // setLocalAnswers([...localAnswers]);
   };
 
   const removeAnswer = (index: number) => () => {
     setLocalAnswers(prev => {
       prev.splice(index, 1);
       onChange(prev);
+      if (onBlur) onBlur(prev);
       return [...prev];
     });
   };

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -84,6 +84,7 @@ interface Props {
   value: Record<string, string | number>;
   error?: Record<string, {isValid: boolean, validationMessage: string}>;
   changeFromInput: (input: InputRow) => (text: string | number) => void;
+  onBlur?: () => void;
   removeItem: () => void;
   color: string;
 }
@@ -94,6 +95,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
   value,
   error,
   changeFromInput,
+  onBlur,
   removeItem,
   color,
 }) => {
@@ -108,6 +110,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
             colorSchema={validColorSchema}
             value={value[input.id] || ''}
             onChangeText={changeFromInput(input)}
+            onBlur={onBlur}
           />
         );
       case 'number':
@@ -118,6 +121,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
             keyboardType="numeric"
             value={value[input.id] || ''}
             onChangeText={changeFromInput(input)}
+            onBlur={onBlur}
           />
         );
       case 'date':
@@ -129,6 +133,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
             onSelect={changeFromInput(input)}
             color={color}
             style={dateStyle}
+            onBlur={onBlur}
           />
         );
       default:
@@ -138,6 +143,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
             textAlign="right"
             value={value[input.id] || ''}
             onChangeText={changeFromInput(input)}
+            onBlur={onBlur}
           />
         );
     }

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -127,7 +127,7 @@ function Step({
                     <FormField
                       key={`${field.id}`}
                       onChange={status === 'ongoing' ? onFieldChange : null}
-                      handleBlur={onFieldBlur}
+                      onBlur={onFieldBlur}
                       inputType={field.type}
                       value={answers[field.id] || ''}
                       answers={answers}

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -51,6 +51,7 @@ function Step({
   formNavigation,
   onSubmit,
   onFieldChange,
+  onFieldBlur,
   isBackBtnVisible,
   updateCaseInContext,
   currentPosition,
@@ -126,6 +127,7 @@ function Step({
                     <FormField
                       key={`${field.id}`}
                       onChange={status === 'ongoing' ? onFieldChange : null}
+                      handleBlur={onFieldBlur}
                       inputType={field.type}
                       value={answers[field.id] || ''}
                       answers={answers}
@@ -202,6 +204,8 @@ Step.propTypes = {
    * The function to handle field input changes
    */
   onFieldChange: PropTypes.func,
+  /** The function to handle fields losing focus */
+  onFieldBlur: PropTypes.func,
   /*
    * A object with form navigation actions
    */

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -51,6 +51,7 @@ interface Props {
   items: SummaryListItem[];
   categories?: SummaryListCategory[];
   onChange: (answers: Record<string, any> | string | number | boolean, fieldId: string) => void;
+  onBlur: (answers: Record<string, any> | string | number | boolean, fieldId: string) => void;
   color: string;
   answers: Record<string, any>;
   validationErrors?: Record<
@@ -70,6 +71,7 @@ const SummaryList: React.FC<Props> = ({
   items,
   categories,
   onChange,
+  onBlur,
   color,
   answers,
   validationErrors,
@@ -95,6 +97,18 @@ const SummaryList: React.FC<Props> = ({
       onChange(value, item.id);
     }
   };
+
+  const onItemBlur = (item: SummaryListItem, index?: number) => (value: string | number | boolean) => {
+    if (
+      ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
+      typeof index !== 'undefined' &&
+      item.inputId
+    ){
+      if(onBlur) onBlur(answers[item.id], item.id);
+    } else {
+      if(onBlur) onBlur(value, item.id);
+    }
+  }
   /**
    * Given an item, and index in the case of repeater fields, this generates the function for clearing the associated data
    * in the form state.
@@ -124,6 +138,7 @@ const SummaryList: React.FC<Props> = ({
         index={index ? index + 1 : undefined}
         value={value}
         changeFromInput={changeFromInput(item, index)}
+        onBlur={onItemBlur(item, index)}
         removeItem={removeListItem(item, index)}
         color={color}
         validationError={validationError}
@@ -143,7 +158,7 @@ const SummaryList: React.FC<Props> = ({
     }
   };
 
-  const listItems = [];
+  const listItems: {category: string; component: JSX.Element}[] = [];
   items
     .filter(item => {
       const answer = answers[item.id];
@@ -158,7 +173,7 @@ const SummaryList: React.FC<Props> = ({
               generateListItem(
                 item,
                 v[item?.inputId],
-                validationErrors[item.id][index]
+                validationErrors?.[item.id]?.[index]
                   ? validationErrors[item.id][index][item?.inputId]
                   : undefined,
                 index
@@ -225,6 +240,10 @@ SummaryList.propTypes = {
    * What should happen to update the values
    */
   onChange: PropTypes.func,
+  /**
+   * What should happen when a field loses focus.
+   */
+  onBlur: PropTypes.func,
   /**
    * Sets the color scheme of the list. default is red.
    */

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -100,6 +100,7 @@ interface Props {
   index?: number;
   editable?: boolean;
   changeFromInput: (value: string | number | boolean) => void;
+  onBlur?: (value: Record<string, any> | string | number | boolean) => void;
   removeItem: () => void;
   color: string;
   validationError?: { isValid: boolean; message: string };
@@ -110,11 +111,15 @@ const SummaryListItem: React.FC<Props> = ({
   value,
   index,
   changeFromInput,
+  onBlur,
   editable,
   removeItem,
   color,
   validationError,
 }) => {
+  const onInputBlur = () => {
+    if(onBlur) onBlur(value);
+  }
   const inputComponent = (input: SummaryListItemType, editable: boolean) => {
     switch (input.type) {
       case 'text':
@@ -123,6 +128,7 @@ const SummaryListItem: React.FC<Props> = ({
           <SmallInput
             value={value as string}
             onChangeText={changeFromInput}
+            onBlur={onInputBlur}
             editable={editable}
           />
         );
@@ -132,6 +138,7 @@ const SummaryListItem: React.FC<Props> = ({
           <SmallInput
             keyboardType="numeric"
             value={value as string}
+            onBlur={onInputBlur}
             onChangeText={changeFromInput}
             editable={editable}
           />
@@ -143,6 +150,7 @@ const SummaryListItem: React.FC<Props> = ({
             value={value as string}
             mode="date"
             selectorProps={{ locale: "sv" }}
+            onBlur={onInputBlur}
             onSelect={changeFromInput}
             color={color}
             style={dateStyle}
@@ -158,6 +166,7 @@ const SummaryListItem: React.FC<Props> = ({
         return (
           <SmallInput
             value={value as string}
+            onBlur={onInputBlur}
             onChangeText={changeFromInput}
             editable={editable}
           />
@@ -200,6 +209,7 @@ SummaryListItem.propTypes = {
    * What should happen to update the values
    */
   changeFromInput: PropTypes.func,
+  onBlur: PropTypes.func,
   /**
    * The function to remove the row and clear the associated input
    */

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -64,7 +64,9 @@ const Form: React.FC<Props> = ({
     allQuestions: [],
   };
 
-  const { formState, formNavigation, handleInputChange, handleSubmit } = useForm(initialState);
+  const { formState, formNavigation, handleInputChange, handleSubmit, handleBlur } = useForm(
+    initialState
+  );
 
   formNavigation.close = () => {
     onClose();
@@ -91,6 +93,7 @@ const Form: React.FC<Props> = ({
         formNavigation={formNavigation}
         onSubmit={() => handleSubmit(onSubmit)}
         onFieldChange={handleInputChange}
+        onFieldBlur={handleBlur}
         updateCaseInContext={updateCaseInContext}
         currentPosition={formState.currentPosition}
         totalStepNumber={formState.numberOfMainSteps}

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -60,6 +60,7 @@ const Form: React.FC<Props> = ({
     user,
     formAnswers: initialAnswers,
     validations: {},
+    dirtyFields: {},
     connectivityMatrix,
     allQuestions: [],
   };

--- a/source/containers/Form/hooks/formReducer.ts
+++ b/source/containers/Form/hooks/formReducer.ts
@@ -12,6 +12,7 @@ import {
   computeNumberMainSteps,
   getAllQuestions,
   validateAnswer,
+  dirtyField,
 } from './formActions';
 
 type Action =
@@ -51,6 +52,10 @@ type Action =
     }
   | {
       type: 'VALIDATE_ANSWER';
+      payload: { answer: Record<string, any>; id: string; checkIfDirty?: boolean };
+    }
+  | {
+      type: 'DIRTY_FIELD';
       payload: { answer: Record<string, any>; id: string };
     }
   | {
@@ -122,7 +127,16 @@ function formReducer(state: FormReducerState, action: Action) {
     }
 
     case 'VALIDATE_ANSWER': {
-      return validateAnswer(state, action.payload.answer, action.payload.id);
+      return validateAnswer(
+        state,
+        action.payload.answer,
+        action.payload.id,
+        action.payload.checkIfDirty
+      );
+    }
+
+    case 'DIRTY_FIELD': {
+      return dirtyField(state, action.payload.answer, action.payload.id);
     }
 
     /**

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -126,8 +126,6 @@ function useForm(initialState: FormReducerState) {
    */
   const handleInputChange = (answer: Record<string, any>, questionId: string) => {
     dispatch({ type: 'UPDATE_ANSWER', payload: answer });
-
-    // dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId } });
   };
 
   const formNavigation = {

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -116,12 +116,18 @@ function useForm(initialState: FormReducerState) {
 
   function closeForm() {}
   /**
+   * Function to trigger when a form field looses focus.
+   */
+  const handleBlur = (answer: Record<string, any>, questionId) => {
+    dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId } });
+  };
+  /**
    * Function for updating answer.
    */
   const handleInputChange = (answer: Record<string, any>, questionId: string) => {
     dispatch({ type: 'UPDATE_ANSWER', payload: answer });
 
-    dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId } });
+    // dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId } });
   };
 
   const formNavigation = {
@@ -139,6 +145,7 @@ function useForm(initialState: FormReducerState) {
     formState,
     formNavigation,
     handleInputChange,
+    handleBlur,
     handleSubmit,
   };
 }

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -18,6 +18,7 @@ export interface FormReducerState {
   connectivityMatrix: StepperActions[][];
   formAnswers: Record<string, any>;
   validations: Record<string, any>;
+  dirtyFields: Record<string, any>;
   numberOfMainSteps?: number;
 }
 
@@ -120,12 +121,14 @@ function useForm(initialState: FormReducerState) {
    */
   const handleBlur = (answer: Record<string, any>, questionId) => {
     dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId } });
+    dispatch({ type: 'DIRTY_FIELD', payload: { answer, id: questionId } });
   };
   /**
    * Function for updating answer.
    */
   const handleInputChange = (answer: Record<string, any>, questionId: string) => {
     dispatch({ type: 'UPDATE_ANSWER', payload: answer });
+    dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId, checkIfDirty: true } });
   };
 
   const formNavigation = {


### PR DESCRIPTION
## Explain the changes you’ve made

Change validation to trigger onBlur, i.e. when the input field loses focus, rather than on every change.

## Explain why these changes are made

After discussion with the designers, this was one of the proposed improvements on current validation behavior that we arrived at. 

## Explain your solution

Create a new form action that should be triggered on blur, which triggers validation.
Then pass that as a prop to FormField, and make sure that each type of input that supports validation handles it correctly. 
It's quite similar to how we handle the onChange event; just that we now don't have to update any state. 

## How to test the changes?

The Test form is great for testing this, or the Form story with validation. Try to check how it works with repeaters and summary lists in particular, that's where it gets a bit tricky. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
