### PR TITLE
fix tab-bar images showing up correctly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -82,7 +82,8 @@
       {
         "trailingComma": "es5",
         "singleQuote": true,
-        "printWidth": 100
+        "printWidth": 100,
+        "endOfLine": "auto"
       }
     ],
     "jsx-a11y/anchor-is-valid": [

--- a/source/components/molecules/TabBarImage/TabBarImage.js
+++ b/source/components/molecules/TabBarImage/TabBarImage.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { Image } from 'react-native-elements';
-import PropTypes from 'prop-types';
-
-const TabBarImage = (src) => () => <Image source={src} style={{ width: 25, height: 25 }} />;
-TabBarImage.propTypes = {
-  src: PropTypes.string,
-};
-export default TabBarImage;

--- a/source/components/molecules/TabBarImage/index.js
+++ b/source/components/molecules/TabBarImage/index.js
@@ -1,1 +1,0 @@
-export { default } from './TabBarImage';

--- a/source/components/molecules/index.ts
+++ b/source/components/molecules/index.ts
@@ -9,7 +9,6 @@ export { default as ListItem } from './ListItem';
 export { default as ScreenWrapper } from './ScreenWrapper';
 export { default as StoryWrapper } from './StoryWrapper';
 export { default as HelpButton } from './HelpButton';
-export { default as TabBarImage } from './TabBarImage';
 export { default as EditableList } from './EditableList';
 export { default as CheckboxField } from './CheckboxField';
 export { default as Modal } from './Modal';

--- a/source/navigator/BottomBarNavigator.js
+++ b/source/navigator/BottomBarNavigator.js
@@ -1,10 +1,15 @@
 /* eslint-disable global-require */
 import React from 'react';
+import styled from 'styled-components/native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { ProfileScreen, HomeScreen } from '../screens';
-import { TabBarImage } from '../components/molecules';
 import CaseNavigator from './CaseNavigator';
 import TabNavigator from '../components/molecules/TabNavigator';
+
+const TabBarImage = styled.Image`
+  width: 25px;
+  height: 25px;
+`;
 
 const Tab = createMaterialTopTabNavigator();
 const BottomBarStack = () => (
@@ -14,8 +19,8 @@ const BottomBarStack = () => (
       component={CaseNavigator}
       options={{
         title: 'Ärende',
-        tabBarIcon: TabBarImage(require('../images/task_3x.png')),
-        tabBarIconInactive: TabBarImage(require('../images/task_3x_gray.png')),
+        tabBarIcon: () => <TabBarImage source={require('../images/task_3x.png')} />,
+        tabBarIconInactive: () => <TabBarImage source={require('../images/task_3x_gray.png')} />,
         tabBarLabel: 'Ärende',
       }}
     />
@@ -26,8 +31,8 @@ const BottomBarStack = () => (
         headerTintColor: 'black',
         tabBarLabel: 'Sally',
         title: 'Sally',
-        tabBarIcon: TabBarImage(require('../images/chat_3x.png')),
-        tabBarIconInactive: TabBarImage(require('../images/chat_3x_gray.png')),
+        tabBarIcon: () => <TabBarImage source={require('../images/chat_3x.png')} />,
+        tabBarIconInactive: () => <TabBarImage source={require('../images/chat_3x_gray.png')} />,
       }}
     />
     <Tab.Screen
@@ -35,8 +40,8 @@ const BottomBarStack = () => (
       component={ProfileScreen}
       options={{
         title: 'Profil',
-        tabBarIcon: TabBarImage(require('../images/profile_3x.png')),
-        tabBarIconInactive: TabBarImage(require('../images/profile_3x_gray.png')),
+        tabBarIcon: () => <TabBarImage source={require('../images/profile_3x.png')} />,
+        tabBarIconInactive: () => <TabBarImage source={require('../images/profile_3x_gray.png')} />,
         tabBarLabel: 'Profil',
       }}
     />


### PR DESCRIPTION
## Explain the changes you’ve made

After RN upgrade, images were generally loading correctly but the tab bar images were not showing correctly. This fixes that, and also removes the unneccessary TabBarImage component. 

## Explain your solution

The TabBarImage component was using an Image component from 'react-native-elements', which  seems to have put a gray overlay over the images. Our other images are loaded using just react-native, and there's really no need (as far as I can see) for the other library here, so I just change so that we display these images using a styled Image-component from react native. 

I also did not see the need for a separate component for something that was essentially two lines of CSS, so I remove the TabBarImage component and replace it with a styled Image in the BottomBarNavigator class. 

The eslint-change is because I got some strange, incorrect linting complaints when loading our source code on a windows system. 

## How to test the changes?

Checkout this branch, go into the app and see if the bottom nav bar images show up correctly. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.