### PR TITLE
Fix/android release build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ buck-out/
 
 # Jest
 coverage/
+
+# Android Keystore
+keystore.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,11 @@ apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.grad
 
 import com.android.build.OutputFile
 
+// Load keystore
+def keystorePropertiesFile = rootProject.file("keystore.properties");
+def keystoreProperties = new Properties()
+keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
  * and bundleReleaseJsAndAssets).
@@ -151,6 +156,14 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        release {
+            if (keystoreProperties['MH_UPLOAD_STORE_FILE']) {
+                storeFile file(keystoreProperties['MH_UPLOAD_STORE_FILE'])
+                storePassword keystoreProperties['MH_UPLOAD_STORE_PASSWORD']
+                keyAlias keystoreProperties['MH_UPLOAD_KEY_ALIAS']
+                keyPassword keystoreProperties['MH_UPLOAD_KEY_PASSWORD']
+            }
+        }
     }
     buildTypes {
         debug {
@@ -159,9 +172,9 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            signingConfig signingConfigs.release
         }
     }
 

--- a/android/example.keystore.properties
+++ b/android/example.keystore.properties
@@ -1,0 +1,4 @@
+MH_UPLOAD_STORE_FILE=mitt-helsingborg-upload-key.keystore
+MH_UPLOAD_KEY_ALIAS=mitt-helsingborg
+MH_UPLOAD_STORE_PASSWORD=******
+MH_UPLOAD_KEY_PASSWORD=******


### PR DESCRIPTION
## Explain the changes you’ve made

Updated build.gradle file with release config to be able to sign and create release bundles for Android.

## Explain your solution

I followed this guide: https://reactnative.dev/docs/signed-apk-android.
But instead of storing the signing key values in _gradle.properties_ i added them in a new file called _keystore.properties_ which is excluded in .gitignore to avoid publishing our signing keys. 

## How to test the changes?

Test it by creating a release build for Android by following this guide: https://reactnative.dev/docs/signed-apk-android

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.