### PR TITLE
Fix/input neutral color schema

### DIFF
--- a/source/components/atoms/Input/Input.stories.js
+++ b/source/components/atoms/Input/Input.stories.js
@@ -11,6 +11,7 @@ storiesOf('Input', module)
       <Input colorSchema="purple" placeholder="Purple input" center />
       <Input colorSchema="red" placeholder="Red input" />
       <Input colorSchema="green" placeholder="Green input" />
+      <Input colorSchema="neutral" placeholder="Neutral input" />
     </StoryWrapper>
   ))
   .add('Keyboard type numeric', () => (
@@ -19,6 +20,7 @@ storiesOf('Input', module)
       <Input colorSchema="purple" placeholder="Purple input" keyboardType="numeric" />
       <Input colorSchema="red" placeholder="Red input" keyboardType="numeric" />
       <Input colorSchema="green" placeholder="Green input" keyboardType="numeric" />
+      <Input colorSchema="neutral" placeholder="Neutral input" keyboardType="numeric" />
     </StoryWrapper>
   ))
   .add('Keyboard type phone pad', () => (
@@ -27,6 +29,7 @@ storiesOf('Input', module)
       <Input colorSchema="purple" placeholder="Purple input" keyboardType="phone-pad" />
       <Input colorSchema="red" placeholder="Red input" keyboardType="phone-pad" />
       <Input colorSchema="green" placeholder="Green input" keyboardType="phone-pad" />
+      <Input colorSchema="neutral" placeholder="Neutral input" keyboardType="phone-pad" />
     </StoryWrapper>
   ))
   .add('Input with failed validation', () => (

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -8,7 +8,7 @@ type InputProps = Omit<TextInputProps, 'onBlur'> & {
   onBlur: (value: string) => void;
   center?: boolean;
   transparent?: boolean;
-  colorSchema?: 'blue' | 'green' | 'red' | 'purple';
+  colorSchema?: 'neutral' | 'blue' | 'green' | 'red' | 'purple';
   showErrorMessage?: boolean;
   error?: { isValid: boolean; message: string };
   textAlign?: 'left' | 'center' | 'right';
@@ -17,8 +17,11 @@ type InputProps = Omit<TextInputProps, 'onBlur'> & {
 const StyledTextInput = styled.TextInput<InputProps>`
   width: 100%;
   font-weight: ${({ theme }) => theme.fontWeights[1]}
-  background-color: ${({ theme, colorSchema, transparent }) =>
-    transparent ? 'transparent' : theme.colors.complementary[colorSchema][2]};
+  background-color: ${props =>
+    props.colorSchema === 'neutral'
+      ? props.theme.colors.neutrals[5]
+      : props.theme.colors.complementary[props.colorSchema][2]};
+  ${({ transparent }) => transparent && `background-color: transparent;`}
   border-radius: 4.5px;
   border: solid 1px
   ${({ theme, error }) =>
@@ -65,7 +68,7 @@ Input.propTypes = {
   /**
    * Default is blue.
    */
-  colorSchema: PropTypes.oneOf(['blue', 'red', 'purple', 'green']),
+  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
   /** Whether or not to show the error message as red text below the input field */
   showErrorMessage: PropTypes.bool,
   error: PropTypes.shape({

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -16,7 +16,7 @@ type InputProps = Omit<TextInputProps, 'onBlur'> & {
 
 const StyledTextInput = styled.TextInput<InputProps>`
   width: 100%;
-  font-weight: ${({ theme }) => theme.fontWeights[1]}
+  font-weight: ${({ theme }) => theme.fontWeights[0]}
   background-color: ${props =>
     props.colorSchema === 'neutral'
       ? props.theme.colors.neutrals[5]
@@ -38,7 +38,7 @@ const StyledTextInput = styled.TextInput<InputProps>`
 const StyledErrorText = styled(Text)`
   font-size: ${({ theme }) => theme.fontSizes[3]};
   color: ${props => props.theme.textInput.errorTextColor};
-  font-weight: ${({ theme }) => theme.fontWeights[1]};
+  font-weight: ${({ theme }) => theme.fontWeights[0]};
   padding-top: 8px;
 `;
 


### PR DESCRIPTION
## Explain the changes you’ve made

Added neutral color schema to Input component. 
Also changed input font weight to 500 so it follows the Figma design.  

## How to test the changes?

Run Storybook => Input

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
