### PR TITLE
feat(summary-list): add ability to summarize values from editable-list

### DIFF
--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -193,7 +193,8 @@ const SummaryList: React.FC<Props> = ({
             }
           });
         } 
-      } else if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId) { 
+      } else if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId 
+      && answers?.[item.id]?.[item.inputId]) { 
         listItems.push(
           <SummaryListItemComponent
               item={item}
@@ -210,7 +211,7 @@ const SummaryList: React.FC<Props> = ({
           const numericValue: number = answers[item.id][item.inputId];
           addToSum(numericValue);
         }
-      } else {
+      } else if (['text', 'number', 'date'].includes(item.type)) {
         listItems.push(
           <SummaryListItemComponent
               item={item}

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -39,7 +39,8 @@ const SumContainer = styled.View<{ colorSchema: string }>`
 export interface SummaryListItem {
   title: string;
   id: string;
-  type: 'number' | 'text' | 'date' | 'checkbox' | 'arrayNumber' | 'arrayText' | 'arrayDate';
+  type: 'number' | 'text' | 'date' | 'checkbox' | 'arrayNumber' | 'arrayText' | 'arrayDate' 
+   | 'editableListText' | 'editableListNumber' | 'editableListDate' ;
   category?: string;
   inputId?: string;
 }
@@ -101,6 +102,10 @@ const SummaryList: React.FC<Props> = ({
       const oldAnswer: Record<string, string | number | boolean>[] = answers[item.id];
       oldAnswer[index][item.inputId] = value;
       onChange(oldAnswer, item.id);
+    } else if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId) {
+      const oldAnswer: Record<string, string | number | boolean> = answers[item.id];
+      oldAnswer[item.inputId] = value;
+      onChange(oldAnswer, item.id);
     } else {
       onChange(value, item.id);
     }
@@ -108,7 +113,7 @@ const SummaryList: React.FC<Props> = ({
 
   const onItemBlur = (item: SummaryListItem, index?: number) => (value: string | number | boolean) => {
     if (
-      ['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type) &&
+      ['arrayNumber', 'arrayText', 'arrayDate', 'editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) &&
       typeof index !== 'undefined' &&
       item.inputId
     ){
@@ -127,6 +132,10 @@ const SummaryList: React.FC<Props> = ({
     if (typeof index !== 'undefined') {
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
       oldAnswer.splice(index, 1);
+      onChange(oldAnswer, item.id);
+    } else if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId) { 
+      const oldAnswer: Record<string, string | number> = answers[item.id];
+      oldAnswer[item.inputId] = undefined;
       onChange(oldAnswer, item.id);
     } else {
       onChange(undefined, item.id);
@@ -184,6 +193,23 @@ const SummaryList: React.FC<Props> = ({
             }
           });
         } 
+      } else if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId) { 
+        listItems.push(
+          <SummaryListItemComponent
+              item={item}
+              value={answers[item.id][item.inputId]}
+              changeFromInput={changeFromInput(item)}
+              onBlur={onItemBlur(item)}
+              removeItem={removeListItem(item)}
+              colorSchema={colorSchema}
+              validationError={validationErrors?.[item.id]?.[item.inputId] ? validationErrors?.[item.id]?.[item.inputId] : undefined}
+              category={item.category}
+            />
+        );
+        if (item.type === 'editableListNumber') {
+          const numericValue: number = answers[item.id][item.inputId];
+          addToSum(numericValue);
+        }
       } else {
         listItems.push(
           <SummaryListItemComponent
@@ -198,7 +224,7 @@ const SummaryList: React.FC<Props> = ({
             />
         );
         if (item.type === 'number') {
-          const numericValue: number | string = answers[item.id];
+          const numericValue: number = answers[item.id];
           addToSum(numericValue);
         }
       }

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React, {useRef} from "react";
-import { View } from "react-native";
-import { TouchableHighlight, TouchableOpacity } from "react-native-gesture-handler";
+import { View, TouchableHighlight, TouchableOpacity  } from "react-native";
 import styled from "styled-components/native";
 import PropTypes from "prop-types";
 import { Text, Icon, Checkbox, Input } from "../../atoms";


### PR DESCRIPTION
## Explain the changes you’ve made

Add functionality for the summary list to handle values from editable lists as well, working in a similar fashion as for repeaters.

## Explain your solution

I add some logic to the Summary list to handle editable list inputs, similar as for repeater. Also add some new types to accomodate for this. 

Also fix a bug where the delete buttons in the summary list was not clickable on smaller resolution android screens, by changing which TouchableOpacity implementation we were using (no idea why it works, but I found the solution online, and it seems to work, so...). 

## How to test the changes?

Go into the Test form on develop, where the first two fields from the editable list should show up in the summary field. Check that deleting them works, and that values change as it should, and that validation works etc. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.