### PR TITLE
Feat/improved focus for list inputs

### DIFF
--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextInputProps, Keyboard } from 'react-native';
+import { TextInputProps, Keyboard, TextInput } from 'react-native';
 import styled, { useTheme } from 'styled-components/native';
 import Text from '../Text';
 
@@ -17,7 +17,7 @@ type InputProps = Omit<TextInputProps, 'onBlur'> & {
 const StyledTextInput = styled.TextInput<InputProps>`
   width: 100%;
   font-weight: ${({ theme }) => theme.fontWeights[0]}
-  background-color: ${props => props.theme.colors.complementary[props.colorSchema][2]};
+  background-color: ${(props) => props.theme.colors.complementary[props.colorSchema][2]};
   ${({ transparent }) => transparent && `background-color: transparent;`}
   border-radius: 4.5px;
   border: solid 1px
@@ -29,41 +29,44 @@ const StyledTextInput = styled.TextInput<InputProps>`
   padding-right: 16px;
   margin: 3px;
   color: ${({ theme }) => theme.colors.neutrals[0]};
-  ${props => (props.center ? 'text-align: center;' : null)}
+  ${(props) => (props.center ? 'text-align: center;' : null)}
 `;
 
 const StyledErrorText = styled(Text)`
   font-size: ${({ theme }) => theme.fontSizes[3]};
-  color: ${props => props.theme.textInput.errorTextColor};
+  color: ${(props) => props.theme.textInput.errorTextColor};
   font-weight: ${({ theme }) => theme.fontWeights[0]};
   padding-top: 8px;
 `;
 
-const Input: React.FC<InputProps> = ({ onBlur, showErrorMessage, ...props }) => {
-  const { value, error } = props;
+const Input: React.FC<InputProps> = React.forwardRef(
+  ({ onBlur, showErrorMessage, ...props }, ref) => {
+    const { value, error } = props;
 
-  const handleBlur = () => {
-    if (onBlur) onBlur(value);
-  };
-  const theme = useTheme();
-  return (
-    <>
-      <StyledTextInput
-        multiline /** Temporary fix to make field scrollable inside scrollview */
-        numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
-        onBlur={handleBlur}
-        placeholderTextColor={theme.colors.neutrals[1]}
-        returnKeyType="done"
-        blurOnSubmit
-        onSubmitEditing={() => {
-          Keyboard.dismiss();
-        }}
-        {...props}
-      />
-      {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
-    </>
-  );
-};
+    const handleBlur = () => {
+      if (onBlur) onBlur(value);
+    };
+    const theme = useTheme();
+    return (
+      <>
+        <StyledTextInput
+          multiline /** Temporary fix to make field scrollable inside scrollview */
+          numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
+          onBlur={handleBlur}
+          placeholderTextColor={theme.colors.neutrals[1]}
+          returnKeyType="done"
+          blurOnSubmit
+          onSubmitEditing={() => {
+            Keyboard.dismiss();
+          }}
+          ref={ref as React.Ref<TextInput>}
+          {...props}
+        />
+        {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
+      </>
+    );
+  }
+);
 
 Input.propTypes = {
   value: PropTypes.string,

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -35,14 +35,14 @@ interface Props {
   style?: ViewStyle;
 }
 
-const Select: React.FC<Props> = ({
+const Select: React.FC<Props> = React.forwardRef(({
   items,
   onValueChange,
   placeholder,
   value,
   editable = true,
   style,
-}) => {
+}, ref) => {
   const currentItem = items.find(item => item.value === value);
   return (
     <Wrapper style={style}>
@@ -57,10 +57,11 @@ const Select: React.FC<Props> = ({
           }
         }}
         items={items}
+        ref={ref as React.LegacyRef<RNPickerSelect>}
       />
     </Wrapper>
   );
-};
+});
 
 Select.propTypes = {
   /** The list of choices */

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -193,9 +193,8 @@ function EditableList({
             error={error ? error[input.key] : undefined}
             activeOpacity={1.0}
             onPress={() => {
-              if (inputIsEditable && inputRefs.current?.[index]?.focus)
-                inputRefs.current[index].focus();
-              else if (inputIsEditable && inputRefs.current?.[index]?.togglePicker)
+              if (editable && inputRefs.current?.[index]?.focus) inputRefs.current[index].focus();
+              else if (editable && inputRefs.current?.[index]?.togglePicker)
                 inputRefs.current[index].togglePicker();
             }}
           >

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -74,7 +74,7 @@ const getInitialState = (inputs, value) => {
 
 /** Switch between different input types */
 const InputComponent = React.forwardRef(
-  ({ input, colorSchema, editable, onChange, onInputBlur, value }, ref) => {
+  ({ input, colorSchema, editable, onChange, onInputBlur, value, state }, ref) => {
     switch (input.type) {
       case 'number':
         return (
@@ -125,6 +125,21 @@ const InputComponent = React.forwardRef(
     }
   }
 );
+InputComponent.propTypes = {
+  input: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    key: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    items: PropTypes.array,
+  }),
+  colorSchema: PropTypes.oneOf(['red', 'blue', 'green', 'purple', 'neutral']),
+  editable: PropTypes.bool,
+  onChange: PropTypes.func,
+  onInputBlur: PropTypes.func,
+  value: PropTypes.string,
+  state: PropTypes.object,
+};
+
 /**
  * EditableList
  * A Molecule Component to use for rendering a list with the possibility of editing the list values.
@@ -203,7 +218,7 @@ function EditableList({
             </EditableListItemLabelWrapper>
             <EditableListItemInputWrapper>
               <InputComponent
-                {...{ input, colorSchema, editable, onChange, onInputBlur, value }}
+                {...{ input, colorSchema, editable, onChange, onInputBlur, value, state }}
                 ref={(el) => {
                   inputRefs.current[index] = el;
                 }}

--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -25,12 +25,12 @@ const ListBodyFieldLabel = styled(Heading)<{ colorSchema: string }>`
 
 interface Props {
   heading?: string;
-  items: { category: string; component: JSX.Element }[];
   categories: { category: string; description: string }[];
-  colorSchema: PrimaryColor;
+  colorSchema?: PrimaryColor;
   showEditButton?: boolean;
   startEditable?: boolean;
   help?: Help;
+  children: React.ReactElement<{ category: string; editable?: boolean }>[];
 }
 
 /**
@@ -39,16 +39,19 @@ interface Props {
  */
 const GroupedList: React.FC<Props> = ({
   heading,
-  items,
   categories,
   colorSchema,
   showEditButton,
   startEditable,
   help,
+  children,
 }) => {
   const [editable, setEditable] = useState(startEditable);
 
-  const groupedItems: Record<string, { category: string; component: JSX.Element }[]> = {};
+  const groupedItems: Record<
+    string,
+    React.ReactElement<{ category: string; editable?: boolean }>[]
+  > = {};
   const changeEditable = () => {
     LayoutAnimation.configureNext({
       duration: 300,
@@ -64,7 +67,7 @@ const GroupedList: React.FC<Props> = ({
   };
 
   categories.forEach((cat) => {
-    const catItems = items.filter((item) => item.category === cat.category);
+    const catItems = children.filter((item) => item.props.category === cat.category);
     if (catItems.length > 0) {
       groupedItems[cat.category] = catItems;
     }
@@ -97,10 +100,7 @@ const GroupedList: React.FC<Props> = ({
             <ListBodyFieldLabel colorSchema={validColorSchema}>
               {categories.find((c) => c.category === key).description}
             </ListBodyFieldLabel>
-            {groupedItems[key].map((item) => ({
-              ...item.component,
-              props: { ...item.component.props, editable },
-            }))}
+            {groupedItems[key].map((item) => React.cloneElement(item, { editable }))}
           </View>
         ))}
       </ListBody>
@@ -113,10 +113,6 @@ GroupedList.propTypes = {
    * The header text of the list.
    */
   heading: PropTypes.string,
-  /**
-   * The items to display. Each item should have a component, a category and a remove function
-   */
-  items: PropTypes.array,
   /**
    * The allowed categories for the groupings
    */
@@ -133,6 +129,7 @@ GroupedList.propTypes = {
    * Whether to start in editable mode or not
    */
   startEditable: PropTypes.bool,
+  children: PropTypes.array,
   /**
    * Show a help button
    */


### PR DESCRIPTION
## Explain the changes you’ve made

Added functionality so that it is much easier to focus the input fields in our various 'list' components, i.e. SummaryList, EditableList and Repeater. Now pressing anywhere on the row will bring the focus to the input part and bring up the keyboard.

## Explain why these changes are made

This was in response to testflight feedback, and it makes the form quite a bit easier to use for the first time. See the task https://app.clickup.com/t/bev5qk 

## Explain your solution

I refactor a bit how the lists work, and then through using React refs I trigger focus on the input fields. This works for selects as well on iOS, but not android. And I haven't implemented it for the date picker, which can be done later but requires some more work. 

Using refs properly is a little tricky, and lead me to some smaller refactoring of input components, but I think the way they are now is generally better and more React-like. 

## How to test the changes?

Go into any story or the test form and try to play around with SummaryList, Repeater and Editable list. Pressing anywhere on the row should bring focus to the text input, for numeric and text inputs at least. 


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
