### PR TITLE
Fix/update date picker

### DIFF
--- a/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
+++ b/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
@@ -38,6 +38,9 @@ const DateInput = styled(Input)<{ transparent: boolean }>`
   border: none;
   text-align: right;
   min-width: 80%;
+  padding-right: 10px;
+  padding-top: 5px;
+  padding-bottom: 5px;
   font-weight: 500;
   color: ${props => props.theme.colors.neutrals[1]};
 `;

--- a/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
+++ b/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
@@ -38,30 +38,29 @@ const DateInput = styled(Input)<{ transparent: boolean }>`
   border: none;
   text-align: right;
   min-width: 80%;
-  padding-right: 10px;
-  padding-top: 5px;
-  padding-bottom: 5px;
   font-weight: 500;
   color: ${props => props.theme.colors.neutrals[1]};
 `;
 
 interface PropInterface {
-  onSelect: (data: Date) => void;
-  date: any;
+  onSelect: (date: string) => void;
+  value: string;
   editable?: boolean;
   transparent?: boolean;
+  style?: React.CSSProperties;
 }
 const CalendarPickerForm: React.FC<PropInterface> = ({
   onSelect,
-  date,
+  value,
   editable = true,
   transparent,
+  style,
 }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   // Handle selected date and hide calendar modal.
   const handleCalendarDateChange = (selectedDate: moment.Moment) => {
-    onSelect(selectedDate.toDate());
+    onSelect(selectedDate.format('Y-MM-DD'));
     setIsVisible(!isVisible);
   };
 
@@ -75,12 +74,13 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
       >
         <DateInput
           placeholder="Välj datum"
-          value={date ? moment(date).format('Y-MM-DD') : undefined}
+          value={value}
           multiline /** Temporary fix to make field scrollable inside scrollview */
           numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
           editable={false}
           pointerEvents="none"
           transparent={transparent}
+          style={style}
         />
       </TouchableOpacity>
 
@@ -113,7 +113,7 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
               }}
               previousTitle="Tidigare"
               nextTitle="Nästa"
-              selectedStartDate={date ? new Date(date) : undefined}
+              selectedStartDate={value ? new Date(value) : undefined}
             />
           </CalendarStyle>
         </CalendarContainer>
@@ -135,11 +135,13 @@ CalendarPickerForm.propTypes = {
   /**
    * Date value. Used for storing and displaying date in components.
    */
-  date: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.string]),
+  value: PropTypes.string,
   /** Turn the input field of. Defaults to true. */
   editable: PropTypes.bool,
   /** Turn the background of input field transparent */
   transparent: PropTypes.bool,
+  /** Additional styling for the input box */
+  style: PropTypes.object,
 };
 
 export default CalendarPickerForm;

--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -4,6 +4,7 @@ import { View, LayoutAnimation } from 'react-native';
 import { Input, Label, Select, Text } from 'source/components/atoms';
 import { CheckboxField, EditableList, GroupListWithAvatar } from 'source/components/molecules';
 import DateTimePickerForm from '../DateTimePicker/DateTimePickerForm';
+import CalendarPicker from '../CalendarPicker/CalendarPickerForm';
 import NavigationButtonField from '../NavigationButtonField/NavigationButtonField';
 import NavigationButtonGroup from '../NavigationButtonGroup/NavigationButtonGroup';
 import SummaryList from '../../organisms/SummaryList/SummaryList';
@@ -26,13 +27,9 @@ const inputTypes = {
     },
   },
   date: {
-    component: DateTimePickerForm,
+    component: CalendarPicker,
     changeEvent: 'onSelect',
-    props: {
-      mode: 'date',
-      selectorProps: { locale: 'sv' },
-    },
-    initialValue: '',
+    initialValue: undefined,
   },
   list: {},
   checkbox: {

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -62,21 +62,13 @@ const ItemInput = styled.TextInput<{colorSchema: string}>`
   min-width: 80%;
   font-weight: 500;
   color: ${props => props.theme.repeater[props.colorSchema].inputText};
-  padding: 6px;
+  padding: 5px;
 `;
 const DeleteButton = styled(Button)<{color: string}>`
   margin-top: 10px;
   margin-bottom: 10px;
   background: ${props => theme.repeater[props.color].deleteButton}
 `
-const dateStyle = {
-  textAlign: 'right',
-  minWidth: '80%',
-  padding: 6,
-  backgroundColor: 'transparent',
-  fontWeight: '500',
-  margin: 0,
-};
 
 interface Props {
   heading?: string;
@@ -128,8 +120,8 @@ const RepeaterFieldListItem: React.FC<Props> = ({
       case 'date':
         return (
           <CalendarPicker
-            date={ value[input.id] ? new Date(value[input.id] as string) : undefined }
-            onSelect={(date: Date) => { changeFromInput(input)(moment(date).format('Y-MM-DD'))}}
+            value={value[input.id] as string}
+            onSelect={changeFromInput(input)}
             editable={true}
             transparent
           />

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
 import styled from 'styled-components/native';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Text } from '../../atoms';
 import Button from '../../atoms/Button';
 import Label from '../../atoms/Label';
 import { InputRow } from './RepeaterField';
-import DateTimePickerForm from '../DateTimePicker/DateTimePickerForm';
+import CalendarPicker from '../CalendarPicker/CalendarPickerForm';
 import theme from '../../../styles/theme';
 
 const Base = styled.View`
@@ -126,14 +127,11 @@ const RepeaterFieldListItem: React.FC<Props> = ({
         );
       case 'date':
         return (
-          <DateTimePickerForm
-            value={value[input.id]?.toString() || ''}
-            mode="date"
-            selectorProps={{ locale: 'sv' }}
-            onSelect={changeFromInput(input)}
-            color={color}
-            style={dateStyle}
-            onBlur={onBlur}
+          <CalendarPicker
+            date={ value[input.id] ? new Date(value[input.id] as string) : undefined }
+            onSelect={(date: Date) => { changeFromInput(input)(moment(date).format('Y-MM-DD'))}}
+            editable={true}
+            transparent
           />
         );
       default:

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -6,9 +6,9 @@ import styled from "styled-components/native";
 import PropTypes from "prop-types";
 import { Text, Icon, Checkbox } from "../../atoms";
 import { SummaryListItem as SummaryListItemType } from "./SummaryList";
-import DateTimePickerForm from "../../molecules/DateTimePicker/DateTimePickerForm";
+import moment from 'moment';
+import CalendarPicker from '../../molecules/CalendarPicker/CalendarPickerForm';
 import { colorPalette } from '../../../styles/palette';
-import { CSSProp } from "styled-components";
 
 interface ItemWrapperProps {
   error?: { isValid: boolean; validationMessage: string; };
@@ -85,15 +85,6 @@ const DeleteButtonHighligth = styled(TouchableHighlight)`
   padding: 0;
   margin: 0;
 `;
-const dateStyle: CSSProp = {
-  textAlign: 'right',
-  minWidth: '80%',
-  padding: 5,
-  fontWeight: '500',
-  backgroundColor:'transparent',
-  borderWidth: 0,
-};
-
 interface Props {
   item: SummaryListItemType;
   value: Record<string, any> | string | number | boolean;
@@ -146,15 +137,11 @@ const SummaryListItem: React.FC<Props> = ({
       case 'date':
       case 'arrayDate':
         return (
-          <DateTimePickerForm
-            value={value as string}
-            mode="date"
-            selectorProps={{ locale: "sv" }}
-            onBlur={onInputBlur}
-            onSelect={changeFromInput}
-            color={color}
-            style={dateStyle}
+          <CalendarPicker
+            date={new Date(value as string)}
+            onSelect={(date: Date) => { changeFromInput(moment(date).format('Y-MM-DD'))}}
             editable={editable}
+            transparent
           />
         );
       case 'checkbox':

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -138,10 +138,11 @@ const SummaryListItem: React.FC<Props> = ({
       case 'arrayDate':
         return (
           <CalendarPicker
-            date={new Date(value as string)}
-            onSelect={(date: Date) => { changeFromInput(moment(date).format('Y-MM-DD'))}}
+            value={value as string}
+            onSelect={changeFromInput}
             editable={editable}
             transparent
+            style={ {paddingRight: 10, paddingTop:5, paddingBottom:5}}
           />
         );
       case 'checkbox':


### PR DESCRIPTION
## Explain the changes you’ve made

Updates various places in the app to use the new CalendarPicker instead of the old DateTimePicker. 

## Explain why these changes are made

The new component is better, and allows for more styling and uniform appereance across both iOS and Android. 

## Explain your solution

I had to do a small refactor in how the CalendarPicker dealt with inputs (rename date -> value, and change it to deal with strings), so that it conforms to how the rest of the input components work. 
Other than that, I just replaced the usage of DateTimePicker with the new CalendarPicker. 

## How to test the changes?

Go into a form that uses dates in various places, like the Test form or Löpande, and try to enter dates in all the different places. It should all use the input, i.e. it should look like a Calendar rather than a spinner (on iOS). 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.