### PR TITLE
feat(custom-scroll-indicator): add a custom horizontal scroll indicator

### DIFF
--- a/source/components/atoms/HorizontalScrollIndicator/HorizontalScrollIndicator.tsx
+++ b/source/components/atoms/HorizontalScrollIndicator/HorizontalScrollIndicator.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components/native';
+
+function* range(start:number, end: number) {
+  for (let i = start; i <= end; i++) {
+      yield i;
+  }
+}
+
+const SegmentWrapper = styled.View`
+  flex-direction: row;
+  justify-content: center;
+`;
+
+const StartSegment = styled.View<{ selected?: boolean }>`
+  height: 3px;
+  width: 12px;
+  margin-right: 3px;
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
+  background-color: ${({ selected, theme }) => (selected ? theme.colors.neutrals[2] : theme.colors.neutrals[4])};
+`;
+const EndSegment = styled.View<{ selected?: boolean }>`
+  height: 3px;
+  width: 12px;  
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+  background-color: ${({ selected, theme }) => (selected ? theme.colors.neutrals[2] : theme.colors.neutrals[4])};
+`;
+const MiddleSegment = styled.View<{ selected?: boolean }>`
+  height: 3px;
+  width: 12px;
+  margin-right: 3px;
+  background-color: ${({ selected, theme }) => (selected ? theme.colors.neutrals[2] : theme.colors.neutrals[4])};
+`;
+interface CustomScrollIndicatorProps {
+  percentage: number;
+  numberOfSegments?: number;
+}
+
+const HorizontalScrollIndicator: React.FC<CustomScrollIndicatorProps> = ({
+  percentage,
+  numberOfSegments = 3,
+}) =>{ 
+  const selectedSegment = Math.round(numberOfSegments * percentage);
+  return (
+  <SegmentWrapper>
+    <StartSegment selected={selectedSegment === 0}/>
+    {numberOfSegments > 2 && [...range(0, numberOfSegments-3)].map((v: number) =>
+      <MiddleSegment key={v} selected={selectedSegment === v+1} />)}    
+    <EndSegment selected={selectedSegment >= numberOfSegments-1} />
+  </SegmentWrapper>
+);
+};
+
+export default HorizontalScrollIndicator;

--- a/source/components/atoms/HorizontalScrollIndicator/index.ts
+++ b/source/components/atoms/HorizontalScrollIndicator/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HorizontalScrollIndicator';

--- a/source/components/atoms/index.ts
+++ b/source/components/atoms/index.ts
@@ -9,3 +9,4 @@ export { default as Checkbox } from './Checkbox';
 export { default as Label } from './Label';
 export { default as Select } from './Select';
 export { default as Progressbar } from './Progressbar';
+export { default as HorizontalScrollIndicator } from './HorizontalScrollIndicator';

--- a/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
+++ b/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { ScrollView } from 'react-native-gesture-handler';
+import styled from 'styled-components/native';
+import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import NavigationButtonField, {
   Props as ButtonProps,
 } from '../NavigationButtonField/NavigationButtonField';
 import { PrimaryColor } from '../../../styles/themeHelpers';
+import { HorizontalScrollIndicator } from '../../atoms';
 
+const ScrollContainer = styled.ScrollView`
+  padding-bottom: 16px;
+`;
 interface Props {
   buttons: ButtonProps[];
   horizontal: boolean;
@@ -23,17 +28,36 @@ const NavigationButtonGroup: React.FC<Props> = ({
   horizontal,
   formNavigation,
   colorSchema,
-}) => (
-  <ScrollView horizontal={horizontal}>
-    {buttons.map((button, index) => (
-      <NavigationButtonField
-        {...{ colorSchema, ...button }}
-        formNavigation={formNavigation}
-        key={`button${index}`}
-      />
-    ))}
-  </ScrollView>
-);
+}) => {
+  const [horizontalScrollPercentage, setHorizontalScrollPercentage] = useState(0);
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (horizontal) {
+      setHorizontalScrollPercentage(
+        event.nativeEvent.contentOffset.x /
+          (event.nativeEvent.contentSize.width - event.nativeEvent.layoutMeasurement.width)
+      );
+    }
+  };
+  return (
+    <>
+      <ScrollContainer
+        horizontal={horizontal}
+        onScroll={handleScroll}
+        showsHorizontalScrollIndicator={false}
+      >
+        {buttons.map((button, index) => (
+          <NavigationButtonField
+            {...{ colorSchema, ...button }}
+            formNavigation={formNavigation}
+            key={`button${index}`}
+          />
+        ))}
+      </ScrollContainer>
+      {horizontal && <HorizontalScrollIndicator percentage={horizontalScrollPercentage} />}
+    </>
+  );
+};
 
 NavigationButtonGroup.propTypes = {
   horizontal: PropTypes.bool,


### PR DESCRIPTION
## Explain the changes you’ve made

Add a horizontal scroll indicator according to the Figma design, for use with the navigation button group. 

## Explain your solution

I add a simple atom component, HorizontalScrollIndicator, which acts a simple scroll bar. This takes how many segments we want, and which percentage the scrolling is. Then I listen  to the onScroll event in the relevant scroll view in the NavigationButtonGroup (only if we are displaying it horizontally), and use this to compute the scroll percentage. 

## How to test the changes?

Go into a form that uses the horizontal navigation button group, like Löpande, and check that the scroll bar behaves as it should. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots (optional)
![scroll-indicator](https://user-images.githubusercontent.com/7421890/103297496-b9a13900-49f8-11eb-991a-2183e71e472a.PNG)
