### PR TITLE
FormField: add the dynamic card renderer to FormField

### DIFF
--- a/source/components/molecules/FormField/FormField.js
+++ b/source/components/molecules/FormField/FormField.js
@@ -10,7 +10,7 @@ import SummaryList from '../../organisms/SummaryList/SummaryList';
 import RepeaterField from '../RepeaterField/RepeaterField';
 import theme from '../../../styles/theme';
 import RadioGroup from '../RadioGroup/RadioGroup';
-
+import DynamicCardRenderer from '../../../containers/DynamicCardRenderer/DynamicCardRenderer';
 /**
  * Explanation of the properties in this data structure:
  *
@@ -99,6 +99,9 @@ const inputTypes = {
     blurEvent: 'onBlur',
     changeEvent: 'onChange',
     props: {},
+  },
+  card: {
+    component: DynamicCardRenderer,
   },
 };
 

--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.stories.js
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.stories.js
@@ -40,7 +40,8 @@ const cardData2 = {
     {
       type: 'button',
       text: 'Do it!',
-      action: { type: 'email', email: 'test@test.com' },
+      action: 'email',
+      email: 'test@test.com',
       icon: 'email',
       iconPosition: 'left',
     },
@@ -59,7 +60,8 @@ const cardData3 = {
     {
       type: 'button',
       text: 'Do it!',
-      action: { type: 'navigate', email: 'test@test.com' },
+      action: 'navigate',
+      screen: 'UserEvents',
       icon: 'arrow-forward',
     },
   ],
@@ -90,7 +92,8 @@ const cardData5 = {
     {
       type: 'button',
       text: 'Helsingborg.se',
-      action: { type: 'url', url: 'https://www.helsingborg.se' },
+      action: 'url',
+      url: 'https://www.helsingborg.se',
       icon: 'arrow-forward',
     },
   ],

--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
@@ -33,30 +33,19 @@ interface Subtitle {
   text: string;
 }
 
-interface Button {
+interface ButtonBase {
   type: 'button';
   text: string;
   colorSchema?: 'blue' | 'red' | 'green' | 'purple';
   icon?: string;
   iconPosition?: 'left' | 'right';
-  action:
-    | {
-        type: 'email';
-        email: string;
-      }
-    | {
-        type: 'phone';
-        phonenumber: string;
-      }
-    | {
-        type: 'navigate';
-        screen: string;
-      }
-    | {
-        type: 'url',
-        url: string;
-    }
 }
+type Button = ButtonBase & (
+  { action: 'email'; email: string } |
+  { action: 'phone'; phonenumber: string } |
+  { action: 'url'; url: string } |
+  { action: 'navigate'; screen: string }
+);
 
 type CardComponent = Image | Text | Title | Subtitle | Button;
 /***** end of types */
@@ -82,20 +71,20 @@ const renderCardComponent = (component: CardComponent, navigation: any) => {
 
   // Treat buttons separately, because they have some more complicated behavior
   if (component.type === 'button') {
-    const { icon, iconPosition, text, action } = component;
+    const { icon, iconPosition, text } = component;
     let onClick: () => void = () => null;
-    switch (action.type) {
+    switch (component.action) {
       case 'email':
-        onClick = () => { launchEmail(action.email)};
+        onClick = () => { launchEmail(component.email)};
         break;
       case 'phone':
-        onClick = () => { launchPhone(action.phonenumber)};
+        onClick = () => { launchPhone(component.phonenumber)};
         break;
       case 'navigate':
-        onClick = () => { if (navigation?.navigate) navigation.navigate(action.screen) }; // TODO think about sending parameters here
+        onClick = () => { if (navigation?.navigate) navigation.navigate(component.screen) }; // TODO think about sending parameters here
         break;
       case 'url':
-        onClick = () => { Linking.openURL(action.url)};
+        onClick = () => { Linking.openURL(component.url)};
         break;
     }
     return (

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -41,8 +41,8 @@ function loadStories() {
 	require('../source/components/organisms/Step/StepFooter/StepFooter.stories');
 	require('../source/components/organisms/SummaryList/SummaryList.stories');
 	require('../source/components/organisms/YoutubePopup/YoutubePopup.stories');
+	require('../source/containers/DynamicCardRenderer/DynamicCardRenderer.stories');
 	require('../source/containers/Form/Form.stories');
-	require('../source/containers/RenderCard/DynamicCardRenderer.stories');
 }
 
 const stories = [
@@ -83,8 +83,8 @@ const stories = [
 	'../source/components/organisms/Step/StepFooter/StepFooter.stories',
 	'../source/components/organisms/SummaryList/SummaryList.stories',
 	'../source/components/organisms/YoutubePopup/YoutubePopup.stories',
-	'../source/containers/Form/Form.stories',
-	'../source/containers/RenderCard/DynamicCardRenderer.stories'
+	'../source/containers/DynamicCardRenderer/DynamicCardRenderer.stories',
+	'../source/containers/Form/Form.stories'
 ];
 
 module.exports = {


### PR DESCRIPTION
## Explain the changes you’ve made

Add the Card as a possible component type inside FormField, using the dynamic card render logic. 
Small structure change in the data format that DynamicCardRenderer accepts, to flatten it and simplify it a little. 

## Explain why these changes are made

So that we can actually control the cards from the backend, and don't have to do any ugly hardcoded solutions. 

## Explain your solution

Adds card as an allowed component type in FormField. 

Change the data structure from having {..., action: {type, email/phonenumber/...}} to the flatter {..., action, email/phonenumber/...}. This is flatter, which makes things in the form builder a little better. This change leads to some small adjustment in the card renderer and the accompanying story. 

Also change the name of a folder, that I forgot to do previously. 

## How to test the changes?

Checkout this branch, and go into the Test form on dev, where at the end of the first page a dynamically rendered card should show up, with a working button linking to a website. 
Also, in the grupperingstest form also in dev, on the second page there's some more examples of dynamic cards. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
