### PR TITLE
Replace tags  #månad-1 and #månad-2 with months

### DIFF
--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -12,11 +12,29 @@ const replacementRules = [
   ['#lastName', 'user.lastName'],
   ['#datum1', 'date.nextMonth.first'],
   ['#datum2', 'date.nextMonth.last'],
+  ['#månad-1', 'date.month.currentMonth-1'],
+  ['#månad-2', 'date.month.currentMonth-2'],
   ['#year', 'date.currentYear'], // this is the current year of next month
+];
+
+const swedishMonthTable = [
+  'januari',
+  'februari',
+  'mars',
+  'april',
+  'maj',
+  'juni',
+  'juli',
+  'augusti',
+  'september',
+  'oktober',
+  'november',
+  'december',
 ];
 
 const replaceDates = (descriptor: string[]): string => {
   const today = new Date();
+
   if (descriptor[1] === 'nextMonth') {
     const month = today.getMonth() + 2;
     if (descriptor[2] === 'first') {
@@ -27,10 +45,22 @@ const replaceDates = (descriptor: string[]): string => {
       return `${days}/${month}`;
     }
   }
+
   if (descriptor[1] === 'currentYear') {
     const year = new Date(today.getFullYear(), today.getMonth() + 1, 1).getFullYear();
     return `${year}`;
   }
+
+  if (descriptor[1] === 'month') {
+    const currentMonth = today.getMonth();
+    if (descriptor[2] === 'currentMonth-1') {
+      return `${swedishMonthTable[currentMonth - 1]}`;
+    }
+    if (descriptor[2] === 'currentMonth-2') {
+      return `${swedishMonthTable[currentMonth - 2]}`;
+    }
+  }
+
   return '';
 };
 

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -12,8 +12,8 @@ const replacementRules = [
   ['#lastName', 'user.lastName'],
   ['#datum1', 'date.nextMonth.first'],
   ['#datum2', 'date.nextMonth.last'],
-  ['#månad-1', 'date.month.currentMonth-1'],
-  ['#månad-2', 'date.month.currentMonth-2'],
+  ['#månad-1', 'date.previousMonth.currentMonth-1'],
+  ['#månad-2', 'date.previousMonth.currentMonth-2'],
   ['#year', 'date.currentYear'], // this is the current year of next month
 ];
 
@@ -51,7 +51,7 @@ const replaceDates = (descriptor: string[]): string => {
     return `${year}`;
   }
 
-  if (descriptor[1] === 'month') {
+  if (descriptor[1] === 'previousMonth') {
     const currentMonth = today.getMonth();
     if (descriptor[2] === 'currentMonth-1') {
       return `${swedishMonthTable[currentMonth - 1]}`;


### PR DESCRIPTION
## Explain the changes you’ve made

Added text replacement for tags #månad-1 and #månad-2 in form. 

## Explain why these changes are made

More info can be found in clickup: https://app.clickup.com/t/awvpcg

## Explain your solution

Replacing tags with date.getMonth() - nr of months.

## How to test the changes?

Test with a form with tag #månad-1 or #månad-2 in label or body. Currently form "Ekonomiskt bistånd - AMF: Löpande ansökan - för AMF att titta på", step 3 - Inkomster has a title "Hur får du pengar i #månad - 1". This title shall (today) be replaced with "Hur får du pengar i november".

## Was this feature tested in the following environments?
- [ ] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.

