### PR TITLE
theme: add a first version of a neutral color schema to the theme

### DIFF
--- a/source/components/atoms/Checkbox/Checkbox.stories.js
+++ b/source/components/atoms/Checkbox/Checkbox.stories.js
@@ -61,6 +61,16 @@ const Checkboxes = injectProps => {
       </FlexRow>
       <FlexRow>
         <Checkbox
+          onChange={handleChange('box3')}
+          checked={checkboxValues.box3}
+          color="neutral"
+          size="small"
+          {...injectProps}
+        />
+        <Text>Small, neutral color scheme</Text>
+      </FlexRow>
+      <FlexRow>
+        <Checkbox
           onChange={handleChange('box4')}
           checked={checkboxValues.box4}
           color="purple"

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -17,10 +17,7 @@ type InputProps = Omit<TextInputProps, 'onBlur'> & {
 const StyledTextInput = styled.TextInput<InputProps>`
   width: 100%;
   font-weight: ${({ theme }) => theme.fontWeights[0]}
-  background-color: ${props =>
-    props.colorSchema === 'neutral'
-      ? props.theme.colors.neutrals[5]
-      : props.theme.colors.complementary[props.colorSchema][2]};
+  background-color: ${props => props.theme.colors.complementary[props.colorSchema][2]};
   ${({ transparent }) => transparent && `background-color: transparent;`}
   border-radius: 4.5px;
   border: solid 1px

--- a/source/components/molecules/CheckboxField/CheckboxField.stories.js
+++ b/source/components/molecules/CheckboxField/CheckboxField.stories.js
@@ -37,6 +37,14 @@ const CheckboxFields = () => {
         help={{ text: 'some other helper text' }}
       />
       <CheckboxField
+        text="Do you feel it? Neutral theme, small"
+        color="neutral"
+        size="small"
+        value={checkboxValues.box1}
+        onChange={handleChange('box1')}
+        help={{ text: 'some other helper text' }}
+      />
+      <CheckboxField
         text="Does it feel good? Can I ask longer questions here? How does it handle long strings?"
         color="red"
         size="small"

--- a/source/styles/palette.js
+++ b/source/styles/palette.js
@@ -9,6 +9,7 @@ const primary = {
   green: ['#205400', '#50811B', '#6F9725', '#80B14A'],
   red: ['#770000', '#AE0B05', '#B23700', '#E84C31'],
   purple: ['#4B0034', '#7B075E', '#9E166A', '#AD428B'],
+  neutral: ['#000000', '#3D3D3D', '#565656', '#707070'],
 };
 
 /**
@@ -22,6 +23,7 @@ const complementary = {
   green: ['#C9D6C2', '#E1E9DB', '#EAF0E4', '#F2F6EE'],
   red: ['#DEC2C2', '#F0DBD9', '#F5E4E3', '#FAEEEC'],
   purple: ['#D4C2CE', '#E8DAE4', '#EFE4EB', '#F6EDF3'],
+  neutral: ['#C5C5C5', '#D5D5D5', '#F5F5F5', '#FFFFFF'],
 };
 
 /**


### PR DESCRIPTION
## Explain the changes you’ve made

Add 'neutral' as a new color schema in the theme. 

## Explain why these changes are made

So that we can style our components in a neutral theme in the same way as we do with other colors. 

## Explain your solution

Just adds a first quick version of gray scale colors to the primary and secondary color palettes. 
And just check how it looks for some components, really only the checkbox and the input; for which I think it looks okay. 

## How to test the changes?

Checkout this branch, go into the storybook and check the input story and the checkboxField story, for examples of how it looks with this new color schema. 

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Anything else? (optional)

Should perhaps be checked for more components, but this is more of a forward looking thing, meant to be used anytime we need a neutral color theme. 