### PR TITLE
add a simple popup with embedded youtube player

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-native-tab-view": "^2.15.1",
     "react-native-vector-icons": "^6.6.0",
     "react-native-webview": "^9.4.0",
+    "react-native-youtube-iframe": "^1.4.0",
     "styled-components": "^5.0.1",
     "validator": "^13.1.17",
     "yarn": "^1.22.0"

--- a/source/components/organisms/YoutubePopup/YoutubePopup.stories.js
+++ b/source/components/organisms/YoutubePopup/YoutubePopup.stories.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react-native';
+import styled from 'styled-components/native';
+import StoryWrapper from '../../molecules/StoryWrapper';
+import YoutubePopup from './YoutubePopup';
+import { Button, Text } from '../../atoms';
+
+const Wrapper = styled.View`
+  flex-direction: row;
+  justify-content: center;
+  height: 300px;
+  align-items: center;
+`;
+
+const YoutubeStory = () => {
+  const [visible, setVisible] = useState(false);
+  return (
+    <>
+      <YoutubePopup
+        visible={visible}
+        youtubeVideoId="o0u4M6vppCI"
+        closePopup={() => setVisible(false)}
+      />
+      <Wrapper>
+        <Button onClick={() => setVisible(true)}>
+          <Text>Visa popup</Text>
+        </Button>
+      </Wrapper>
+    </>
+  );
+};
+
+storiesOf('Youtube Popup', module).add('Default', () => (
+  <StoryWrapper>
+    <YoutubeStory />
+  </StoryWrapper>
+));

--- a/source/components/organisms/YoutubePopup/YoutubePopup.tsx
+++ b/source/components/organisms/YoutubePopup/YoutubePopup.tsx
@@ -65,7 +65,6 @@ const YoutubePopup: React.FC<Props> = ({ visible, closePopup, youtubeVideoId }) 
 );
 
 YoutubePopup.propTypes = {
-  /** whether to show the dialog or not */
   visible: PropTypes.bool,
   closePopup: PropTypes.func,
   /** for a youtube link to a video, like https://www.youtube.com/watch?v=dQw4w9WgXcQ, the id is the string aftter ?v=  */

--- a/source/components/organisms/YoutubePopup/YoutubePopup.tsx
+++ b/source/components/organisms/YoutubePopup/YoutubePopup.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import PropTypes from 'prop-types';
+import { Modal } from 'react-native';
+import YoutubePlayer from 'react-native-youtube-iframe';
+import Button from '../../atoms/Button';
+import Text from '../../atoms/Text';
+
+const BackgroundBlur = styled.View`
+  position: absolute;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0px;
+  background-color: rgba(0, 0, 0, 0.35);
+`;
+
+const PopupContainer = styled.View`
+  position: absolute;
+  z-index: 1000;
+  top: 33%;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0px;
+  max-height: 50%;
+  width: 100%;
+  background-color: black;
+`;
+const ContentContainer = styled.View`
+  padding: 0px;
+  padding-bottom: 0px;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 10;
+`;
+
+const ButtonContainer = styled.View`
+  justify-content: center;
+  flex-direction: row;
+`;
+
+interface Props {
+  visible: boolean;
+  closePopup: () => void;
+  youtubeVideoId: string;
+}
+const YoutubePopup: React.FC<Props> = ({ visible, closePopup, youtubeVideoId }) => (
+  <Modal visible={visible} transparent presentationStyle="overFullScreen" animationType="fade">
+    <BackgroundBlur>
+      <PopupContainer>
+        <ContentContainer>
+          <YoutubePlayer height={300} play={false} videoId={youtubeVideoId} />
+          <ButtonContainer>
+            <Button colorSchema="red" onClick={closePopup}>
+              <Text>Stäng</Text>
+            </Button>
+          </ButtonContainer>
+        </ContentContainer>
+      </PopupContainer>
+    </BackgroundBlur>
+  </Modal>
+);
+
+YoutubePopup.propTypes = {
+  /** whether to show the dialog or not */
+  visible: PropTypes.bool,
+  closePopup: PropTypes.func,
+  /** for a youtube link to a video, like https://www.youtube.com/watch?v=dQw4w9WgXcQ, the id is the string aftter ?v=  */
+  youtubeVideoId: PropTypes.string,
+};
+
+export default YoutubePopup;

--- a/source/components/organisms/YoutubePopup/index.js
+++ b/source/components/organisms/YoutubePopup/index.js
@@ -1,0 +1,1 @@
+export { default } from './YoutubePopup';

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -40,6 +40,7 @@ function loadStories() {
 	require('../source/components/organisms/Step/StepDescription/StepDescription.stories');
 	require('../source/components/organisms/Step/StepFooter/StepFooter.stories');
 	require('../source/components/organisms/SummaryList/SummaryList.stories');
+	require('../source/components/organisms/YoutubePopup/YoutubePopup.stories');
 	require('../source/containers/Form/Form.stories');
 }
 
@@ -80,6 +81,7 @@ const stories = [
 	'../source/components/organisms/Step/StepDescription/StepDescription.stories',
 	'../source/components/organisms/Step/StepFooter/StepFooter.stories',
 	'../source/components/organisms/SummaryList/SummaryList.stories',
+	'../source/components/organisms/YoutubePopup/YoutubePopup.stories',
 	'../source/containers/Form/Form.stories'
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,7 +5587,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
   integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
 
-events@^3.0.0:
+events@^3.0.0, events@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
@@ -10479,6 +10479,13 @@ react-native-windows@^0.62.0-0:
     username "^5.1.0"
     uuid "^3.3.2"
     xml-parser "^1.2.1"
+
+react-native-youtube-iframe@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-youtube-iframe/-/react-native-youtube-iframe-1.4.0.tgz#aa29d84ec1aa06b9700286f4360c8aef7ac40863"
+  integrity sha512-k6T5GT2EO+T5al165x+T5TVWSJ6/sF2iJPTOpxjgwpBNobYOIHq4/pJK08qYhTQIA4F+BSj7ElM6BQ2REjy5EQ==
+  dependencies:
+    events "^3.2.0"
 
 react-native@0.61.5:
   version "0.61.5"


### PR DESCRIPTION
## Explain the changes you’ve made

Add a popup containing an embedded youtube player, and that blurs the background.
Design input needed here, I just made something really simple to demonstrate that embedding videos work. 

## Explain why these changes are made

We want to be able to show helper videos in the app, possibly from various places, as described in [this task](https://app.clickup.com/t/amt4t2). 

## Explain your solution

I investigated what libraries could be used to do this, and settled on react-native-youtube-iframe, since it seems both simple and uniform across both OS's. Once that was fixed, everything is very easy, just display a popup with a partially darkened background and some minimal styling. One can do a lot more with the library, like starting playback automatically and triggering things when the video ends etc., but I kept it very simple for now.

A thing to note here and seemingly with all other libraries: many videos on youtube won't work. The uploader of the video can forbid it from being played in embedded players, which apparently most videos with copyright have. It is possible to get around this, but that seems a lot trickier, and since we control the videos that we want to show, I don't think this will be a problem for our use case.  

This popup can later be connected to some helper button, but here we really need both UX and graphical design to tell us how we want it. Depending on this, it can also be added to the form builder, but how exactly we do that depends on the UX.

## How to test the changes?

Check out the branch, run yarn or npm install. I don't think pod install is needed. Then go into storybook, and go to the Youtube Popup story, and press the button.

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

