### PR TITLE
CloseDialog: fix layout

### DIFF
--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -23,9 +23,7 @@ const PopupContainer = styled.View`
   top: 33%;
   left: 10%;
   right: 10%;
-  bottom: 0;
   padding: 0px;
-  max-height: 50%;
   width: 80%;
   background-color: white;
   flex-direction: column;
@@ -36,7 +34,7 @@ const PopupContainer = styled.View`
 `;
 const ContentContainer = styled.View`
   padding: 10px;
-  padding-bottom: 20px;
+  padding-bottom: 15px;
   flex-direction: column;
   justify-content: space-between;
   flex: 10;
@@ -44,8 +42,8 @@ const ContentContainer = styled.View`
 const ButtonRow = styled.View`
   flex-direction: row;
   justify-content: space-evenly;
-  padding: 20px;
-  margin-bottom: 10px;
+  padding: 15px;
+  margin-bottom: 0px;
 `;
 
 interface Props {


### PR DESCRIPTION
## Explain the changes you’ve made

The CloseDialog layout on Android devices on smaller screens was broken, making the buttons not work, so you got stuck on the confirmation popup.

## Explain your solution

Some of the layout CSS (that I wrote) was pants-on-head stupid; the "bottom: 0" plus "max-height" at the same time is not a good idea, and does not deal with varying screen sizes in a good way. Hopefully it's now better and will work okay on both iPhones and smaller screened android devices. 

## How to test the changes?

Go into a form and click on the exit button, and look at the close dialog, and test that its buttons work. Check that it looks okay on both iOs and Android, that's really the relevant part. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
