### PR TITLE
added replacement for #month

### DIFF
--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -10,10 +10,11 @@ import { User } from '../../../types/UserTypes';
 const replacementRules = [
   ['#firstName', 'user.firstName'],
   ['#lastName', 'user.lastName'],
-  ['#datum1', 'date.nextMonth.first'],
-  ['#datum2', 'date.nextMonth.last'],
-  ['#månad-1', 'date.previousMonth.currentMonth-1'],
-  ['#månad-2', 'date.previousMonth.currentMonth-2'],
+  ['#date-1', 'date.nextMonth.first'],
+  ['#date-2', 'date.nextMonth.last'],
+  ['#month', 'date.previousMonth.currentMonth'],
+  ['#month-1', 'date.previousMonth.currentMonth-1'],
+  ['#month-2', 'date.previousMonth.currentMonth-2'],
   ['#year', 'date.currentYear'], // this is the current year of next month
 ];
 
@@ -53,14 +54,18 @@ const replaceDates = (descriptor: string[]): string => {
 
   if (descriptor[1] === 'previousMonth') {
     const currentMonth = today.getMonth();
-    if (descriptor[2] === 'currentMonth-1') {
-      return `${swedishMonthTable[currentMonth - 1]}`;
-    }
-    if (descriptor[2] === 'currentMonth-2') {
-      return `${swedishMonthTable[currentMonth - 2]}`;
+
+    switch (descriptor[2]) {
+      case 'currentMonth':
+        return `${swedishMonthTable[currentMonth]}`;
+      case 'currentMonth-1':
+        return `${swedishMonthTable[currentMonth - 1]}`;
+      case 'currentMonth-2':
+        return `${swedishMonthTable[currentMonth - 2]}`;
+      default:
+        return `${swedishMonthTable[currentMonth]}`;
     }
   }
-
   return '';
 };
 
@@ -99,9 +104,9 @@ const replaceText = (text: string, user: User) => {
  * @param user the user object
  */
 export const replaceMarkdownTextInSteps = (steps: Step[], user: User): Step[] => {
-  const newSteps = steps.map(step => {
+  const newSteps = steps.map((step) => {
     if (step.questions) {
-      step.questions = step.questions.map(qs => {
+      step.questions = step.questions.map((qs) => {
         if (qs.label && qs.label !== '') {
           qs.label = replaceText(qs.label, user);
         }


### PR DESCRIPTION
## Explain the changes you’ve made

Add support for the replacement of #month , to be replaced with current month. Also make the replacement syntax a bit more consistent, using english names instead of a mix of English and Swedish.

## Explain your solution

Just add the current month logic, similarly to the other months.
Also rewrote a small part with  a switch, which felt better than just a lot of if-statements. 

## How to test the changes?

Go into a form that uses #month , like the Test form on dev. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
