### PR TITLE
Fix (android): building and loading .env-file after RN upgrade

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile
 


### PR DESCRIPTION
## Explain the changes you’ve made

While setting up an Android environment (on a Windows machine, unsure if that matters) after the RN upgrade, I ran into some small issues with old versions as well as the .env config not loading. These two changes fixes that.

## Explain your solution

One change updates the minimal Android SDK version to a newer one, which seems to be required after the RN upgrade.

The other is mentioned in the 'react-native-config' library as being required for the reading of .env to work on android. 

## How to test the changes?

Build the upgraded RN app on android, and check that the .env file is loaded correctly. 


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

