### PR TITLE
Fix/refactor modal

### DIFF
--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -38,7 +38,7 @@ const BackButtonIcon = styled(Icon).attrs(({ theme, colorSchema }) => ({
   color: theme.colors.primary[colorSchema][0],
 }))``;
 
-const CloseButton = styled.View((props) => ({
+const CloseButton = styled.TouchableOpacity((props) => ({
   alignItems: 'center',
   borderRadius: 30,
   justifyContent: 'center',
@@ -79,11 +79,7 @@ const BackNavigation = ({
       )}
 
       {showCloseButton ? (
-        <CloseButton
-          primary={primary}
-          colorSchema={colorSchema}
-          onStartShouldSetResponder={onClose}
-        >
+        <CloseButton primary={primary} colorSchema={colorSchema} onPress={onClose}>
           <CloseButtonIcon colorSchema={colorSchema} primary={primary} name="close" />
         </CloseButton>
       ) : null}
@@ -93,7 +89,7 @@ const BackNavigation = ({
       <CloseButton
         primary={primary}
         colorSchema={colorSchema}
-        onStartShouldSetResponder={() => {
+        onPress={() => {
           onBack();
         }}
       >

--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { TouchableHighlight, ScrollView, Image, Linking } from 'react-native';
 import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
@@ -113,7 +113,7 @@ const HelpButton = (props) => {
           </Container>
         </ModalContainer>
       </Modal>
-      <TouchableHighlight onPressIn={toggleModal} onPress={toggleModal} underlayColor="transparent">
+      <TouchableHighlight onPress={toggleModal} underlayColor="transparent">
         <Icon name="help-outline" size={size} />
       </TouchableHighlight>
     </>

--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Modal, TouchableHighlight, ScrollView, Image, Linking } from 'react-native';
+import { TouchableHighlight, ScrollView, Image, Linking } from 'react-native';
 import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import { Icon, Button } from '../../atoms';
 import icons from '../../../helpers/Icons';
 import Text from '../../atoms/Text';
 import BackNavigation from '../BackNavigation/BackNavigation';
+import { Modal, useModal } from '../Modal';
 
 const ModalContainer = styled.View({
   backgroundColor: '#00213F',
@@ -68,7 +69,7 @@ const LinkButton = styled(Button)`
 
 const HelpButton = (props) => {
   const { text, size, heading, tagline, url } = props;
-  const [modalVisible, setModalVisible] = useState(false);
+  const [visible, toggleModal] = useModal();
 
   const link = () => {
     Linking.openURL(url);
@@ -86,16 +87,9 @@ const HelpButton = (props) => {
 
   return (
     <>
-      <Modal
-        visible={modalVisible}
-        animationType="slide"
-        onRequestClose={() => {
-          setModalVisible(false);
-        }}
-        presentationStyle="pageSheet"
-      >
+      <Modal visible={visible} hide={toggleModal}>
         <ModalContainer>
-          <CloseModal showBackButton={false} onClose={() => setModalVisible(false)} />
+          <CloseModal showBackButton={false} onClose={toggleModal} />
           <BannerWrapper>
             <BannerIcon resizeMode="contain" source={icons.ICON_HELP} />
           </BannerWrapper>
@@ -119,13 +113,7 @@ const HelpButton = (props) => {
           </Container>
         </ModalContainer>
       </Modal>
-      <TouchableHighlight
-        onPressIn={() => setModalVisible(false)}
-        onPress={() => {
-          setModalVisible(true);
-        }}
-        underlayColor="transparent"
-      >
+      <TouchableHighlight onPressIn={toggleModal} onPress={toggleModal} underlayColor="transparent">
         <Icon name="help-outline" size={size} />
       </TouchableHighlight>
     </>

--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -69,7 +69,7 @@ const LinkButton = styled(Button)`
 
 const HelpButton = (props) => {
   const { text, size, heading, tagline, url } = props;
-  const [visible, toggleModal] = useModal();
+  const [isModalVisible, toggleModal] = useModal();
 
   const link = () => {
     Linking.openURL(url);
@@ -87,7 +87,7 @@ const HelpButton = (props) => {
 
   return (
     <>
-      <Modal visible={visible} hide={toggleModal}>
+      <Modal visible={isModalVisible} hide={toggleModal}>
         <ModalContainer>
           <CloseModal showBackButton={false} onClose={toggleModal} />
           <BannerWrapper>

--- a/source/components/molecules/Modal/Modal.js
+++ b/source/components/molecules/Modal/Modal.js
@@ -1,30 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import RnModal from 'react-native-modal';
-import styled from 'styled-components/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Modal as RnModal } from 'react-native';
 
-const ModalContainer = styled(RnModal)`
-  margin-left: 0px;
-  margin-right: 0px;
-  margin-bottom: 0px;
-  margin-top: 0px;
-  border-top-left-radius: 17.5px;
-  border-top-right-radius: 17.5px;
-`;
-
-const Modal = ({ visible, children, ...other }) => (
-  <ModalContainer
-    animationInTiming={500}
-    animationOutTiming={500}
-    propagateSwipe
-    isVisible={visible}
-    transparent
+const Modal = ({ visible, children, setVisibility, ...other }) => (
+  <RnModal
+    statusBarTranslucent={false}
+    visible={visible}
+    animationType="slide"
+    transparent={false}
+    onRequestClose={() => {
+      if (setVisibility) {
+        setVisibility(false);
+      }
+    }}
+    presentationStyle="pageSheet"
     {...other}
   >
-    <SafeAreaView edges={['top', 'right', 'left']} />
     {children}
-  </ModalContainer>
+  </RnModal>
 );
 
 Modal.propTypes = {

--- a/source/components/molecules/Modal/Modal.js
+++ b/source/components/molecules/Modal/Modal.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal as RnModal } from 'react-native';
+import { Modal as ReactNativeModal } from 'react-native';
 
 const Modal = ({ visible, hide, children, ...other }) => (
-  <RnModal
+  <ReactNativeModal
     statusBarTranslucent={false}
     visible={visible}
     animationType="slide"
@@ -13,7 +13,7 @@ const Modal = ({ visible, hide, children, ...other }) => (
     {...other}
   >
     {children}
-  </RnModal>
+  </ReactNativeModal>
 );
 
 Modal.propTypes = {

--- a/source/components/molecules/Modal/Modal.js
+++ b/source/components/molecules/Modal/Modal.js
@@ -1,18 +1,14 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal as RnModal } from 'react-native';
 
-const Modal = ({ visible, children, setVisibility, ...other }) => (
+const Modal = ({ visible, hide, children, ...other }) => (
   <RnModal
     statusBarTranslucent={false}
     visible={visible}
     animationType="slide"
     transparent={false}
-    onRequestClose={() => {
-      if (setVisibility) {
-        setVisibility(false);
-      }
-    }}
+    onRequestClose={hide}
     presentationStyle="pageSheet"
     {...other}
   >
@@ -21,6 +17,7 @@ const Modal = ({ visible, children, setVisibility, ...other }) => (
 );
 
 Modal.propTypes = {
+  hide: PropTypes.func,
   visible: PropTypes.bool.isRequired,
   children: PropTypes.any,
 };

--- a/source/components/molecules/Modal/Modal.stories.js
+++ b/source/components/molecules/Modal/Modal.stories.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 import { View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import styled from 'styled-components/native';
@@ -10,92 +10,25 @@ import Text from '../../atoms/Text';
 const ModalButton = styled(Button)`
   margin-top: 24px;
 `;
-class ModalExample extends Component {
-  constructor(props) {
-    super(props);
+const ModalExample = () => {
+  const [visible, setVisible] = useState(false);
 
-    this.state = {
-      modal: {
-        visible: false,
-        heading: '',
-        content: '',
-        closeButtonText: '',
-      },
-    };
-  }
+  return (
+    <View>
+      <Modal color="purple" visible={visible} setVisibility={(isVisible) => setVisible(isVisible)}>
+        <Text>Children 1</Text>
+        <Text>Children 2</Text>
+        <Button onClick={() => setVisible(false)}>
+          <Text>Close</Text>
+        </Button>
+      </Modal>
 
-  changeModal(visible, heading = '', content = '', closeButtonText = 'Klar') {
-    this.setState({
-      modal: {
-        visible,
-        heading,
-        content,
-        closeButtonText,
-      },
-    });
-  }
-
-  render() {
-    const { modal } = this.state;
-    const { visible, heading, closeButtonText } = modal;
-
-    return (
-      <View>
-        <Modal
-          color="purple"
-          visible={visible}
-          heading={heading}
-          closeButtonText={closeButtonText}
-          changeModal={(isVisible) => this.changeModal(isVisible)}
-        >
-          <Text>Trying out children</Text>
-          <Button onClick={() => this.changeModal(!visible)}>
-            <Text>En knapp</Text>
-          </Button>
-        </Modal>
-
-        <ModalButton
-          color="purple"
-          onClick={() =>
-            this.changeModal(
-              !visible,
-              'Modal one',
-              'Donec ullamcorper nulla non metus auctor fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Donec ullamcorper nulla non metus auctor fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. \n\nSociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean lacinia bibendum nulla sed consectetur. Donec ullamcorper nulla non metus auctor fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. \n\nSociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean lacinia bibendum nulla sed consectetur. Donec ullamcorper nulla non metus auctor fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.  \n\nSociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean lacinia bibendum nulla sed consectetur. Donec ullamcorper nulla non metus auctor fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing.'
-            )
-          }
-        >
-          <Text>Show modal</Text>
-        </ModalButton>
-
-        <ModalButton
-          color="blue"
-          onClick={() =>
-            this.changeModal(
-              !visible,
-              'Modal two',
-              'Donec ullamcorper nulla non metus auctor fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Donec ullamcorper nulla non metus auctor fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
-            )
-          }
-        >
-          <Text>Show modal</Text>
-        </ModalButton>
-
-        <ModalButton
-          color="dark"
-          onClick={() =>
-            this.changeModal(
-              !visible,
-              'Markdown modal',
-              `[I'm an inline-style link](https://www.google.com)`
-            )
-          }
-        >
-          <Text>Show modal</Text>
-        </ModalButton>
-      </View>
-    );
-  }
-}
+      <ModalButton color="purple" onClick={() => setVisible(true)}>
+        <Text>Show modal</Text>
+      </ModalButton>
+    </View>
+  );
+};
 
 storiesOf('Modal', module).add('default', () => (
   <StoryWrapper>

--- a/source/components/molecules/Modal/Modal.stories.js
+++ b/source/components/molecules/Modal/Modal.stories.js
@@ -1,29 +1,30 @@
-import React, { Component, useState } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import styled from 'styled-components/native';
+import { Modal, useModal } from './';
 import StoryWrapper from '../StoryWrapper';
-import Modal from './Modal';
 import Button from '../../atoms/Button/Button';
 import Text from '../../atoms/Text';
 
 const ModalButton = styled(Button)`
   margin-top: 24px;
 `;
+
 const ModalExample = () => {
-  const [visible, setVisible] = useState(false);
+  const [visible, toggleModal] = useModal();
 
   return (
     <View>
-      <Modal color="purple" visible={visible} setVisibility={(isVisible) => setVisible(isVisible)}>
+      <Modal color="purple" visible={visible} hide={toggleModal}>
         <Text>Children 1</Text>
         <Text>Children 2</Text>
-        <Button onClick={() => setVisible(false)}>
+        <Button onClick={toggleModal}>
           <Text>Close</Text>
         </Button>
       </Modal>
 
-      <ModalButton color="purple" onClick={() => setVisible(true)}>
+      <ModalButton color="purple" onClick={toggleModal}>
         <Text>Show modal</Text>
       </ModalButton>
     </View>

--- a/source/components/molecules/Modal/index.js
+++ b/source/components/molecules/Modal/index.js
@@ -1,1 +1,2 @@
-export { default } from './Modal';
+export { default as Modal } from './Modal';
+export { default as useModal } from './useModal';

--- a/source/components/molecules/Modal/useModal.js
+++ b/source/components/molecules/Modal/useModal.js
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [visible, setVisible] = useState(false);
+
+  function toggleModal() {
+    setVisible(!visible);
+  }
+
+  return [visible, toggleModal];
+};
+
+export default useModal;

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -8,7 +8,7 @@ import { Step as StepType, StepperActions } from '../../types/FormTypes';
 import { CaseStatus } from '../../types/CaseType';
 import { User } from '../../types/UserTypes';
 import useForm, { FormReducerState, FormPosition } from './hooks/useForm';
-import Modal from '../../components/molecules/Modal';
+import { Modal, useModal } from '../../components/molecules/Modal';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import theme from '../../styles/theme';
@@ -117,7 +117,9 @@ const Form: React.FC<Props> = ({
   );
 
   const mainStep = formState.currentPosition.currentMainStepIndex;
+  const [visible, toggleModal] = useModal();
   const [scrollViewRef, setRef] = useState<ScrollView>(null);
+
   useEffect(() => {
     if (scrollViewRef && scrollViewRef?.scrollTo) {
       InteractionManager.runAfterInteractions(() => {
@@ -139,7 +141,7 @@ const Form: React.FC<Props> = ({
         edges={['top', 'right', 'left']}
       />
       {stepComponents[formState.currentPosition.currentMainStepIndex]}
-      <Modal visible={formState.currentPosition.level > 0}>
+      <Modal visible={formState.currentPosition.level > 0} hide={toggleModal}>
         {stepComponents[formState.currentPosition.index]}
       </Modal>
     </FormScreenWrapper>

--- a/source/screens/LoginScreen.js
+++ b/source/screens/LoginScreen.js
@@ -12,7 +12,7 @@ import Input from '../components/atoms/Input';
 import Text from '../components/atoms/Text';
 import AuthLoading from '../components/molecules/AuthLoading';
 import BackNavigation from '../components/molecules/BackNavigation';
-import Modal from '../components/molecules/Modal';
+import { Modal, useModal } from '../components/molecules/Modal';
 import { ValidationHelper } from '../helpers';
 import AuthContext from '../store/AuthContext';
 import { useNotification } from '../store/NotificationContext';
@@ -156,8 +156,8 @@ function LoginScreen(props) {
   } = useContext(AuthContext);
   const showNotification = useNotification();
 
-  const [loginModal, loginModalVisible] = useState(false);
-  const [userAgreementModal, userAgreementModalVisible] = useState(false);
+  const [loginModalVisible, toggleLoginModal] = useModal();
+  const [agreementModalVisible, toggleAgreementModal] = useModal();
   const [personalNumber, setPersonalNumber] = useState('');
 
   /**
@@ -266,21 +266,15 @@ function LoginScreen(props) {
               <Button z={0} size="large" block onClick={() => handleLogin()}>
                 <Text>Logga in med Mobilt BankID</Text>
               </Button>
-              <Link onPress={() => loginModalVisible(true)}>Fler alternativ</Link>
+              <Link onPress={toggleLoginModal}>Fler alternativ</Link>
             </Form>
           )}
 
           <Footer>
             <FooterText>
               När du använder tjänsten Mitt Helsingborg godkänner du vårt{' '}
-              <ParagraphLink
-                onPress={() => {
-                  userAgreementModalVisible(true);
-                }}
-              >
-                användaravtal
-              </ParagraphLink>{' '}
-              och att du har tagit del av hur vi hanterar dina{' '}
+              <ParagraphLink onPress={toggleAgreementModal}>användaravtal</ParagraphLink> och att du
+              har tagit del av hur vi hanterar dina{' '}
               <ParagraphLink
                 onPress={() =>
                   Linking.openURL(
@@ -296,18 +290,14 @@ function LoginScreen(props) {
         </SafeAreaViewTop>
       </FlexView>
 
-      <LoginModal visible={loginModal} setVisibility={(isVisible) => loginModalVisible(isVisible)}>
+      <LoginModal visible={loginModalVisible} hide={toggleLoginModal}>
         <StatusBar barStyle="dark-content" backgroundColor="white" />
         <KeyboardAwareScrollView
           keyboardShouldPersistTaps="handled"
           contentContainerStyle={{ flexGrow: 1 }}
           extraScrollHeight={50}
         >
-          <CloseModalButton
-            onClose={() => loginModalVisible(false)}
-            primary={false}
-            showBackButton={false}
-          />
+          <CloseModalButton onClose={toggleLoginModal} primary={false} showBackButton={false} />
           <FlexView>
             <Header>
               <ModalHeading>Logga in med BankID på en annan enhet</ModalHeading>
@@ -367,32 +357,14 @@ function LoginScreen(props) {
         </KeyboardAwareScrollView>
       </LoginModal>
 
-      <LoginModal
-        setVisibility={(isVisible) => userAgreementModalVisible(isVisible)}
-        visible={userAgreementModal}
-        scrollViewProps={{
-          keyboardShouldPersistTaps: 'handled',
-          contentContainerStyle: { flexGrow: 1 },
-          extraScrollHeight: 50,
-        }}
-      >
+      <LoginModal visible={agreementModalVisible} hide={toggleAgreementModal}>
         <KeyboardAwareScrollView>
-          <CloseModalButton
-            onClose={() => userAgreementModalVisible(false)}
-            primary={false}
-            showBackButton={false}
-          />
+          <CloseModalButton onClose={toggleAgreementModal} primary={false} showBackButton={false} />
           <UserAgreementForm>
             <MarkdownConstructor rules={userAgreementMarkdownRules} rawText={userAgreementText} />
           </UserAgreementForm>
           <UserAgreementFooter>
-            <Button
-              z={0}
-              block
-              onClick={() => {
-                userAgreementModalVisible(false);
-              }}
-            >
+            <Button z={0} block onClick={toggleAgreementModal}>
               <Text>Återvänd till inloggning</Text>
             </Button>
           </UserAgreementFooter>

--- a/source/screens/LoginScreen.js
+++ b/source/screens/LoginScreen.js
@@ -296,7 +296,8 @@ function LoginScreen(props) {
         </SafeAreaViewTop>
       </FlexView>
 
-      <LoginModal visible={loginModal}>
+      <LoginModal visible={loginModal} setVisibility={(isVisible) => loginModalVisible(isVisible)}>
+        <StatusBar barStyle="dark-content" backgroundColor="white" />
         <KeyboardAwareScrollView
           keyboardShouldPersistTaps="handled"
           contentContainerStyle={{ flexGrow: 1 }}
@@ -367,6 +368,7 @@ function LoginScreen(props) {
       </LoginModal>
 
       <LoginModal
+        setVisibility={(isVisible) => userAgreementModalVisible(isVisible)}
         visible={userAgreementModal}
         scrollViewProps={{
           keyboardShouldPersistTaps: 'handled',


### PR DESCRIPTION
## Explain the changes you’ve made

Refactored Modal component and implemented custom hook useModal.
Changed Modal lib to use the "react-native" one. 
Changed all occurrences of modal to use the same component for consistency. 

## Explain why these changes are made

The current Modal was acting pretty bad and we used two seperate libs to show Modals.
The look and behavior of the modal is now closer to the figma design.

## Explain your solution

Changed lib and created custom hook, then changed all occurrences of Modals. 

Also fixed a weird bug that occured on Android after closing a modal, where the user had to click twice to re-open the modal. This was fixed by changing the close-button from View to a TouchableOpacity component instead. Have no idea why that solved the problem 😄 

## How to test the changes?

Check different modals in the project:
- There is two on the LoginScreen
- Sub forms is modals
- Helper buttons triggers modals

Or look in the Storybook.

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.
- 