### PR TITLE
improve how some components deal with helpers/explainers

### DIFF
--- a/source/components/atoms/Fieldset/Fieldset.stories.js
+++ b/source/components/atoms/Fieldset/Fieldset.stories.js
@@ -11,12 +11,11 @@ fieldsetStories.add('default', () => (
   </StoryWrapper>
 ));
 
-fieldsetStories.add('With Icon', () => (
+fieldsetStories.add('With Help', () => (
   <StoryWrapper>
     <Fieldset
       legend="Tillgångar"
-      onIconPress={() => console.log('Icon is pressed')}
-      iconName="help-outline"
+      help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
     />
   </StoryWrapper>
 ));
@@ -24,26 +23,14 @@ fieldsetStories.add('Color Schemas', () => (
   <StoryWrapper>
     <Fieldset
       legend="Blue (default)"
-      onIconPress={() => console.log('Icon is pressed')}
-      iconName="help-outline"
+      help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
     />
     <Fieldset
       legend="Red"
-      onIconPress={() => console.log('Icon is pressed')}
-      iconName="help-outline"
       colorSchema="red"
+      help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
     />
-    <Fieldset
-      legend="Purple"
-      onIconPress={() => console.log('Icon is pressed')}
-      iconName="help-outline"
-      colorSchema="purple"
-    />
-    <Fieldset
-      legend="Green"
-      onIconPress={() => console.log('Icon is pressed')}
-      iconName="help-outline"
-      colorSchema="green"
-    />
+    <Fieldset legend="Purple" colorSchema="purple" />
+    <Fieldset legend="Green" colorSchema="green" />
   </StoryWrapper>
 ));

--- a/source/components/atoms/Fieldset/Fieldset.tsx
+++ b/source/components/atoms/Fieldset/Fieldset.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import Text from '../Text/Text';
 import Icon from '../Icon';
 import Button from '../Button';
+import { Help } from '../../../types/FormTypes';
+import HelpButton from '../../molecules/HelpButton';
 
 interface FieldsetContainerProps {
   colorSchema: string;
@@ -74,51 +77,57 @@ const FieldsetLegendBorder = styled.View<FieldsetLegendBorderProps>`
 `;
 
 interface FieldsetProps {
-  children: React.ReactNode;
   legend: string;
-  onIconPress?: () => void;
-  iconName?: string;
-  iconSize?: number;
   colorSchema: string;
   empty?: boolean;
+  help?: Help;
   renderHeaderActions?: () => void;
 }
 
-function Fieldset({
+const Fieldset: React.FC<FieldsetProps> = ({
   children,
   legend,
-  onIconPress,
-  iconName,
-  iconSize,
+  help,
   colorSchema,
   renderHeaderActions,
   empty,
-}: FieldsetProps) {
-  const showIcon = onIconPress && iconName;
-  return (
-    <FieldsetContainer colorSchema={colorSchema} empty={empty}>
-      <FieldsetHeader>
-        <FieldsetHeaderSection justifyContent="flex-start">
-          <FieldsetLegendBorder colorSchema={colorSchema}>
-            <FieldsetLegend colorSchema={colorSchema}>{legend.toUpperCase()}</FieldsetLegend>
-          </FieldsetLegendBorder>
-        </FieldsetHeaderSection>
+}) => (
+  <FieldsetContainer colorSchema={colorSchema} empty={empty}>
+    <FieldsetHeader>
+      <FieldsetHeaderSection justifyContent="flex-start">
+        <FieldsetLegendBorder colorSchema={colorSchema}>
+          <FieldsetLegend colorSchema={colorSchema}>{legend.toUpperCase()}</FieldsetLegend>
+        </FieldsetLegendBorder>
+      </FieldsetHeaderSection>
+      <FieldsetHeaderSection justifyContent="flex-end">
+        {help && Object.keys(help).length > 0 && <HelpButton {...help} />}
+        {renderHeaderActions && renderHeaderActions()}
+      </FieldsetHeaderSection>
+    </FieldsetHeader>
+    <FieldsetBody>{children}</FieldsetBody>
+  </FieldsetContainer>
+);
 
-        <FieldsetHeaderSection justifyContent="flex-end">
-          {showIcon && <Icon onPress={onIconPress} name={iconName} size={iconSize} />}
-          {renderHeaderActions && renderHeaderActions()}
-        </FieldsetHeaderSection>
-      </FieldsetHeader>
-      <FieldsetBody>{children}</FieldsetBody>
-    </FieldsetContainer>
-  );
-}
+Fieldset.propTypes = {
+  empty: PropTypes.bool,
+  /**
+   * Show a help button
+   */
+  help: PropTypes.shape({
+    text: PropTypes.string,
+    size: PropTypes.number,
+    heading: PropTypes.string,
+    tagline: PropTypes.string,
+    url: PropTypes.string,
+  }),
+  renderHeaderActions: PropTypes.func,
+  colorSchema: PropTypes.string,
+  legend: PropTypes.string,
+  children: PropTypes.node,
+};
 
 Fieldset.defaultProps = {
   colorSchema: 'blue',
-  iconName: undefined,
-  renderHeaderActions: undefined,
-  iconSize: 22,
 };
 
 export default Fieldset;

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import { Text, Button, Fieldset } from '../../atoms';
 import Select from '../../atoms/Select';
+import HelpButton from '../HelpButton';
 import CalendarPicker from '../CalendarPicker/CalendarPickerForm';
 
 const EditableListBody = styled.View`
@@ -80,11 +81,11 @@ function EditableList({
   onBlur,
   inputIsEditable,
   startEditable,
+  help,
   error,
 }) {
   const [editable, setEditable] = useState(startEditable);
   const [state, setState] = useState(getInitialState(inputs, value));
-
   const changeEditable = () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setEditable(!editable);
@@ -155,15 +156,16 @@ function EditableList({
     <Fieldset
       colorSchema={colorSchema}
       legend={title || ''}
-      onIconPress={() => console.log('Icon is pressed')}
-      iconName="help-outline"
-      renderHeaderActions={() =>
-        inputIsEditable && (
-          <FieldsetButton colorSchema={colorSchema} z={0} size="small" onClick={changeEditable}>
-            <Text>{editable ? 'Färdig' : 'Ändra'}</Text>
-          </FieldsetButton>
-        )
-      }
+      renderHeaderActions={() => (
+        <>
+          {help && Object.keys(help).length > 0 && <HelpButton {...help} />}
+          {inputIsEditable && (
+            <FieldsetButton colorSchema={colorSchema} z={0} size="small" onClick={changeEditable}>
+              <Text>{editable ? 'Färdig' : 'Ändra'}</Text>
+            </FieldsetButton>
+          )}
+        </>
+      )}
     >
       <EditableListBody>
         {inputs.map(input => (
@@ -220,6 +222,16 @@ EditableList.propTypes = {
   startEditable: PropTypes.bool,
   /** Validation error object */
   error: PropTypes.object,
+  /**
+   * Show an help button
+   */
+  help: PropTypes.shape({
+    text: PropTypes.string,
+    size: PropTypes.number,
+    heading: PropTypes.string,
+    tagline: PropTypes.string,
+    url: PropTypes.string,
+  }),
   /**
    * The color schema/theme of the component
    */

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -156,9 +156,9 @@ function EditableList({
     <Fieldset
       colorSchema={colorSchema}
       legend={title || ''}
+      help={help}
       renderHeaderActions={() => (
         <>
-          {help && Object.keys(help).length > 0 && <HelpButton {...help} />}
           {inputIsEditable && (
             <FieldsetButton colorSchema={colorSchema} z={0} size="small" onClick={changeEditable}>
               <Text>{editable ? 'Färdig' : 'Ändra'}</Text>

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -223,7 +223,7 @@ EditableList.propTypes = {
   /** Validation error object */
   error: PropTypes.object,
   /**
-   * Show an help button
+   * Show a help button
    */
   help: PropTypes.shape({
     text: PropTypes.string,

--- a/source/components/molecules/EditableList/EditableList.stories.js
+++ b/source/components/molecules/EditableList/EditableList.stories.js
@@ -58,7 +58,12 @@ storiesOf('EditableList', module).add('Default', () => (
 storiesOf('EditableList', module).add('Input is editable', () => (
   <StoryWrapper>
     <ScrollView>
-      <EditableList onInputChange={() => {}} inputs={inputs} title="Editable List" />
+      <EditableList
+        onInputChange={() => {}}
+        inputs={inputs}
+        title="Editable List"
+        help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
+      />
       <EditableList onInputChange={() => {}} inputs={inputs} title="Start editable" startEditable />
     </ScrollView>
   </StoryWrapper>
@@ -67,10 +72,33 @@ storiesOf('EditableList', module).add('Input is editable', () => (
 storiesOf('EditableList', module).add('Color Schema', () => (
   <StoryWrapper>
     <ScrollView>
-      <EditableList onInputChange={() => {}} inputs={inputs} title="Blue (Default)" />
-      <EditableList colorSchema="red" onInputChange={() => {}} inputs={inputs} title="Red" />
-      <EditableList colorSchema="purple" onInputChange={() => {}} inputs={inputs} title="Purple" />
-      <EditableList colorSchema="green" onInputChange={() => {}} inputs={inputs} title="Green" />
+      <EditableList
+        onInputChange={() => {}}
+        inputs={inputs}
+        title="Blue (Default)"
+        help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
+      />
+      <EditableList
+        colorSchema="red"
+        onInputChange={() => {}}
+        inputs={inputs}
+        title="Red"
+        help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
+      />
+      <EditableList
+        colorSchema="purple"
+        onInputChange={() => {}}
+        inputs={inputs}
+        title="Purple"
+        help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
+      />
+      <EditableList
+        colorSchema="green"
+        onInputChange={() => {}}
+        inputs={inputs}
+        title="Green"
+        help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
+      />
     </ScrollView>
   </StoryWrapper>
 ));

--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { View, LayoutAnimation } from 'react-native';
 import { Input, Label, Select, Text } from 'source/components/atoms';
 import { CheckboxField, EditableList, GroupListWithAvatar } from 'source/components/molecules';
-import DateTimePickerForm from '../DateTimePicker/DateTimePickerForm';
 import CalendarPicker from '../CalendarPicker/CalendarPickerForm';
 import NavigationButtonField from '../NavigationButtonField/NavigationButtonField';
 import NavigationButtonGroup from '../NavigationButtonGroup/NavigationButtonGroup';
@@ -35,6 +34,8 @@ const inputTypes = {
   checkbox: {
     component: CheckboxField,
     changeEvent: 'onChange',
+    helpInComponent: true,
+    helpProp: 'help',
     props: {},
     initialValue: false,
   },
@@ -42,6 +43,8 @@ const inputTypes = {
     component: EditableList,
     changeEvent: 'onInputChange',
     blurEvent: 'onBlur',
+    helpInComponent: true,
+    helpProp: 'help',
     props: {},
     initialValue: {},
   },
@@ -73,6 +76,8 @@ const inputTypes = {
     component: SummaryList,
     changeEvent: 'onChange',
     blurEvent: 'onBlur',
+    helpInComponent: true,
+    helpProp: 'help',
     props: { answers: true, validation: true },
   },
   repeaterField: {
@@ -95,7 +100,7 @@ const FormField = ({
   answers,
   validationErrors,
   conditionalOn,
-  labelHelp,
+  help,
   ...other
 }) => {
   const input = inputTypes[inputType];
@@ -119,8 +124,6 @@ const FormField = ({
   const inputCompProps = {
     color,
     value: initialValue,
-    help:
-      other.inputHelp && other.text ? { text: other.inputHelp, heading: other.text } : undefined,
     ...inputProps,
     error: validationErrors[id],
     ...other,
@@ -129,6 +132,7 @@ const FormField = ({
   if (input?.props?.validation) inputCompProps.validationErrors = validationErrors;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;
   if (input && input.blurEvent) inputCompProps[input.blurEvent] = onInputBlur;
+  if (input && input.helpInComponent) inputCompProps[input.helpProp || 'help'] = help;
 
   /** Checks if the field is conditional on another input, and if so,
    * evaluates whether this field should be active or not */
@@ -160,7 +164,7 @@ const FormField = ({
           <Label
             color={color}
             underline={labelLine}
-            help={labelHelp ? { heading: label, text: labelHelp } : {}}
+            help={!input.helpInComponent && help && Object.keys(help).length > 0 ? help : {}}
           >
             {label}
           </Label>
@@ -230,9 +234,15 @@ FormField.propTypes = {
    */
   conditionalOn: PropTypes.string,
   /**
-   * Property to show a help button
+   * Show an help button
    */
-  labelHelp: PropTypes.string,
+  help: PropTypes.shape({
+    text: PropTypes.string,
+    size: PropTypes.number,
+    heading: PropTypes.string,
+    tagline: PropTypes.string,
+    url: PropTypes.string,
+  }),
 };
 
 FormField.defaultProps = {

--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -11,6 +11,16 @@ import RepeaterField from '../RepeaterField/RepeaterField';
 import theme from '../../../styles/theme';
 import RadioGroup from '../RadioGroup/RadioGroup';
 
+/**
+ * Explanation of the properties in this data structure:
+ *
+ * component: which React component to render.
+ * changeEvent: the name of the event that the component should update the form value on. For example 'onChangeText' for a field input, or 'onChange' for a checkbox etc.
+ * blurEvent: if the component can be blurred, this is the name of the corresponding prop, typically 'onBlur'
+ * helpInComponent: set to true if the component has a help button 'inside', where the help should go instead of in the label.
+ * helpProp: the name of the prop where the help object should be sent, typically just 'help'.
+ * props: additional props to send into the generated component
+ */
 const inputTypes = {
   text: {
     component: Input,
@@ -234,7 +244,7 @@ FormField.propTypes = {
    */
   conditionalOn: PropTypes.string,
   /**
-   * Show an help button
+   * Show a help button
    */
   help: PropTypes.shape({
     text: PropTypes.string,

--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { View, LayoutAnimation } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
-import Label from '../../atoms/Label/Label';
+import { Help } from '../../../types/FormTypes';
 import Text from '../../atoms/Text';
+import HelpButton from '../HelpButton';
 import Fieldset, { FieldsetButton } from '../../atoms/Fieldset/Fieldset';
 import { colorPalette } from '../../../styles/palette';
 import theme from '../../../styles/theme';
@@ -30,6 +31,7 @@ interface Props {
   color: string;
   showEditButton?: boolean;
   startEditable?: boolean;
+  help?: Help;
 }
 
 /**
@@ -43,6 +45,7 @@ const GroupedList: React.FC<Props> = ({
   color,
   showEditButton,
   startEditable,
+  help,
 }) => {
   const [editable, setEditable] = useState(startEditable);
 
@@ -64,15 +67,16 @@ const GroupedList: React.FC<Props> = ({
     <Fieldset
       colorSchema={colorSchema}
       legend={heading || ''}
-      onIconPress={() => console.log('Icon is pressed')}
-      iconName="help-outline"
-      renderHeaderActions={() =>
-        showEditButton && (
-          <FieldsetButton colorSchema={colorSchema} z={0} size="small" onClick={changeEditable}>
-            <Text>{editable ? 'Färdig' : 'Ändra'}</Text>
-          </FieldsetButton>
-        )
-      }
+      renderHeaderActions={() => (
+        <>
+          {help && Object.keys(help).length > 0 && <HelpButton {...help} />}
+          {showEditButton && (
+            <FieldsetButton colorSchema={colorSchema} z={0} size="small" onClick={changeEditable}>
+              <Text>{editable ? 'Färdig' : 'Ändra'}</Text>
+            </FieldsetButton>
+          )}
+        </>
+      )}
     >
       <ListBody>
         {Object.keys(groupedItems).map((key, index) => (
@@ -116,6 +120,16 @@ GroupedList.propTypes = {
    * Whether to start in editable mode or not
    */
   startEditable: PropTypes.bool,
+  /**
+   * Show an help button
+   */
+  help: PropTypes.shape({
+    text: PropTypes.string,
+    size: PropTypes.number,
+    heading: PropTypes.string,
+    tagline: PropTypes.string,
+    url: PropTypes.string,
+  }),
 };
 
 GroupedList.defaultProps = {

--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -67,9 +67,9 @@ const GroupedList: React.FC<Props> = ({
     <Fieldset
       colorSchema={colorSchema}
       legend={heading || ''}
+      help={help}
       renderHeaderActions={() => (
         <>
-          {help && Object.keys(help).length > 0 && <HelpButton {...help} />}
           {showEditButton && (
             <FieldsetButton colorSchema={colorSchema} z={0} size="small" onClick={changeEditable}>
               <Text>{editable ? 'Färdig' : 'Ändra'}</Text>

--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -36,7 +36,7 @@ interface Props {
 
 /**
  * A grouped list, grouping items according to categories.
- * Can show an edit-button, which toggles an editable prop in the children.
+ * Can show an edit-button, which toggles an editable prop in the children, and an help button that opens a help modal.
  */
 const GroupedList: React.FC<Props> = ({
   heading,
@@ -121,7 +121,7 @@ GroupedList.propTypes = {
    */
   startEditable: PropTypes.bool,
   /**
-   * Show an help button
+   * Show a help button
    */
   help: PropTypes.shape({
     text: PropTypes.string,

--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Modal, TouchableHighlight, ScrollView, Image, Linking } from 'react-native';
 import styled from 'styled-components/native';
-import { Text, Icon, Button } from 'app/components/atoms';
+import { Icon, Button } from 'app/components/atoms';
 import PropTypes from 'prop-types';
 import icons from 'source/helpers/Icons';
+import Text from '../../atoms/Text';
 import BackNavigation from '../BackNavigation/BackNavigation';
 
 const ModalContainer = styled.View({

--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -73,7 +73,7 @@ const HelpButton = props => {
     Linking.openURL(url);
   };
 
-  if (heading.length === 0 && text.length === 0 && url.length) {
+  if ((!heading || heading.length === 0) && (!text || text?.length === 0) && url.length) {
     return (
       <>
         <TouchableHighlight onPress={link} underlayColor="transparent">
@@ -107,7 +107,7 @@ const HelpButton = props => {
             >
               <Tagline>{tagline}</Tagline>
               <Heading>{heading}</Heading>
-              <HelpText>{text.length ? text : 'Text not available'}</HelpText>
+              <HelpText>{text?.length ? text : 'Text not available'}</HelpText>
               {url.length > 0 ? (
                 <LinkButton onClick={link} color="floral" block>
                   <Text>Läs mer</Text>

--- a/source/components/organisms/SummaryList/SummaryList.stories.js
+++ b/source/components/organisms/SummaryList/SummaryList.stories.js
@@ -103,7 +103,8 @@ const SummaryStory = () => {
         showSum
       />
       <SummaryList
-        heading="Blå, ingen summa"
+        heading="Blå, ingen summa, med hjälp"
+        help={{ text: 'hello from the help text', heading: 'Do not fear, help is here' }}
         items={items}
         categories={categories}
         color="blue"

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -269,7 +269,7 @@ SummaryList.propTypes = {
    */
   startEditable: PropTypes.bool,
     /**
-   * Show an help button
+   * Show a help button
    */
   help: PropTypes.shape({
     text: PropTypes.string,

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -6,6 +6,7 @@ import Text from '../../atoms/Text/Text';
 import Heading from '../../atoms/Heading';
 import SummaryListItemComponent from './SummaryListItem';
 import { getValidColorSchema } from '../../../styles/theme';
+import { Help } from '../../../types/FormTypes';
 
 const SumLabel = styled(Heading)<{ colorSchema: string }>`
   margin-top: 5px;
@@ -60,6 +61,7 @@ interface Props {
   >;
   showSum: boolean;
   startEditable?: boolean;
+  help? : Help;
 }
 /**
  * Summary list, that is linked and summarizes values from other input components.
@@ -77,6 +79,7 @@ const SummaryList: React.FC<Props> = ({
   validationErrors,
   showSum,
   startEditable,
+  help,
 }) => {
   /**
    * Given an item, and possibly an index in the case of repeater fields, this generates a function that
@@ -211,6 +214,7 @@ const SummaryList: React.FC<Props> = ({
           color={color}
           showEditButton
           startEditable={startEditable}
+          help={help}
         />
         {showSum && (
           <SumContainer colorSchema={validColorSchema}>
@@ -264,6 +268,16 @@ SummaryList.propTypes = {
    * Whether to start in editable mode or not.
    */
   startEditable: PropTypes.bool,
+    /**
+   * Show an help button
+   */
+  help: PropTypes.shape({
+    text: PropTypes.string,
+    size: PropTypes.number,
+    heading: PropTypes.string,
+    tagline: PropTypes.string,
+    url: PropTypes.string,
+  }),
 };
 
 SummaryList.defaultProps = {

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -1,5 +1,11 @@
 import { ValidationObject } from './Validation';
 
+export interface Help {
+  text?: string;
+  heading?: string;
+  tagline?: string;
+  url?: string;
+}
 export interface SummaryItem {
   category: string;
   title: string;
@@ -37,7 +43,9 @@ export interface Question {
   items?: SummaryItem[];
   inputs?: ListInput[];
   validation?: ValidationObject;
+  help?: Help;
 }
+
 export type ActionType = 'start' | 'next' | 'submit' | 'sign' | 'close' | 'backToMain';
 export interface Action {
   type: ActionType;


### PR DESCRIPTION
## Explain the changes you’ve made
Improve how EditableList, SummaryList and CheckboxField displays help. These components have had help icons in the design, but these have been non-functional or worked in a 'shoddy' way. This fixes them to work as intended, and fix so that we deal with the help object in a more unified way. 

## Explain your solution

The idea is that from the backend/formbuilder, each question can have a help-object, which describes what should show up in the help modal. Some components have a help button in them; in which case this should trigger the correct help modal. Others do not, in which case the help button should appear in the label instead. I add a parameter (helpInComponent) to the list of input types in FormField to keep track of this, and some logic to pass the help object along if helpInComponent is true. 

Then I changed the Fieldset component so that it can accept a help object, in which case it will display a help button, and then EditableList and SummaryList just pass the help object down, and let Fieldset render the button. 

Next step is to update the way help is entered in the formBuilder so that it conforms to this standard. 

## How to test the changes?

The Test form in the dev environment has all the components with helpers added to them, so one can try it through that one. 
Otherwise in the stories for EditableList, SummaryList and FieldSet, I added help buttons to some of them, so that's another way to test the functionality. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots (optional)
![Helpers](https://user-images.githubusercontent.com/7421890/100877768-8925b800-34a9-11eb-8f8d-b8c5abdad667.jpg)
