### PR TITLE
feat/form close dialog

### DIFF
--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -55,7 +55,7 @@ interface Props {
 }
 /** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
 const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
-  <Modal visible={visible} transparent presentationStyle="overFullScreen">
+  <Modal visible={visible} transparent presentationStyle="overFullScreen" animationType="fade">
     <BackgroundBlur>
       <PopupContainer>
         <ContentContainer>

--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import PropTypes from 'prop-types';
+import { Modal } from 'react-native';
+import Button from '../../../atoms/Button';
+import Text from '../../../atoms/Text';
+import Card from '../../../molecules/Card';
+
+const BackgroundBlur = styled.View`
+  position: absolute;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0px;
+  background-color: rgba(0, 0, 0, 0.25);
+`;
+
+const PopupContainer = styled.View`
+  position: absolute;
+  z-index: 1000;
+  top: 33%;
+  left: 10%;
+  right: 10%;
+  bottom: 0;
+  padding: 0px;
+  max-height: 50%;
+  width: 80%;
+  background-color: white;
+  flex-direction: column;
+  border-radius: 6px;
+  shadow-offset: 0 0;
+  shadow-opacity: 0.1;
+  shadow-radius: 6px;
+`;
+const ContentContainer = styled.View`
+  padding: 10px;
+  padding-bottom: 20px;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 10;
+`;
+const ButtonRow = styled.View`
+  flex-direction: row;
+  justify-content: space-evenly;
+  padding: 20px;
+  margin-bottom: 10px;
+`;
+
+interface Props {
+  visible: boolean;
+  closeForm: () => void;
+  closeDialog: () => void;
+}
+/** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
+const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
+  <Modal visible={visible} transparent presentationStyle="overFullScreen">
+    <BackgroundBlur>
+      <PopupContainer>
+        <ContentContainer>
+          <Card colorSchema="neutral">
+            <Card.Body>
+              <Card.Title>Vill du avbryta ansökan?</Card.Title>
+              <Card.Text>
+                Ansökan sparas i 3 dagar. Efter det raderas den och du får starta en ny.
+              </Card.Text>
+            </Card.Body>
+          </Card>
+          <ButtonRow>
+            <Button colorSchema="red" onClick={closeDialog}>
+              <Text>Nej</Text>
+            </Button>
+            <Button
+              small
+              onClick={() => {
+                closeDialog();
+                closeForm();
+              }}
+            >
+              <Text>Ja</Text>
+            </Button>
+          </ButtonRow>
+        </ContentContainer>
+      </PopupContainer>
+    </BackgroundBlur>
+  </Modal>
+);
+
+CloseDialog.propTypes = {
+  /** whether to show the dialog or not */
+  visible: PropTypes.bool,
+  /** callback to navigate out of the form */
+  closeForm: PropTypes.func,
+  /** callback to close the dialog */
+  closeDialog: PropTypes.func,
+};
+
+export default CloseDialog;

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import AuthContext from 'app/store/AuthContext';
@@ -9,6 +9,7 @@ import Banner from './StepBanner/StepBanner';
 import StepFooter from './StepFooter/StepFooter';
 import StepDescription from './StepDescription/StepDescription';
 import Progressbar from '../../atoms/Progressbar/Progressbar';
+import CloseDialog from './CloseDialog/CloseDialog';
 
 const StepContainer = styled.View`
   background: ${props => props.theme.colors.neutrals[7]};
@@ -67,7 +68,7 @@ function Step({
     isBankidInstalled,
     handleSetStatus,
   } = useContext(AuthContext);
-
+  const [closeDialogVisible, setCloseDialogVisible] = useState(false);
   /**
    * Set auth context status to idle when navigating
    */
@@ -89,11 +90,16 @@ function Step({
 
   return (
     <StepContainer>
+      <CloseDialog
+        visible={closeDialogVisible}
+        closeForm={closeForm}
+        closeDialog={() => setCloseDialogVisible(false)}
+      />
       <StepBackNavigation
         showBackButton={isBackBtnVisible}
         inSubstep={inSubstep}
         onBack={backButtonBehavior}
-        onClose={closeForm}
+        onClose={() => setCloseDialogVisible(true)}
       />
       <StepContentContainer
         contentContainerStyle={{


### PR DESCRIPTION
## Explain the changes you’ve made
Adds a simple popup dialog for confirming that the user wants to quit from a form. 
The content follows a first sketch from Maria, but the design is basic, and needs some input from a designer eventually.

## Explain why these changes are made

To prevent accidental exits, and to inform the user of the 3-day period that we save incomplete applications. 

## Explain your solution
No context complexity, just a simple component that uses the react-native modal to present a popup floating over the content. Blocks the background with a semi-transparent dark color. 

## How to test the changes?

Open any form, and try to exit it, the dialog should show, and the buttons should work.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
