### PR TITLE
fix styling of repeater delete button

### DIFF
--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -168,7 +168,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
     <Base>
       <ItemLabel colorSchema={validColorSchema} underline={false}>{heading || "Item"}</ItemLabel>
       {rows}
-      <DeleteButton colorSchema="red" color={validColorSchema} block onClick={removeItem}><DeleteButtonText color={validColorSchema}>Ta bort</DeleteButtonText></DeleteButton>
+      <DeleteButton z={0} colorSchema="neutral" color={validColorSchema} block onClick={removeItem}><DeleteButtonText color={validColorSchema}>Ta bort</DeleteButtonText></DeleteButton>
     </Base>
   );
 };

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -67,8 +67,16 @@ const ItemInput = styled(Input)`
 const DeleteButton = styled(Button)<{color: string}>`
   margin-top: 10px;
   margin-bottom: 10px;
-  background: ${props => theme.repeater[props.color].deleteButton}
-`
+  background: ${props => theme.repeater[props.color].deleteButton};
+`;
+
+const DeleteButtonText = styled(Text)<{color: string}>`
+  color: ${props => theme.repeater[props.color].deleteButtonText};
+  text-transform: uppercase;
+  font-weight: 900;
+  font-size: 12px;
+  line-height: 18px;
+`;
 
 interface Props {
   heading?: string;
@@ -160,7 +168,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
     <Base>
       <ItemLabel colorSchema={validColorSchema} underline={false}>{heading || "Item"}</ItemLabel>
       {rows}
-      <DeleteButton colorSchema="red" color={validColorSchema} block onClick={removeItem}><Text>Ta bort</Text></DeleteButton>
+      <DeleteButton colorSchema="red" color={validColorSchema} block onClick={removeItem}><DeleteButtonText color={validColorSchema}>Ta bort</DeleteButtonText></DeleteButton>
     </Base>
   );
 };

--- a/source/styles/theme.js
+++ b/source/styles/theme.js
@@ -649,27 +649,32 @@ const theme = {
   repeater: {
     blue: {
       inputBackground: colorPalette.complementary.blue[2],
-      deleteButton: '#DD6161',
+      deleteButton: colorPalette.complementary.blue[0],
+      deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     green: {
       inputBackground: colorPalette.complementary.green[2],
-      deleteButton: '#DD6161',
+      deleteButton: colorPalette.complementary.green[0],
+      deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     red: {
       inputBackground: colorPalette.complementary.red[2],
-      deleteButton: '#DD6161',
+      deleteButton: colorPalette.complementary.red[0],
+      deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     purple: {
       inputBackground: colorPalette.complementary.purple[2],
-      deleteButton: '#DD6161',
+      deleteButton: colorPalette.complementary.purple[0],
+      deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     neutral: {
       inputBackground: colorPalette.complementary.neutral[2],
-      deleteButton: '#DD6161',
+      deleteButton: colorPalette.complementary.neutral[0],
+      deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     darkBlue: {

--- a/source/styles/theme.js
+++ b/source/styles/theme.js
@@ -649,31 +649,31 @@ const theme = {
   repeater: {
     blue: {
       inputBackground: colorPalette.complementary.blue[2],
-      deleteButton: colorPalette.complementary.blue[0],
+      deleteButton: colorPalette.complementary.blue[1],
       deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     green: {
       inputBackground: colorPalette.complementary.green[2],
-      deleteButton: colorPalette.complementary.green[0],
+      deleteButton: colorPalette.complementary.green[1],
       deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     red: {
       inputBackground: colorPalette.complementary.red[2],
-      deleteButton: colorPalette.complementary.red[0],
+      deleteButton: colorPalette.complementary.red[1],
       deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     purple: {
       inputBackground: colorPalette.complementary.purple[2],
-      deleteButton: colorPalette.complementary.purple[0],
+      deleteButton: colorPalette.complementary.purple[1],
       deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },
     neutral: {
       inputBackground: colorPalette.complementary.neutral[2],
-      deleteButton: colorPalette.complementary.neutral[0],
+      deleteButton: colorPalette.complementary.neutral[1],
       deleteButtonText: '#D73640',
       inputText: colorPalette.neutrals[1],
     },


### PR DESCRIPTION
## Explain the changes you’ve made

Change and improve the styling of the delete button for the repeater, making it adapt to color schemes and stand out a bit less. 
The task is https://app.clickup.com/t/bwz7d1 and some updated design can be found on figma, see https://www.figma.com/file/B0XpoR5OFMESSMRPzKGEoD/Mitt-HBG-Design-v3-%E2%80%A2-HT2020?node-id=4035%3A0 

## Explain why these changes are made

As a response to some test feedback. 

## Explain your solution

Just change some colors in the theme, and add some new styling to the text on the button. 

## How to test the changes?

Look at a repeater anywhere, and in the different color schemes. The Test form or the repeater stories are good places. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
