### PR TITLE
fix answer validation if there is no questions on the step

### DIFF
--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -318,7 +318,10 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
   const currentStepQuestions = state.steps[currentStepIndex].questions;
   let allInputsValid = true;
 
-  if (!currentStepQuestions) return state
+  if (!currentStepQuestions || currentStepQuestions.length === 0){
+    onValidCallback();
+    return state
+  } 
 
   // Set dirtyFields for handling input onFocus.
   let dirtyFields = {}


### PR DESCRIPTION
## Explain the changes you’ve made

I found a small bug in the validation on next, which somehow got through the review. This is a case of following the testing instructions and only testing it in that context, and it's a little tricky to spot from just reading the code. 

## Explain why these changes are made
If there was no questions on the step, the onValidCallback wouldn't trigger, and so you wouldn't go to the next step. 

## Explain your solution
Just add that it triggers the onValidCallback if there is no questions. 

## How to test the changes?

go into a form with an empty step, and check that the next-button work. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
