### PR TITLE
feat(inactivity-logout): log the user out after some inactive time 

### DIFF
--- a/source/hooks/useTouchActivity.ts
+++ b/source/hooks/useTouchActivity.ts
@@ -2,13 +2,29 @@ import { useState } from 'react';
 import { PanResponder } from 'react-native';
 import useInterval from './useInterval';
 
-export default function useTouchActivity(inactivityTime, intervalDelay, initialActive) {
+/**
+ * @param inactivityTime how long (in ms) the user should be inactive before displaying the inactivity dialog
+ * @param intervalDelay with which interval we should check for inactivity, in ms
+ * @param initialActive whether to start as active or not
+ * @param logoutDelay how long to wait on the dialog before logging the user out
+ * @param logOut the callback for handling logging out the user
+ */
+export default function useTouchActivity(
+  inactivityTime: number,
+  intervalDelay: number,
+  initialActive: boolean,
+  logoutDelay: number,
+  logOut: () => void
+) {
   const [latestTouchTime, setLatestTouchTime] = useState(Date.now());
   const [isActive, setIsActive] = useState(initialActive);
 
   const handleInterval = () => {
     if (Date.now() - latestTouchTime > inactivityTime && isActive) {
       setIsActive(false);
+    }
+    if (Date.now() - latestTouchTime > inactivityTime + logoutDelay && !isActive) {
+      logOut();
     }
   };
 
@@ -30,7 +46,7 @@ export default function useTouchActivity(inactivityTime, intervalDelay, initialA
     onStartShouldSetPanResponderCapture: onTouch,
   });
 
-  const updateIsActive = (isActive) => {
+  const updateIsActive = (isActive: boolean) => {
     setIsActive(isActive);
   };
 

--- a/source/navigator/CustomStackNavigator.tsx
+++ b/source/navigator/CustomStackNavigator.tsx
@@ -67,17 +67,20 @@ const CustomStackNavigator = ({
   });
   const { handleLogout, isAuthenticated } = useContext(AuthContext);
 
+  const handleEndUserSession = async () => {
+    if (isAuthenticated) {
+      await handleLogout();
+      navigation.navigate('Start');
+    }
+  };
+
   const { isActive, panResponder, updateIsActive, updateLatestTouchTime } = useTouchActivity(
     parseInt(env.INACTIVITY_TIME),
     5000,
-    true
+    true,
+    60000,
+    handleEndUserSession
   );
-
-  const handleEndUserSession = async () => {
-    await handleLogout();
-    updateIsActive(true);
-    navigation.navigate('Start');
-  };
 
   const handleContinueUserSession = () => {
     updateIsActive(true);


### PR DESCRIPTION
## Explain the changes you’ve made

Changed the useTouchActivity hook so that the user is logged out some time after the inactivity dialog is shown.

## Explain why these changes are made

For security reasons the user should not remain logged in forever while inactive.

## Explain your solution

Add two extra parameters to the useTouchActivity hook, one for controlling the delay before logging the user out, and another for the callback to handle the logout. And some small changes to the useTouchActivity to use these and properly log the user out. 

Also added some types to the functions in useTouchActivity, and some jsDoc comments.  

## How to test the changes?

Check out branch, make sure that you've set the INACTIVITY_TIME in your .env file to something smallish, and then let the app run for a while. Also maybe change the third parameter of useTouchActivity in CustomStackNavigator to something smaller while testing, I set it to 60000 i.e. one minute. We can also discuss what this value should be. 

The desired behavior is that first the inactivity dialog should show up, and then after the delay set, the user should automatically be logged out and placed on the login screen. 
Check also that it resets correctly and works in different places etc., and that it doesn't trigger while logged out.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
