### PR TITLE
fix a LayoutAnimation bug on android

### DIFF
--- a/source/components/atoms/RadioButton/RadioButton.tsx
+++ b/source/components/atoms/RadioButton/RadioButton.tsx
@@ -44,7 +44,16 @@ interface Props {
 const RadioButton: React.FC<Props> = ({ selected, onSelect, colorSchema, size }) => {
   const theme = useContext(ThemeContext);
   const onPress = () => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    LayoutAnimation.configureNext({
+      duration: 300,
+      create: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+        property: LayoutAnimation.Properties.opacity,
+      },
+      update: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+      },
+    });
     onSelect();
   };
   const validColorSchema = getValidColorSchema(colorSchema);

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -92,7 +92,16 @@ function EditableList({
   const [editable, setEditable] = useState(startEditable);
   const [state, setState] = useState(getInitialState(inputs, value));
   const changeEditable = () => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    LayoutAnimation.configureNext({
+      duration: 300,
+      create: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+        property: LayoutAnimation.Properties.opacity,
+      },
+      update: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+      },
+    });
     setEditable(!editable);
   };
 

--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components/native';
 import { Help } from '../../../types/FormTypes';
 import Text from '../../atoms/Text';
 import Fieldset, { FieldsetButton } from '../../atoms/Fieldset/Fieldset';
-import { colorPalette } from '../../../styles/palette';
 import theme from '../../../styles/theme';
 import { getValidColorSchema, PrimaryColor } from '../../../styles/themeHelpers';
 import { Heading } from '../../atoms';
@@ -19,16 +18,16 @@ const ListBody = styled.View`
 const ListBodyFieldLabel = styled(Heading)<{ colorSchema: string }>`
   margin-top: 5px;
   margin-left: 3px;
-  font-weight: ${props => props.theme.fontWeights[1]};
-  font-size: ${props => props.theme.fontSizes[3]};
-  color: ${props => props.theme.colors.primary[props.colorSchema][1]};
+  font-weight: ${(props) => props.theme.fontWeights[1]};
+  font-size: ${(props) => props.theme.fontSizes[3]};
+  color: ${(props) => props.theme.colors.primary[props.colorSchema][1]};
 `;
 
 interface Props {
   heading?: string;
   items: { category: string; component: JSX.Element }[];
   categories: { category: string; description: string }[];
-  colorSchema: string;
+  colorSchema: PrimaryColor;
   showEditButton?: boolean;
   startEditable?: boolean;
   help?: Help;
@@ -51,12 +50,21 @@ const GroupedList: React.FC<Props> = ({
 
   const groupedItems: Record<string, { category: string; component: JSX.Element }[]> = {};
   const changeEditable = () => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    LayoutAnimation.configureNext({
+      duration: 300,
+      create: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+        property: LayoutAnimation.Properties.opacity,
+      },
+      update: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+      },
+    });
     setEditable(!editable);
   };
 
-  categories.forEach(cat => {
-    const catItems = items.filter(item => item.category === cat.category);
+  categories.forEach((cat) => {
+    const catItems = items.filter((item) => item.category === cat.category);
     if (catItems.length > 0) {
       groupedItems[cat.category] = catItems;
     }
@@ -87,9 +95,9 @@ const GroupedList: React.FC<Props> = ({
         {Object.keys(groupedItems).map((key, index) => (
           <View key={`${index}-${key}`}>
             <ListBodyFieldLabel colorSchema={validColorSchema}>
-              {categories.find(c => c.category === key).description}
+              {categories.find((c) => c.category === key).description}
             </ListBodyFieldLabel>
-            {groupedItems[key].map(item => ({
+            {groupedItems[key].map((item) => ({
               ...item.component,
               props: { ...item.component.props, editable },
             }))}

--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -60,7 +60,16 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
   };
 
   const addAnswer = () => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    LayoutAnimation.configureNext({
+      duration: 300,
+      create: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+        property: LayoutAnimation.Properties.opacity,
+      },
+      update: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+      },
+    });
     setLocalAnswers(prev => [...prev, {}]);
   };
 

--- a/source/components/molecules/TabNavigator/TabNavigatorItem.tsx
+++ b/source/components/molecules/TabNavigator/TabNavigatorItem.tsx
@@ -65,7 +65,16 @@ const TabNavigatorItem: React.FC<Props> = ({
         target: route.key,
         canPreventDefault: true,
       });
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+      LayoutAnimation.configureNext({
+        duration: 300,
+        create: {
+          type: LayoutAnimation.Types.easeInEaseOut,
+          property: LayoutAnimation.Properties.opacity,
+        },
+        update: {
+          type: LayoutAnimation.Types.easeInEaseOut,
+        },
+      });
       if (!event.defaultPrevented) {
         navigation.dispatch({
           ...TabActions.jumpTo(route.name),

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -181,7 +181,17 @@ const FormField = ({
     );
 
   if (checkCondition(conditionalOn)) {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    LayoutAnimation.configureNext({
+      duration: 300,
+      create: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+        property: LayoutAnimation.Properties.opacity,
+      },
+      update: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+      },
+    });
+
     return (
       <View>
         {label ? (


### PR DESCRIPTION
## Explain the changes you’ve made

Fix a bug where rapidly toggling the edit-button in summary list crashed the app on android, which is an issue with the layout animation. A simple fix where you just replace the animation configuration with a slightly different one, was suggested on a discussion of the issue, and seems to fix it, and work on both iOs and Android.

## Explain your solution

Just replace the LayoutAnimation.configureNext everywhere. 

## How to test the changes?

Go anywhere with a summary list with  a few items, and click the edit button repeatedly, on Android. It should not crash.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.