### PR TITLE
Fix/case summary navigation

### DIFF
--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -80,14 +80,7 @@ const computeCaseComponent = (status, latestCase, form, caseType, navigation, cr
                 navigation.navigate('UserEvents', {
                   screen: caseType.navigateTo,
                   params: {
-                    name: caseType.name,
-                    status,
-                    caseData: latestCase,
-                    form,
-                    totalSteps,
-                    currentStep,
-                    updatedAt,
-                    caseType,
+                    id: latestCase.id,
                   },
                 });
               }}
@@ -127,14 +120,7 @@ const computeCaseComponent = (status, latestCase, form, caseType, navigation, cr
                   navigation.navigate('UserEvents', {
                     screen: caseType.navigateTo,
                     params: {
-                      name: caseType.name,
-                      status,
-                      caseData: latestCase,
-                      form,
-                      totalSteps,
-                      currentStep,
-                      updatedAt,
-                      caseType,
+                      id: latestCase.id,
                     },
                   });
                 }}


### PR DESCRIPTION
## Explain the changes you’ve made

Refactored case summary screen so it only receives case ID as route parameter instead of a whole list of props.

## Explain why these changes are made

Makes navigation/routing less painful in the app.

## Explain your solution

Added logic to the case summary screen that fetches the case and form data.

## How to test the changes?

Navigate to case summary screen and everything should work as before. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
