### PR TITLE
NavigationButtonGroup: fix so that colorSchema works

### DIFF
--- a/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
+++ b/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
@@ -4,6 +4,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import NavigationButtonField, {
   Props as ButtonProps,
 } from '../NavigationButtonField/NavigationButtonField';
+import { PrimaryColor } from '../../../styles/themeHelpers';
 
 interface Props {
   buttons: ButtonProps[];
@@ -14,12 +15,22 @@ interface Props {
     down: (targetStepId: string) => void;
     up: () => void;
   };
+  colorSchema?: PrimaryColor;
 }
 
-const NavigationButtonGroup: React.FC<Props> = ({ buttons, horizontal, formNavigation }) => (
+const NavigationButtonGroup: React.FC<Props> = ({
+  buttons,
+  horizontal,
+  formNavigation,
+  colorSchema,
+}) => (
   <ScrollView horizontal={horizontal}>
     {buttons.map((button, index) => (
-      <NavigationButtonField {...button} formNavigation={formNavigation} key={`button${index}`} />
+      <NavigationButtonField
+        {...{ colorSchema, ...button }}
+        formNavigation={formNavigation}
+        key={`button${index}`}
+      />
     ))}
   </ScrollView>
 );
@@ -28,6 +39,7 @@ NavigationButtonGroup.propTypes = {
   horizontal: PropTypes.bool,
   buttons: PropTypes.array,
   formNavigation: PropTypes.any,
+  colorSchema: PropTypes.oneOf(['blue', 'red', 'green', 'purple', 'neutral']),
 };
 
 export default NavigationButtonGroup;


### PR DESCRIPTION
## Explain the changes you’ve made

Fix so that NavigationButtonGroup loads the colorSchema as it should. 
If a button is given a color, it will get that, otherwise it will use the theme from the step. 

## Explain your solution

Just some renaming and adding of a prop. 

## How to test the changes?

Go into a form that uses NavButtonGroup, like the test form or the löpande form. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
