### PR TITLE
improve how the keyboard works with input fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-native-exception-handler": "^2.10.9",
     "react-native-gesture-handler": "^1.6.0",
     "react-native-image-picker": "^2.3.1",
+    "react-native-keyboard-aware-scroll-view": "^0.9.3",
     "react-native-markdown-display": "^5.1.0",
     "react-native-modal": "^11.5.4",
     "react-native-network-info": "^5.2.1",

--- a/source/components/molecules/Modal/Modal.js
+++ b/source/components/molecules/Modal/Modal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RnModal from 'react-native-modal';
 import styled from 'styled-components/native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 const ModalContainer = styled(RnModal)`
   margin-left: 0px;
@@ -22,7 +23,7 @@ const Modal = ({ visible, children, ...other }) => (
     transparent
     {...other}
   >
-    {children}
+    <KeyboardAwareScrollView>{children}</KeyboardAwareScrollView>
   </ModalContainer>
 );
 

--- a/source/components/molecules/ScreenWrapper.js
+++ b/source/components/molecules/ScreenWrapper.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components/native';
-import { Platform } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
-const Container = styled.KeyboardAvoidingView`
+const Container = styled(KeyboardAwareScrollView)`
   flex: 1;
   background-color: ${props => props.theme.colors.neutrals[6]};
 `;
@@ -11,15 +11,7 @@ const Container = styled.KeyboardAvoidingView`
 const ScreenWrapper = props => {
   const { style, children } = props;
 
-  return (
-    <Container
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      keyboardVerticalOffset={0}
-      style={style}
-    >
-      {children}
-    </Container>
-  );
+  return <Container style={style}>{children}</Container>;
 };
 
 ScreenWrapper.propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10334,10 +10334,23 @@ react-native-image-picker@^2.3.1:
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-2.3.3.tgz#eaacd4a1ed9e9887613be31f0765478ca2f18a51"
   integrity sha512-i/7JDnxKkUGSbFY2i7YqFNn3ncJm1YlcrPKXrXmJ/YUElz8tHkuwknuqBd9QCJivMfHX41cmq4XvdBDwIOtO+A==
 
+react-native-iphone-x-helper@^1.0.3:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
+  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
+
 react-native-iphone-x-helper@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
+
+react-native-keyboard-aware-scroll-view@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.3.tgz#65ab4cab1a987b486d97924602756fa88b7fbfcc"
+  integrity sha512-EDyFp8wAJoKvi1T2pzoPRn8R0Inp3G+575jPAWEFTlXq26URMmk8760rzde2XLW+v/1+QwDyBg6d/5mz63/ZRA==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-iphone-x-helper "^1.0.3"
 
 react-native-markdown-display@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
## Explain the changes you’ve made

Switch the keyboard avoidance from using the built-in react native keyboard avoidance view to a third party library, that seems to handle it better and work with more general components. 

## Explain why these changes are made

The keyboard avoidance was not working at all when in a modal (substep) or when using some of the more complicated input components, so that needed fixing. 

## Explain your solution

Simply swap the KeyboardAvoidingView to using the library 'react-native-keyboard-aware-scroll-view', which seems to handle everything better, and seems to work out of the box on both iOS and Android. 
Also add it to the modal component, so that this behavior is enabled inside modals as well.

I spent like an hour trying various other fixes using just react native, but nothing worked really well, so then I eventually found this library and tried it, and it seems to work. 

## How to test the changes?
Checkout this branch, run yarn to install the extra library, and then go through a form, with the keyboard enabled. Try repeaters, editable lists, and summary lists, and go into substeps and try things there as well. 

Would also be good if someone else tried it on Android, it seems to work for me but the simulator is painfully slow so I didn't test very much. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
