### PR TITLE
feat(background-inactivity): run inactivity check in background

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "16.13.1",
     "react-native": "0.63.4",
     "react-native-asset": "^2.0.1",
+    "react-native-background-timer": "^2.4.1",
     "react-native-calendar-picker": "^7.0.5",
     "react-native-config": "luggit/react-native-config#master",
     "react-native-elements": "^3.0.0-alpha.1",

--- a/source/hooks/useInterval.js
+++ b/source/hooks/useInterval.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import BackgroundTimer from 'react-native-background-timer';
 
 export default function useInterval(callback, delay) {
   const savedCallback = useRef();
@@ -10,12 +11,13 @@ export default function useInterval(callback, delay) {
 
   // Set up the interval.
   useEffect(() => {
+    // only one background timer can run at a time, so we stop here to make sure that we don't have unintended collisions
+    BackgroundTimer.stopBackgroundTimer();
     function tick() {
       savedCallback.current();
     }
     if (delay !== null) {
-      const id = setInterval(tick, delay);
-      return () => clearInterval(id);
+      BackgroundTimer.runBackgroundTimer(tick, delay);
     }
   }, [delay]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10694,6 +10694,11 @@ react-native-asset@^2.0.1:
     sha1-file "^1.0.4"
     xcode "^2.0.0"
 
+react-native-background-timer@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-background-timer/-/react-native-background-timer-2.4.1.tgz#a3bc1cafa8c1e3aeefd0611de120298b67978a0f"
+  integrity sha512-TE4Kiy7jUyv+hugxDxitzu38sW1NqjCk4uE5IgU2WevLv7sZacaBc6PZKOShNRPGirLl1NWkaG3LDEkdb9Um5g==
+
 react-native-calendar-picker@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/react-native-calendar-picker/-/react-native-calendar-picker-7.0.5.tgz#985c4ae3100686ae3197f85b6ef20f4a53ef8f41"


### PR DESCRIPTION
## Explain the changes you’ve made

Change the useInterval hook so that it runs periodically in the background as well, using the react-native-background-timer library.

## Explain your solution

Using the library, it is very straightforward to use its functions to update the hook; instead of using setInterval one uses BackgroundTimer.runBackgroundTimer, and that's about it. 

## How to test the changes?

Switch to branch, run yarn to install the new library. On iOS, you also need to run pod install in the iOS directory. 
Then in your .env-file, set INACTIVITY_TIME= 10000 ,or some other smaller value, because if INACTIVITY_TIME is not set, it will not activate the timer. Then go into the app, and switch it to run in the background and wait a while. When you switch back, you should be greeted by the inactivity dialog. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
