### PR TITLE
fix: add neutral colorscheme for repeater and fieldset

### DIFF
--- a/source/styles/theme.js
+++ b/source/styles/theme.js
@@ -217,6 +217,13 @@ const theme = {
       iconRight: deprecatedPalette.mono.light,
       shadow: 'rgba(255, 255, 255, 0.0)',
     },
+    neutral: {
+      background: deprecatedPalette.mono.lightest,
+      text: deprecatedPalette.mono.darker,
+      icon: deprecatedPalette.purple[1],
+      iconRight: deprecatedPalette.mono.light,
+      shadow: 'rgba(255, 255, 255, 0.0)',
+    },
     gray: {
       background: deprecatedPalette.mono.lighter,
       text: deprecatedPalette.mono.darker,
@@ -626,6 +633,12 @@ const theme = {
       background: colorPalette.complementary.purple[3],
       backgroundEmpty: colorPalette.complementary.purple[3],
     },
+    neutral: {
+      legend: colorPalette.primary.neutral[0],
+      legendBorder: colorPalette.complementary.neutral[1],
+      background: colorPalette.complementary.neutral[3],
+      backgroundEmpty: colorPalette.complementary.neutral[3],
+    },
     darkBlue: {
       legend: colorPalette.neutrals[7],
       legendBorder: 'rgba(0, 33, 63, 0.24)',
@@ -651,6 +664,11 @@ const theme = {
     },
     purple: {
       inputBackground: colorPalette.complementary.purple[2],
+      deleteButton: '#DD6161',
+      inputText: colorPalette.neutrals[1],
+    },
+    neutral: {
+      inputBackground: colorPalette.complementary.neutral[2],
       deleteButton: '#DD6161',
       inputText: colorPalette.neutrals[1],
     },


### PR DESCRIPTION
## Explain the changes you’ve made

Adds configuration to theme so that the repeater and fieldset works with the neutral color theme.

## Explain why these changes are made

If the repeater was given a neutral color, it crashed the app. 

## Explain your solution

Just adds the configuration to the theme.

## How to test the changes?

Added a step to the test form in dev, which has all the components in neutral theme.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
