### PR TITLE
summary list: add a check that the value is an array

### DIFF
--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -187,6 +187,8 @@ const SummaryList: React.FC<Props> = ({
               addToSum(numericValue);
             }
           });
+        } else if (values && values?.length > 0) {
+          console.log(`Possible type error in the form; SummaryList ${heading}, at item {id:${item.id}, inputId: ${item?.inputId}, title: ${item.title}} expected to get values as array, but got something else. Check the form configuration.`);
         }
       } else {
         listItems.push(

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -170,7 +170,7 @@ const SummaryList: React.FC<Props> = ({
     .forEach(item => {
       if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {
         const values: Record<string, string | number>[] = answers[item.id];
-        if (values && values?.length > 0) {
+        if (values && values?.length > 0 && Array.isArray(values)) {
           values.forEach((v, index) => {
             listItems.push(
               generateListItem(


### PR DESCRIPTION
## Explain the changes you’ve made
 
Improve a fail-safe check in the summary list to avoid hard crashes from one kind of wrong form input. 

## Explain your solution

In the summary list, when summarising values from repeaters, the value should be an array. However it is possible to mess this up in the form-builder, so that you set the type to "arrayNumber" but point it to a regular number. In that case, the current checks would return true, but the app would then crash when trying to call forEach on a string. 

This adds a check that the value is indeed an array, and logs an error message for diagnostics if the value is of the wrong type. This should help us catch wrongly configured things in summary lists more easily. 

## How to test the changes?
Misconfigure a form, and check if it still breaks the app.
However, I fixed the cases in EKB-Löpande that I found, but there might be more. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
