### PR TITLE
input: add a done button to the keyboard

### DIFF
--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextInputProps } from 'react-native';
+import { TextInputProps, Keyboard } from 'react-native';
 import styled, { useTheme } from 'styled-components/native';
 import Text from '../Text';
 
@@ -56,6 +56,11 @@ const Input: React.FC<InputProps> = ({ onBlur, showErrorMessage, ...props }) => 
         numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
         onBlur={handleBlur}
         placeholderTextColor={theme.colors.neutrals[1]}
+        returnKeyType="done"
+        blurOnSubmit
+        onSubmitEditing={() => {
+          Keyboard.dismiss();
+        }}
         {...props}
       />
       {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}

--- a/source/screens/LoginScreen.js
+++ b/source/screens/LoginScreen.js
@@ -268,7 +268,11 @@ function LoginScreen(props) {
           extraScrollHeight: 50,
         }}
       >
-        <CloseModalButton onClose={() => setModalVisible(false)} primary={false} showBackButton={false} />
+        <CloseModalButton
+          onClose={() => setModalVisible(false)}
+          primary={false}
+          showBackButton={false}
+        />
         <Body>
           <Header>
             <ModalHeading>Logga in med BankID på en annan enhet</ModalHeading>
@@ -294,6 +298,7 @@ function LoginScreen(props) {
               <Label strong>PERSONNUMMER</Label>
               <LoginInput
                 colorSchema="neutral"
+                returnKeyType={null}
                 placeholder="ååååmmddxxxx"
                 value={personalNumber}
                 onChangeText={handlePersonalNumber}


### PR DESCRIPTION
## Explain the changes you’ve made

Add a done button to the keyboard. 
[Clickup task](https://app.clickup.com/t/amt6pa)

## Explain your solution

Due to the refactoring of the input component, this just amounts to adding the required props to the Input component, and then it's applied all through the app. 

## How to test the changes?

Checkout this branch, go into a form or some story, and make sure to use the simulated keyboard. Then it should display a done-button, and clicking it should blur the field and dismiss the keyboard. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.