### PR TITLE
feat(scroll-to-top): scroll to the top when going between pages in a form

### DIFF
--- a/source/components/molecules/ScreenWrapper.js
+++ b/source/components/molecules/ScreenWrapper.js
@@ -1,18 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import styled from 'styled-components/native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
-const Container = styled(KeyboardAwareScrollView)`
+const ScreenWrapper = styled(KeyboardAwareScrollView)`
   flex: 1;
   background-color: ${(props) => props.theme.colors.neutrals[6]};
 `;
-
-const ScreenWrapper = (props) => {
-  const { style, children } = props;
-
-  return <Container style={style}>{children}</Container>;
-};
 
 ScreenWrapper.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
-import { Text } from 'react-native';
+import { Text, Animated } from 'react-native';
 import styled from 'styled-components/native';
 import FormField from '../../../containers/FormField';
 import AuthContext from '../../../store/AuthContext';
@@ -97,98 +97,119 @@ function Step({
   const inSubstep = currentPosition.level !== 0;
   const backButtonBehavior = inSubstep ? formNavigation.goToMainForm : formNavigation.back;
 
+  const [fadeValue] = useState(new Animated.Value(0));
+
+  useEffect(() => {
+    const fadeIn = () => {
+      Animated.timing(fadeValue, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+        isInteraction: false,
+      }).start();
+    };
+    fadeIn();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <StepContainer>
-      <CloseDialog
-        visible={closeDialogVisible}
-        closeForm={closeForm}
-        closeDialog={() => setCloseDialogVisible(false)}
-      />
-      <StepBackNavigation
-        showBackButton={isBackBtnVisible}
-        inSubstep={inSubstep}
-        onBack={backButtonBehavior}
-        onClose={() => setCloseDialogVisible(true)}
-        colorSchema={colorSchema || 'blue'}
-      />
-      <StepContentContainer
-        contentContainerStyle={{
-          flexGrow: 1,
+      <Animated.View
+        style={{
+          opacity: fadeValue,
         }}
-        showsHorizontalScrollIndicator={false}
       >
-        {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
-          <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
-        )}
-        {currentPosition.level === 0 && (
-          <Progressbar
-            currentStep={currentPosition.currentMainStep}
-            totalStepNumber={totalStepNumber}
-          />
-        )}
-        <StepBody>
-          {(isResolved || isIdle) && (
-            <>
-              <StepDescription
-                theme={theme}
-                currentStep={
-                  currentPosition.level === 0 ? currentPosition.currentMainStep : undefined
-                }
-                totalStepNumber={totalStepNumber}
-                colorSchema={colorSchema || 'blue'}
-                {...description}
-              />
-              {questions && (
-                <StepFieldListWrapper>
-                  {questions.map((field) => (
-                    <FormField
-                      key={`${field.id}`}
-                      onChange={status === 'ongoing' ? onFieldChange : null}
-                      onBlur={onFieldBlur}
-                      inputType={field.type}
-                      value={answers[field.id] || ''}
-                      answers={answers}
-                      validationErrors={validation}
-                      colorSchema={field.color && field.color !== '' ? field.color : colorSchema}
-                      id={field.id}
-                      formNavigation={formNavigation}
-                      {...field}
-                    />
-                  ))}
-                </StepFieldListWrapper>
-              )}
-            </>
+        <CloseDialog
+          visible={closeDialogVisible}
+          closeForm={closeForm}
+          closeDialog={() => setCloseDialogVisible(false)}
+        />
+        <StepBackNavigation
+          showBackButton={isBackBtnVisible}
+          inSubstep={inSubstep}
+          onBack={backButtonBehavior}
+          onClose={() => setCloseDialogVisible(true)}
+          colorSchema={colorSchema || 'blue'}
+        />
+        <StepContentContainer
+          contentContainerStyle={{
+            flexGrow: 1,
+          }}
+          showsHorizontalScrollIndicator={false}
+        >
+          {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
+            <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
           )}
+          {currentPosition.level === 0 && (
+            <Progressbar
+              currentStep={currentPosition.currentMainStep}
+              totalStepNumber={totalStepNumber}
+            />
+          )}
+          <StepBody>
+            {(isResolved || isIdle) && (
+              <>
+                <StepDescription
+                  theme={theme}
+                  currentStep={
+                    currentPosition.level === 0 ? currentPosition.currentMainStep : undefined
+                  }
+                  totalStepNumber={totalStepNumber}
+                  colorSchema={colorSchema || 'blue'}
+                  {...description}
+                />
+                {questions && (
+                  <StepFieldListWrapper>
+                    {questions.map((field) => (
+                      <FormField
+                        key={`${field.id}`}
+                        onChange={status === 'ongoing' ? onFieldChange : null}
+                        onBlur={onFieldBlur}
+                        inputType={field.type}
+                        value={answers[field.id] || ''}
+                        answers={answers}
+                        validationErrors={validation}
+                        colorSchema={field.color && field.color !== '' ? field.color : colorSchema}
+                        id={field.id}
+                        formNavigation={formNavigation}
+                        {...field}
+                      />
+                    ))}
+                  </StepFieldListWrapper>
+                )}
+              </>
+            )}
 
-          {isLoading && (
-            <SignStepWrapper>
-              <AuthLoading
-                cancelSignIn={() => handleCancelOrder()}
-                isBankidInstalled={isBankidInstalled}
-              />
-            </SignStepWrapper>
-          )}
+            {isLoading && (
+              <SignStepWrapper>
+                <AuthLoading
+                  cancelSignIn={() => handleCancelOrder()}
+                  isBankidInstalled={isBankidInstalled}
+                />
+              </SignStepWrapper>
+            )}
 
-          {/* TODO: Fix how to display error messages */}
-          {isRejected && (
-            <SignStepWrapper>
-              <Text>{error && error.message}</Text>
-            </SignStepWrapper>
-          )}
-        </StepBody>
-        {actions && actions.length > 0 ? (
-          <StepFooter
-            actions={actions}
-            caseStatus={status}
-            answers={answers}
-            formNavigation={formNavigation}
-            currentPosition={currentPosition}
-            onUpdate={onFieldChange}
-            updateCaseInContext={updateCaseInContext}
-            validateStepAnswers={validateStepAnswers}
-          />
-        ) : null}
-      </StepContentContainer>
+            {/* TODO: Fix how to display error messages */}
+            {isRejected && (
+              <SignStepWrapper>
+                <Text>{error && error.message}</Text>
+              </SignStepWrapper>
+            )}
+          </StepBody>
+          {actions && actions.length > 0 ? (
+            <StepFooter
+              actions={actions}
+              caseStatus={status}
+              answers={answers}
+              formNavigation={formNavigation}
+              currentPosition={currentPosition}
+              onUpdate={onFieldChange}
+              updateCaseInContext={updateCaseInContext}
+              validateStepAnswers={validateStepAnswers}
+            />
+          ) : null}
+        </StepContentContainer>
+      </Animated.View>
     </StepContainer>
   );
 }

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -1,11 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { Text } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 import FormField from '../../../containers/FormField';
 import AuthContext from '../../../store/AuthContext';
-import globalTheme from '../../../styles/theme';
 import Progressbar from '../../atoms/Progressbar/Progressbar';
 import { AuthLoading } from '../../molecules';
 import BackNavigation from '../../molecules/BackNavigation/BackNavigation';
@@ -101,10 +99,6 @@ function Step({
 
   return (
     <StepContainer>
-      <SafeAreaView
-        style={{ backgroundColor: globalTheme.colors.complementary[colorSchema || 'blue'][0] }}
-        edges={['top', 'right', 'left']}
-      />
       <CloseDialog
         visible={closeDialogVisible}
         closeForm={closeForm}

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -19,7 +19,7 @@ const StepContainer = styled.View`
   flex: 1;
 `;
 
-const StepContentContainer = styled.ScrollView`
+const StepContentContainer = styled.View`
   /* Covers space occupied by the StepBackNavigation */
   margin-top: -80px;
   height: 100%;

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -10,6 +10,8 @@ import { User } from '../../types/UserTypes';
 import useForm, { FormReducerState, FormPosition } from './hooks/useForm';
 import Modal from '../../components/molecules/Modal';
 import { ScrollView } from 'react-native-gesture-handler';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import theme from '../../styles/theme';
 
 const FormScreenWrapper = styled(ScreenWrapper)`
   padding: 0;
@@ -124,12 +126,18 @@ const Form: React.FC<Props> = ({
     }
   }, [mainStep, scrollViewRef]);
 
+  const colorSchema = formState?.steps[formState.currentPosition.currentMainStepIndex]?.colorSchema || 'blue';
+
   return (
     <FormScreenWrapper
       innerRef={(ref) => {
         setRef((ref as unknown) as ScrollView);
       }}
     >
+      <SafeAreaView
+        style={{ backgroundColor: theme.colors.complementary[colorSchema || 'blue'][0] }}
+        edges={['top', 'right', 'left']}
+      />
       {stepComponents[formState.currentPosition.currentMainStepIndex]}
       <Modal visible={formState.currentPosition.level > 0}>
         {stepComponents[formState.currentPosition.index]}

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { Ref, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { InteractionManager } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
@@ -44,7 +44,6 @@ const Form: React.FC<Props> = ({
   connectivityMatrix,
   user,
   onClose,
-  onStart,
   onSubmit,
   initialAnswers,
   status,
@@ -82,14 +81,13 @@ const Form: React.FC<Props> = ({
   };
 
   const stepComponents = formState.steps.map(
-    ({ id, banner, theme, title, group, description, questions, actions, colorSchema }) => (
+    ({ id, banner, title, group, description, questions, actions, colorSchema }) => (
       <Step
         key={`${id}`}
         banner={{
           ...banner,
         }}
         colorSchema={colorSchema}
-        theme={theme}
         description={{
           heading: title,
           tagline: group,
@@ -138,6 +136,55 @@ const Form: React.FC<Props> = ({
       </Modal>
     </FormScreenWrapper>
   );
+};
+
+Form.propTypes = {
+  /**
+   * FormPosition object that determines where to start the form.
+   */
+  initialPosition: PropTypes.shape({
+    index: PropTypes.number,
+    level: PropTypes.number,
+    currentMainStep: PropTypes.number,
+    currentMainStepIndex: PropTypes.number,
+  }),
+  /**
+   * Function to handle a close action in the form.
+   */
+  onClose: PropTypes.func.isRequired,
+  /**
+   * Function to handle when a form should start.
+   */
+  onStart: PropTypes.func.isRequired,
+  /**
+   * Function to handle when a form is submitting.
+   */
+  onSubmit: PropTypes.func.isRequired,
+  /**
+   * Array of steps that the Form should render.
+   */
+  steps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  connectivityMatrix: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)),
+  /**
+   * The user info.
+   */
+  user: PropTypes.object,
+  /**
+   * Initial answer for each question.
+   */
+  initialAnswers: PropTypes.object,
+  /**
+   * Status, either ongoing or submitted (or others, possibly?)
+   */
+  status: PropTypes.oneOf(['ongoing', 'submitted']),
+  /**
+   * function for updating case in caseContext
+   */
+  updateCaseInContext: PropTypes.func,
+};
+
+Form.defaultProps = {
+  initialAnswers: {},
 };
 
 export default Form;

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,16 +1,19 @@
-import React from 'react';
+import React, { Ref, useEffect, useState } from 'react';
+import { InteractionManager } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import Step from '../../components/organisms/Step/Step';
+import { ScreenWrapper } from '../../components/molecules';
 import { Step as StepType, StepperActions } from '../../types/FormTypes';
 import { CaseStatus } from '../../types/CaseType';
 import { User } from '../../types/UserTypes';
 import useForm, { FormReducerState, FormPosition } from './hooks/useForm';
 import Modal from '../../components/molecules/Modal';
+import { ScrollView } from 'react-native-gesture-handler';
 
-const FormContainer = styled.View`
+const FormScreenWrapper = styled(ScreenWrapper)`
+  padding: 0;
   flex: 1;
-  height: auto;
 `;
 
 interface Props {
@@ -112,65 +115,29 @@ const Form: React.FC<Props> = ({
       />
     )
   );
+
+  const mainStep = formState.currentPosition.currentMainStepIndex;
+  const [scrollViewRef, setRef] = useState<ScrollView>(null);
+  useEffect(() => {
+    if (scrollViewRef && scrollViewRef?.scrollTo) {
+      InteractionManager.runAfterInteractions(() => {
+        scrollViewRef.scrollTo({ x: 0, y: 0, animated: false });
+      });
+    }
+  }, [mainStep, scrollViewRef]);
+
   return (
-    <>
-      <FormContainer>
-        {stepComponents[formState.currentPosition.currentMainStepIndex]}
-      </FormContainer>
+    <FormScreenWrapper
+      innerRef={(ref) => {
+        setRef((ref as unknown) as ScrollView);
+      }}
+    >
+      {stepComponents[formState.currentPosition.currentMainStepIndex]}
       <Modal visible={formState.currentPosition.level > 0}>
         {stepComponents[formState.currentPosition.index]}
       </Modal>
-    </>
+    </FormScreenWrapper>
   );
-};
-
-Form.propTypes = {
-  /**
-   * FormPosition object that determines where to start the form.
-   */
-  initialPosition: PropTypes.shape({
-    index: PropTypes.number,
-    level: PropTypes.number,
-    currentMainStep: PropTypes.number,
-    currentMainStepIndex: PropTypes.number,
-  }),
-  /**
-   * Function to handle a close action in the form.
-   */
-  onClose: PropTypes.func.isRequired,
-  /**
-   * Function to handle when a form should start.
-   */
-  onStart: PropTypes.func.isRequired,
-  /**
-   * Function to handle when a form is submitting.
-   */
-  onSubmit: PropTypes.func.isRequired,
-  /**
-   * Array of steps that the Form should render.
-   */
-  steps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  connectivityMatrix: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)),
-  /**
-   * The user info.
-   */
-  user: PropTypes.object,
-  /**
-   * Initial answer for each question.
-   */
-  initialAnswers: PropTypes.object,
-  /**
-   * Status, either ongoing or submitted (or others, possibly?)
-   */
-  status: PropTypes.oneOf(['ongoing', 'submitted']),
-  /**
-   * function for updating case in caseContext
-   */
-  updateCaseInContext: PropTypes.func,
-};
-
-Form.defaultProps = {
-  initialAnswers: {},
 };
 
 export default Form;

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { ActivityIndicator } from 'react-native';
 import styled from 'styled-components';
-import { ScreenWrapper } from '../components/molecules';
 import Form from '../containers/Form/Form';
 import { getFormQuestions } from '../helpers/CaseDataConverter';
 import generateInitialCaseAnswers from '../store/actions/dynamicFormData';
@@ -14,11 +13,6 @@ const SpinnerContainer = styled.View`
   flex: 1;
   justify-content: center;
   align-items: center;
-`;
-
-const FormScreenWrapper = styled(ScreenWrapper)`
-  padding: 0;
-  flex: 1;
 `;
 
 const FormCaseScreen = ({ route, navigation, ...props }) => {
@@ -85,21 +79,19 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
   }
 
   return (
-    <FormScreenWrapper>
-      <Form
-        steps={form.steps}
-        connectivityMatrix={form.connectivityMatrix}
-        initialPosition={caseData?.currentPosition || initialCase?.currentPosition}
-        user={user}
-        onClose={handleCloseForm}
-        onStart={handleStartForm}
-        onSubmit={handleSubmitForm}
-        initialAnswers={initialCase?.data || caseData.data || {}}
-        status={initialCase.status || 'ongoing'}
-        updateCaseInContext={updateCaseContext}
-        {...props}
-      />
-    </FormScreenWrapper>
+    <Form
+      steps={form.steps}
+      connectivityMatrix={form.connectivityMatrix}
+      initialPosition={caseData?.currentPosition || initialCase?.currentPosition}
+      user={user}
+      onClose={handleCloseForm}
+      onStart={handleStartForm}
+      onSubmit={handleSubmitForm}
+      initialAnswers={initialCase?.data || caseData.data || {}}
+      status={initialCase.status || 'ongoing'}
+      updateCaseInContext={updateCaseContext}
+      {...props}
+    />
   );
 };
 


### PR DESCRIPTION
## Explain the changes you’ve made

Added some logic to the Form component so that every time you go to a new step (main or sub), your view scrolls to the top of the page. 

## Explain why these changes are made

Basic usability: it's really not convenient for people to end up on the bottom of a page, especially if it's the first time they go to it. 

## Explain your solution

Moved the ScreenWrapper into the Form component, since this is where the logic for handling form navigation lives, and then added a useEffect that triggers every time the user moves between main steps. This works since the substeps live inside a modal and thus do not need this, and it also means that opening and closing a substep do not reset your scroll position in the main step. 

Also simplified the ScreenWrapper and removed an unnecessary ScrollView from Step that was interfering with the scroll logic. We should try to avoid nested scroll views unless strictly necessary, as it makes it confusing to keep track of where the scrolling is actually happening. 

## How to test the changes?

Go into any form with longer pages, and see what happens when you go between steps in the main form, and how substeps work. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
