### PR TITLE
case views: rename currentStep -> currentPosition

### DIFF
--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -84,7 +84,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
         <Form
           steps={form.steps}
           connectivityMatrix={form.connectivityMatrix}
-          initialPosition={caseData?.currentStep || initialCase?.currentStep}
+          initialPosition={caseData?.currentPosition || initialCase?.currentPosition}
           user={user}
           onClose={handleCloseForm}
           onStart={handleStartForm}

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -38,7 +38,7 @@ const colorSchema = 'red';
  */
 const computeCaseComponent = (status, latestCase, form, caseType, navigation, createCase) => {
   const updatedAt = latestCase?.updatedAt ? formatUpdatedAt(latestCase.updatedAt) : '';
-  const currentStep = latestCase?.currentStep?.currentMainStep || '';
+  const currentStep = latestCase?.currentPosition?.currentMainStep || '';
   const totalSteps = form?.stepStructure ? form.stepStructure.length : 0;
 
   switch (status) {

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -43,7 +43,7 @@ const CaseSummary = props => {
 
   const {
     status,
-    currentStep: { currentMainStep: currentStep } = {},
+    currentPosition: { currentMainStep: currentStep } = {},
     details: { administrators, period: { startDate, endDate } = {} } = {},
     updatedAt,
   } = caseData;


### PR DESCRIPTION
## Explain the changes you’ve made

The progressbar in the two case screens had stopped working after a change elsewhere in the app, and in the API, which changed a name of a property. This fixes that, so that the progressbar works as intended again. Also changes the same name in the FormCase screen so that resuming the form also works as intended again.


## Explain your solution

Just a name change in three places, currentStep -> currentPosition. 

## How to test the changes?

Check out this branch and check that the progressbars and resume form works as intended. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
