### PR TITLE
Feat/back to main and next

### DIFF
--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -28,7 +28,6 @@ const ButtonWrapper = styled.View`
 interface Props {
   actions: Action[];
   caseStatus: CaseStatus;
-  background?: string;
   answers: Record<string, any>;
   allQuestions: Question[];
   formNavigation: {
@@ -47,7 +46,11 @@ interface Props {
   updateCaseInContext: (
     answers: Record<string, any>,
     status: CaseStatus,
+<<<<<<< HEAD
     currentPosition: FormPosition
+=======
+    currentFormPosition: FormPosition
+>>>>>>> 5289c63 (feat(backToMainAndNext): remove some unnecessary comments, and fix some typing mistakes in StepFooter)
   ) => void;
   currentPosition: FormPosition;
   validateStepAnswers: (errorCallback: () => void, onValidCallback: () => void) => void;
@@ -161,7 +164,6 @@ const StepFooter: React.FC<Props> = ({
 
 StepFooter.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
-
   /**
    * Properties for actions in the footer of the step.
    */
@@ -173,10 +175,6 @@ StepFooter.propTypes = {
       conditionalOn: PropTypes.string,
     })
   ).isRequired,
-  /**
-   * Background color for the footer
-   */
-  background: PropTypes.string,
   /**
    * Status: ongoing or submitted or possibly others
    */
@@ -190,41 +188,31 @@ StepFooter.propTypes = {
    * An object bundling all functions relevant for navigation through the form.
    */
   formNavigation: PropTypes.shape({
-    /** go to next step */
     next: PropTypes.func,
-    /** go to previous step */
     back: PropTypes.func,
     /** go up a level to parent step */
     up: PropTypes.func,
     /** go down to a child step */
     down: PropTypes.func,
-    /** close the form */
     close: PropTypes.func,
     /** action to trigger when starting the form */
     start: PropTypes.func,
-    /** action to return to main form */
     goToMainForm: PropTypes.func,
     goToMainFormAndNext: PropTypes.func,
-    /** whether we are at the last of the main steps */
     isLastStep: PropTypes.func,
   }).isRequired,
   onUpdate: PropTypes.func,
-  /** Behaviour for the submit action */
   onSubmit: PropTypes.func,
   /** Behaviour for updating case in context and backend */
   updateCaseInContext: PropTypes.func,
-  /** The current position in the form */
   currentPosition: PropTypes.shape({
     index: PropTypes.number,
     level: PropTypes.number,
     currentMainStep: PropTypes.number,
     currentMainStepIndex: PropTypes.number,
   }).isRequired,
-  /** Validate all answers in current step * */
+  /** Validate all answers in current step */
   validateStepAnswers: PropTypes.func,
 };
 
-StepFooter.defaultProps = {
-  background: '#00213F',
-};
 export default StepFooter;

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -39,6 +39,7 @@ interface Props {
     start: (callback: () => void) => void;
     close: () => void;
     goToMainForm: () => void;
+    goToMainFormAndNext: () => void;
     isLastStep: () => boolean;
   };
   onUpdate: (answers: Record<string, any>) => void;
@@ -102,6 +103,9 @@ const StepFooter: React.FC<Props> = ({
       }
       case 'backToMain': {
         return formNavigation.goToMainForm;
+      }
+      case 'backToMainAndNext': {
+        return formNavigation.goToMainFormAndNext;
       }
       default: {
         return () => {
@@ -200,6 +204,7 @@ StepFooter.propTypes = {
     start: PropTypes.func,
     /** action to return to main form */
     goToMainForm: PropTypes.func,
+    goToMainFormAndNext: PropTypes.func,
     /** whether we are at the last of the main steps */
     isLastStep: PropTypes.func,
   }).isRequired,

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -166,7 +166,20 @@ export function goBackToMainForm(state: FormReducerState) {
     currentPosition: {...currentPosition, index: currentPosition.currentMainStepIndex, level: 0 }
   }
 }
+/**
+ * Goes back to the main form, and then to the next step.
+ * @param state current form state
+ */
+export function goBackToMainFormAndNext(state: FormReducerState) {
+  const { currentPosition } = state;
 
+  const nextMainStepIndex = currentPosition.currentMainStepIndex < state.numberOfMainSteps-2 ? currentPosition.currentMainStepIndex + 1 : currentPosition.currentMainStep;
+
+  return {
+    ...state,
+    currentPosition: {...currentPosition, index: nextMainStepIndex, currentMainStepIndex: nextMainStepIndex, level: 0 },
+  };
+}
 /**
  * Action to run when starting a form.
  * @param {object} state the current state of the form

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -166,9 +166,7 @@ export function goBackToMainForm(state: FormReducerState) {
     currentPosition: {...currentPosition, index: currentPosition.currentMainStepIndex, level: 0 }
   }
 }
-/**
- * Goes back to the main form, and then to the next step.
- */
+
 export function goBackToMainFormAndNext(state: FormReducerState) {
   const { connectivityMatrix, currentPosition } = state;
 

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -168,17 +168,24 @@ export function goBackToMainForm(state: FormReducerState) {
 }
 /**
  * Goes back to the main form, and then to the next step.
- * @param state current form state
  */
 export function goBackToMainFormAndNext(state: FormReducerState) {
-  const { currentPosition } = state;
+  const { connectivityMatrix, currentPosition } = state;
 
-  const nextMainStepIndex = currentPosition.currentMainStepIndex < state.numberOfMainSteps-2 ? currentPosition.currentMainStepIndex + 1 : currentPosition.currentMainStep;
-
-  return {
-    ...state,
-    currentPosition: {...currentPosition, index: nextMainStepIndex, currentMainStepIndex: nextMainStepIndex, level: 0 },
-  };
+  const newPosition = {...currentPosition, index: currentPosition.currentMainStepIndex, level: 0};
+  const nextIndex = getNextIndex(connectivityMatrix, newPosition);
+  if (nextIndex >= 0) {
+    return {
+      ...state,
+      currentPosition: {
+        index: nextIndex,
+        level: 0,
+        currentMainStep:
+          state.currentPosition.currentMainStep + 1,
+        currentMainStepIndex: nextIndex,
+      },
+    };
+  }
 }
 /**
  * Action to run when starting a form.

--- a/source/containers/Form/hooks/formReducer.ts
+++ b/source/containers/Form/hooks/formReducer.ts
@@ -14,6 +14,7 @@ import {
   validateAnswer,
   validateAllStepAnswers,
   dirtyField,
+  goBackToMainFormAndNext,
 } from './formActions';
 
 type Action =
@@ -42,6 +43,9 @@ type Action =
     }
   | {
       type: 'GO_TO_MAIN_FORM';
+    }
+  | {
+      type: 'GO_TO_MAIN_FORM_AND_NEXT';
     }
   | {
       type: 'START_FORM';
@@ -122,7 +126,9 @@ function formReducer(state: FormReducerState, action: Action) {
     case 'GO_TO_MAIN_FORM': {
       return goBackToMainForm(state);
     }
-
+    case 'GO_TO_MAIN_FORM_AND_NEXT': {
+      return goBackToMainFormAndNext(state);
+    }
     case 'START_FORM': {
       return startForm(state, action.payload);
     }

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -86,6 +86,9 @@ function useForm(initialState: FormReducerState) {
     dispatch({ type: 'GO_TO_MAIN_FORM' });
   };
 
+  const goToMainFormAndNext = () => {
+    dispatch({ type: 'GO_TO_MAIN_FORM_AND_NEXT' });
+  };
   const isLastStep = () => false; // Need to think and fix this. //formState.steps.length === formState.counter;
 
   /**
@@ -147,6 +150,7 @@ function useForm(initialState: FormReducerState) {
     start: startForm,
     close: closeForm,
     goToMainForm,
+    goToMainFormAndNext,
     isLastStep,
   };
 

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -48,7 +48,14 @@ export interface Question {
   help?: Help;
 }
 
-export type ActionType = 'start' | 'next' | 'submit' | 'sign' | 'close' | 'backToMain';
+export type ActionType =
+  | 'start'
+  | 'next'
+  | 'submit'
+  | 'sign'
+  | 'close'
+  | 'backToMain'
+  | 'backToMainAndNext';
 export interface Action {
   type: ActionType;
   label: string;


### PR DESCRIPTION
## Explain the changes you’ve made

Implements a type of navigation, where you go from a substep back to the next main step. 

## Explain why these changes are made

While this is not needed for EKB-löpande, it is required for grundansökan, and since we want that to be functional for testing, I'm adding this. 
Actually did this a few weeks ago, but apparently never made a PR out of it, but I still added it to the formbuilder, so Maria has been using it for grundansökan.

## Explain your solution

Add a new navigation type, 'backToMainAndNext', with associated logic.

## How to test the changes?

Either in the Grundansökan form, most of the subforms there implement this navigation. Or in the Test form in develop, on the first page I've added a nav-button and a subpage that implements this navigation behavior. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

