### PR TITLE
Fixed broken sub step buttons on Android

### DIFF
--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -10,6 +10,8 @@ const BackNavigationWrapper = styled.View({
   margin: 0,
   justifyContent: 'space-between',
   top: 0,
+  left: 0,
+  right: 0,
   zIndex: 999,
 });
 
@@ -34,6 +36,7 @@ const BackButton = styled.View((props) => ({
   width: 32,
   backgroundColor: props.theme.colors.neutrals[7],
 }));
+
 const BackButtonIcon = styled(Icon).attrs(({ theme, colorSchema }) => ({
   color: theme.colors.primary[colorSchema][0],
 }))``;

--- a/source/components/molecules/HelpButton/HelpButton.js
+++ b/source/components/molecules/HelpButton/HelpButton.js
@@ -21,6 +21,7 @@ const Container = styled.View({
 
 const CloseModal = styled(BackNavigation)`
   padding: 26px;
+  position: absolute;
 `;
 
 const BannerWrapper = styled.View`

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -18,15 +18,11 @@ const StepContainer = styled.View`
   flex: 1;
 `;
 
-const StepContentContainer = styled.View`
-  /* Covers space occupied by the StepBackNavigation */
-  margin-top: -80px;
-  height: 100%;
-  position: relative;
-`;
+const StepContentContainer = styled.View``;
 
 const StepBackNavigation = styled(BackNavigation)`
   padding: 24px;
+  position: absolute;
 `;
 
 const StepBanner = styled(Banner)`

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -133,12 +133,7 @@ function Step({
             />
           )}
 
-          <StepContentContainer
-            contentContainerStyle={{
-              flexGrow: 1,
-            }}
-            showsHorizontalScrollIndicator={false}
-          >
+          <StepContentContainer>
             {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
               <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
             )}


### PR DESCRIPTION
## Explain the changes you’ve made

Fixed bug on Android that caused user not be able to click on buttons in sub forms. 

## Explain your solution

Removed negative margins on wrapper container and replaced with position absolute. 

## How to test the changes?

yarn android
Go to a sub form and click on any button in step footer and it should now work. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.
