### PR TITLE
Implemented complementary color schema o back nav

### DIFF
--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -43,12 +43,17 @@ const CloseButton = styled.View(props => ({
   margin: 0,
   height: 32,
   width: 32,
-  backgroundColor: props.theme.colors.primary[props.colorSchema][0],
+  backgroundColor: props.primary
+    ? props.theme.colors.primary[props.colorSchema][0]
+    : props.theme.colors.complementary[props.colorSchema][3],
 }));
 
-const CloseButtonIcon = styled(Icon).attrs(({ theme }) => ({
-  color: theme.colors.neutrals[7],
-}))``;
+const CloseButtonIcon = styled(Icon)`
+  color: ${props =>
+    props.primary
+      ? props.theme.colors.neutrals[7]
+      : props.theme.colors.primary[props.colorSchema][0]};
+`;
 
 const BackNavigation = ({
   style,
@@ -58,6 +63,7 @@ const BackNavigation = ({
   showBackButton,
   showCloseButton,
   inSubstep,
+  primary,
 }) =>
   !inSubstep ? (
     <BackNavigationWrapper style={style}>
@@ -70,8 +76,12 @@ const BackNavigation = ({
       )}
 
       {showCloseButton ? (
-        <CloseButton colorSchema={colorSchema} onStartShouldSetResponder={onClose}>
-          <CloseButtonIcon name="close" />
+        <CloseButton
+          primary={primary}
+          colorSchema={colorSchema}
+          onStartShouldSetResponder={onClose}
+        >
+          <CloseButtonIcon colorSchema={colorSchema} primary={primary} name="close" />
         </CloseButton>
       ) : null}
     </BackNavigationWrapper>
@@ -100,6 +110,7 @@ BackNavigation.propTypes = {
   showBackButton: PropTypes.bool,
   showCloseButton: PropTypes.bool,
   inSubstep: PropTypes.bool,
+  primary: PropTypes.bool,
 };
 
 BackNavigation.defaultProps = {
@@ -107,6 +118,7 @@ BackNavigation.defaultProps = {
   style: [],
   showBackButton: true,
   showCloseButton: true,
+  primary: true,
 };
 
 export default BackNavigation;

--- a/source/components/molecules/BackNavigation/BackNavigation.stories.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.stories.js
@@ -43,6 +43,7 @@ backNavigationStories.add('Color Schema Red', props => (
 
 backNavigationStories.add('Primary color schema', props => (
   <StoryWrapper {...props}>
+    <BackNavigation colorSchema="red" primary isBackBtnVisible={false} />
     <BackNavigation colorSchema="red" primary={false} isBackBtnVisible={false} />
   </StoryWrapper>
 ));

--- a/source/components/molecules/BackNavigation/BackNavigation.stories.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.stories.js
@@ -22,18 +22,27 @@ backNavigationStories.add('Color Schema Blue', props => (
     <BackNavigation isBackBtnVisible={false} />
   </StoryWrapper>
 ));
+
 backNavigationStories.add('Color Schema Purple', props => (
   <StoryWrapper {...props}>
     <BackNavigation colorSchema="purple" isBackBtnVisible={false} />
   </StoryWrapper>
 ));
+
 backNavigationStories.add('Color Schema Green', props => (
   <StoryWrapper {...props}>
     <BackNavigation colorSchema="green" isBackBtnVisible={false} />
   </StoryWrapper>
 ));
+
 backNavigationStories.add('Color Schema Red', props => (
   <StoryWrapper {...props}>
     <BackNavigation colorSchema="red" isBackBtnVisible={false} />
+  </StoryWrapper>
+));
+
+backNavigationStories.add('Primary color schema', props => (
+  <StoryWrapper {...props}>
+    <BackNavigation colorSchema="red" primary={false} isBackBtnVisible={false} />
   </StoryWrapper>
 ));


### PR DESCRIPTION
## Explain the changes you’ve made

I've added support for secondary/complementary color schema for "Back Navigation".

## Explain your solution

Added a primary prop to the component. Set to false if you want to use secondary color schema. Not sure if this is the best way but i'm open to suggestions. 

## How to test the changes?

Run StoryBook => BackNavigation => Primary color schema

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots 

<img width="56" alt="Screenshot 2020-12-04 at 09 09 54" src="https://user-images.githubusercontent.com/21363149/101166270-4a723800-3638-11eb-8331-38591c102fd7.png">
