### PR TITLE
Validate all inputs in a step

### DIFF
--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -47,6 +47,7 @@ function Step({
   actions,
   answers,
   validation,
+  validateStepAnswers,
   status,
   formNavigation,
   onSubmit,
@@ -168,6 +169,7 @@ function Step({
             currentPosition={currentPosition}
             onUpdate={onFieldChange}
             updateCaseInContext={updateCaseInContext}
+            validateStepAnswers={validateStepAnswers}
           />
         ) : null}
       </StepContentContainer>
@@ -188,6 +190,10 @@ Step.propTypes = {
    * User input validation result.
    */
   validation: PropTypes.object,
+  /**
+   * Function that runs validation for all inputs in a step.
+   */
+  validateStepAnswers: PropTypes.func,
   /**
    * The answers of a form.
    */

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -6,6 +6,7 @@ import { Button, Text } from '../../../atoms';
 import { Action, ActionType } from '../../../../types/FormTypes';
 import { CaseStatus } from '../../../../types/CaseType';
 import { CurrentFormPosition } from '../../../../containers/Form/hooks/useForm';
+import { useNotification } from '../../../../store/NotificationContext';
 
 const ActionContainer = styled.View`
   flex: 1;
@@ -44,6 +45,7 @@ interface Props {
     currentMainStep: number
   ) => void;
   currentPosition: CurrentFormPosition;
+  validateStepAnswers: () => void;
 }
 
 const StepFooter: React.FC<Props> = ({
@@ -56,8 +58,10 @@ const StepFooter: React.FC<Props> = ({
   updateCaseInContext,
   currentPosition,
   children,
+  validateStepAnswers,
 }) => {
   const { user, handleSign, status, isLoading } = useContext(AuthContext);
+  const showNotification = useNotification();
 
   useEffect(() => {
     const signCase = () => {
@@ -96,10 +100,23 @@ const StepFooter: React.FC<Props> = ({
       }
       default: {
         return () => {
+          const errorCallback = () => {
+            showNotification(
+              'Oj, fel inmatning!',
+              'Vänligen rätta fel innan ni går vidare',
+              'error',
+              8000
+            );
+          };
+          const onValidCallback = () => {
+            if (formNavigation.next) formNavigation.next();
+          };
+
           if (onUpdate && caseStatus === 'ongoing') onUpdate(answers);
           if (updateCaseInContext && caseStatus === 'ongoing')
             updateCaseInContext(answers, 'ongoing', currentPosition);
-          if (formNavigation.next) formNavigation.next();
+
+          validateStepAnswers(errorCallback, onValidCallback);
         };
       }
     }
@@ -200,6 +217,8 @@ StepFooter.propTypes = {
     currentMainStep: PropTypes.number,
     currentMainStepIndex: PropTypes.number,
   }).isRequired,
+  /** Validate all answers in current step * */
+  validateStepAnswers: PropTypes.func,
 };
 
 StepFooter.defaultProps = {

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -65,9 +65,14 @@ const Form: React.FC<Props> = ({
     allQuestions: [],
   };
 
-  const { formState, formNavigation, handleInputChange, handleSubmit, handleBlur } = useForm(
-    initialState
-  );
+  const {
+    formState,
+    formNavigation,
+    handleInputChange,
+    handleSubmit,
+    handleBlur,
+    validateStepAnswers,
+  } = useForm(initialState);
 
   formNavigation.close = () => {
     onClose();
@@ -88,6 +93,7 @@ const Form: React.FC<Props> = ({
         }}
         answers={formState.formAnswers}
         validation={formState.validations}
+        validateStepAnswers={validateStepAnswers}
         status={status}
         questions={questions}
         actions={actions}

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -354,7 +354,6 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
       }
     } else if (question.type === 'repeaterField') {               // Checks for isValid in repeaterField.
       const repeaterField = state.validations[question.id];       // repeater are stored in an array and we need to check isValid for every one.
-      console.log(repeaterField);
 
       for (const repeaterIndexIndex in repeaterField) {
         const repeater = repeaterField[repeaterIndexIndex];

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -336,14 +336,14 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
   for (const questionIndex in currentStepQuestions) {
     const question = currentStepQuestions[questionIndex]
 
-    if (['text', 'number'].includes(question.type)) {             // Checks for isValid in text and number.
+    if (['text', 'number'].includes(question.type)) {
       if (state.validations[question.id]?.isValid === false) {
         allInputsValid = false;
 
         break;
       }
-    } else if (question.type === 'editableList') {                // Checks for isValid in editableList.
-      const editableList = state.validations[question.id];        // editableList can have many elements and we need to check isValid for every one.
+    } else if (question.type === 'editableList') {
+      const editableList = state.validations[question.id];
 
       for (const editableListKey in editableList) {
         if (editableList[editableListKey]?.isValid === false) {
@@ -352,8 +352,8 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
           break;
         }
       }
-    } else if (question.type === 'repeaterField') {               // Checks for isValid in repeaterField.
-      const repeaterField = state.validations[question.id];       // repeater are stored in an array and we need to check isValid for every one.
+    } else if (question.type === 'repeaterField') {
+      const repeaterField = state.validations[question.id];
 
       for (const repeaterIndexIndex in repeaterField) {
         const repeater = repeaterField[repeaterIndexIndex];

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -330,18 +330,20 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
     state = validateAnswer(state, { [id]: answer }, id);
   });
 
-  // Find out if any validation failed.
+  // Find out if any validation failed for types text, input, editableList and repeaterField.
+  // Validation field unique so different handling required for the different types.
+  // Will break at the very first found instance of isValid === false and set allInputsValid = false.
   for (const questionIndex in currentStepQuestions) {
     const question = currentStepQuestions[questionIndex]
 
-    if (['text', 'number'].includes(question.type)) {
+    if (['text', 'number'].includes(question.type)) {             // Checks for isValid in text and number.
       if (state.validations[question.id]?.isValid === false) {
         allInputsValid = false;
 
         break;
       }
-    } else if (question.type === 'editableList') {
-      const editableList = state.validations[question.id];
+    } else if (question.type === 'editableList') {                // Checks for isValid in editableList.
+      const editableList = state.validations[question.id];        // editableList can have many elements and we need to check isValid for every one.
 
       for (const editableListKey in editableList) {
         if (editableList[editableListKey]?.isValid === false) {
@@ -350,8 +352,9 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
           break;
         }
       }
-    } else if (question.type === 'repeaterField') {
-      const repeaterField = state.validations[question.id];
+    } else if (question.type === 'repeaterField') {               // Checks for isValid in repeaterField.
+      const repeaterField = state.validations[question.id];       // repeater are stored in an array and we need to check isValid for every one.
+      console.log(repeaterField);
 
       for (const repeaterIndexIndex in repeaterField) {
         const repeater = repeaterField[repeaterIndexIndex];

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -331,12 +331,39 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
   });
 
   // Find out if any validation failed.
-  const fieldKeys = state.validations;
-  for(const fieldKey in fieldKeys) {
-    if (state.validations[fieldKey]?.isValid === false) {
-      allInputsValid = false;
+  for (const questionIndex in currentStepQuestions) {
+    const question = currentStepQuestions[questionIndex]
 
-      break;
+    if (['text', 'number'].includes(question.type)) {
+      if (state.validations[question.id]?.isValid === false) {
+        allInputsValid = false;
+
+        break;
+      }
+    } else if (question.type === 'editableList') {
+      const editableList = state.validations[question.id];
+
+      for (const editableListKey in editableList) {
+        if (editableList[editableListKey]?.isValid === false) {
+          allInputsValid = false;
+
+          break;
+        }
+      }
+    } else if (question.type === 'repeaterField') {
+      const repeaterField = state.validations[question.id];
+
+      for (const repeaterIndexIndex in repeaterField) {
+        const repeater = repeaterField[repeaterIndexIndex];
+
+        for (const repeaterIndex in repeater) {
+          if (repeater[repeaterIndex]?.isValid === false) {
+            allInputsValid = false;
+
+            break;
+          }
+        }
+      }
     }
   }
 

--- a/source/containers/Form/hooks/formReducer.ts
+++ b/source/containers/Form/hooks/formReducer.ts
@@ -12,6 +12,7 @@ import {
   computeNumberMainSteps,
   getAllQuestions,
   validateAnswer,
+  validateAllStepAnswers,
   dirtyField,
 } from './formActions';
 
@@ -53,6 +54,10 @@ type Action =
   | {
       type: 'VALIDATE_ANSWER';
       payload: { answer: Record<string, any>; id: string; checkIfDirty?: boolean };
+    }
+  | {
+      type: 'VALIDATE_ALL_STEP_ANSWERS';
+      payload: { onErrorCallback: () => void; onValidCallback: () => void };
     }
   | {
       type: 'DIRTY_FIELD';
@@ -132,6 +137,14 @@ function formReducer(state: FormReducerState, action: Action) {
         action.payload.answer,
         action.payload.id,
         action.payload.checkIfDirty
+      );
+    }
+
+    case 'VALIDATE_ALL_STEP_ANSWERS': {
+      return validateAllStepAnswers(
+        state,
+        action.payload.onErrorCallback,
+        action.payload.onValidCallback
       );
     }
 

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -39,6 +39,14 @@ function useForm(initialState: FormReducerState) {
       type: 'GET_ALL_QUESTIONS',
     });
   }, [formState.steps]);
+
+  const validateStepAnswers = (onErrorCallback, onValidCallback) => {
+    dispatch({
+      type: 'VALIDATE_ALL_STEP_ANSWERS',
+      payload: { onErrorCallback, onValidCallback },
+    });
+  };
+
   /**
    * Function for going forward in the form
    */
@@ -148,6 +156,7 @@ function useForm(initialState: FormReducerState) {
     handleInputChange,
     handleBlur,
     handleSubmit,
+    validateStepAnswers,
   };
 }
 


### PR DESCRIPTION
## Explain the changes you’ve made

Added form action that validates all inputs in a step.

## Explain why these changes are made

This action can be used to validate all user inputs before user can be allowed to continue with a form.
Some steps in the form need to be looked and correctly imputed before the user can be allowed to continue.

## Explain your solution

formAction validateAllStepAnswers will validate all inputs for current step and invoke callbacks depending on how the validation goes (errors found or all inputs valid).

## How to test the changes?

Invoke the form "Test form" in app (not storybook) and test validation for email and phone number with:
1) No inputs -> Press "Submit": 
Should not be allowed to move to next step. 
Toaster should be displayed with warning.
Error text shall be displayed under both input fields.

2) Run step 1) and then input values for email and phone:
Errror text shall be updated as user inputs values.

3) Full inputs email and phone correctly and then press "Submit":
Form shall proceed to next step.

4) Restarting the form with empty fields email and phone -> Start filling inputs:
Inputs shall start validating onBlur (when user clicks outside input field), form shall otherwise behave like step 2) and 3).


## Was this feature tested in the following environments?
- [ ] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.



## Anyhting else? (optional)

Ticket for task: https://app.clickup.com/t/9yyj0h
