### PR TITLE
Fix/date validation

### DIFF
--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -40,8 +40,7 @@ const StyledErrorText = styled(Text)`
 `;
 
 const Input: React.FC<InputProps> = React.forwardRef(
-  ({ onBlur, showErrorMessage, ...props }, ref) => {
-    const { value, error } = props;
+  ({ onBlur, showErrorMessage, value, error, ...props }, ref) => {
 
     const handleBlur = () => {
       if (onBlur) onBlur(value);

--- a/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
+++ b/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { View, TouchableOpacity } from 'react-native';
 import CalendarPicker from 'react-native-calendar-picker';
@@ -12,7 +12,6 @@ import Button from '../../atoms/Button';
 import Text from '../../atoms/Text';
 import { Modal, useModal } from '../Modal';
 
-// Set localized date form.
 moment.locale('sv');
 
 const CalendarContainer = styled.View`
@@ -62,7 +61,7 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
   style,
 }) => {
   const [modalVisible, toggleModal] = useModal();
-  // Handle selected date and hide calendar modal.
+
   const handleCalendarDateChange = (selectedDate: moment.Moment) => {
     onSelect(selectedDate.format('Y-MM-DD'));
     toggleModal();
@@ -134,15 +133,11 @@ CalendarPickerForm.propTypes = {
    * Calendar date change callback.
    */
   onSelect: PropTypes.func,
-  /**
-   * Date value. Used for storing and displaying date in components.
-   */
   value: PropTypes.string,
   /** Turn the input field of. Defaults to true. */
   editable: PropTypes.bool,
   /** Turn the background of input field transparent */
   transparent: PropTypes.bool,
-  /** Additional styling for the input box */
   style: PropTypes.object,
   colorSchema: PropTypes.oneOf(['blue', 'green', 'red', 'purple', 'neutral']),
   showErrorMessage: PropTypes.bool,

--- a/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
+++ b/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
@@ -10,7 +10,7 @@ import { colorPalette } from '../../../styles/palette';
 import { PrimaryColor } from '../../../styles/themeHelpers';
 import Button from '../../atoms/Button';
 import Text from '../../atoms/Text';
-import Modal from '../Modal/Modal';
+import { Modal, useModal } from '../Modal';
 
 // Set localized date form.
 moment.locale('sv');
@@ -35,7 +35,6 @@ const ButtonContainer = styled.View`
 `;
 const DateInput = styled(Input)<{ transparent: boolean }>`
   ${({ transparent }) => transparent && 'background: transparent;'}
-  border: none;
   text-align: right;
   min-width: 80%;
   font-weight: 500;
@@ -48,6 +47,8 @@ interface PropInterface {
   editable?: boolean;
   transparent?: boolean;
   style?: React.CSSProperties;
+  showErrorMessage?: boolean;
+  error?: { isValid: boolean; message: string };
   colorSchema: PrimaryColor;
 }
 const CalendarPickerForm: React.FC<PropInterface> = ({
@@ -56,24 +57,20 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
   editable = true,
   transparent,
   colorSchema,
+  showErrorMessage,
+  error,
   style,
 }) => {
-  const [isVisible, setIsVisible] = useState(false);
-
+  const [modalVisible, toggleModal] = useModal();
   // Handle selected date and hide calendar modal.
   const handleCalendarDateChange = (selectedDate: moment.Moment) => {
     onSelect(selectedDate.format('Y-MM-DD'));
-    setIsVisible(!isVisible);
+    toggleModal();
   };
 
   return (
     <View>
-      <TouchableOpacity
-        disabled={!editable}
-        onPress={() => {
-          setIsVisible(!isVisible);
-        }}
-      >
+      <TouchableOpacity disabled={!editable} onPress={toggleModal}>
         <DateInput
           placeholder="Välj datum"
           value={value}
@@ -84,10 +81,12 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
           transparent={transparent}
           style={style}
           colorSchema={colorSchema}
+          showErrorMessage={showErrorMessage}
+          error={error}
         />
       </TouchableOpacity>
 
-      <Modal visible={isVisible} presentationStyle="overFullScreen">
+      <Modal visible={modalVisible} presentationStyle="overFullScreen" hide={toggleModal}>
         <CalendarContainer>
           <CalendarStyle>
             <CalendarPicker
@@ -121,7 +120,7 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
           </CalendarStyle>
         </CalendarContainer>
         <ButtonContainer>
-          <Button colorSchema="blue" onClick={() => setIsVisible(false)}>
+          <Button colorSchema="blue" onClick={toggleModal}>
             <Text>Avbryt</Text>
           </Button>
         </ButtonContainer>
@@ -145,6 +144,12 @@ CalendarPickerForm.propTypes = {
   transparent: PropTypes.bool,
   /** Additional styling for the input box */
   style: PropTypes.object,
+  colorSchema: PropTypes.oneOf(['blue', 'green', 'red', 'purple', 'neutral']),
+  showErrorMessage: PropTypes.bool,
+  error: PropTypes.shape({
+    isValid: PropTypes.bool.isRequired,
+    message: PropTypes.string.isRequired,
+  }),
 };
 
 export default CalendarPickerForm;

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -244,6 +244,7 @@ export function validateAnswer(
 
   if (['text', 'number', 'date', 'checkbox'].includes(question.type)) {
     const { validation } = question;
+    console.log('validation: ', validation, question.type);
     if (validation && ((checkIfDirty && state.dirtyFields?.[questionId]) || !checkIfDirty)) {
       const [isValid, validationMessage] = validateInput(answer[questionId], validation.rules);
 
@@ -312,7 +313,7 @@ export function validateAnswer(
  * @param onErrorCallback   Called when validation failed for an input field.
  * @param onValidCallback   Called when all field validated successfully.
  */
-export function validateAllStepAnswers( state: FormReducerState, onErrorCallback, onValidCallback ) {
+export function validateAllStepAnswers( state: FormReducerState, onErrorCallback: () => void, onValidCallback: () => void ) {
   // Collect all questions.
   const currentStepIndex = state.currentPosition.index;
   const currentStepQuestions = state.steps[currentStepIndex].questions;
@@ -339,7 +340,7 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
   for (const questionIndex in currentStepQuestions) {
     const question = currentStepQuestions[questionIndex]
 
-    if (['text', 'number, checkbox'].includes(question.type)) {
+    if (['text', 'number', 'date', 'checkbox'].includes(question.type)) {
       if (state.validations[question.id]?.isValid === false) {
         allInputsValid = false;
 

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -244,7 +244,6 @@ export function validateAnswer(
 
   if (['text', 'number', 'date', 'checkbox'].includes(question.type)) {
     const { validation } = question;
-    console.log('validation: ', validation, question.type);
     if (validation && ((checkIfDirty && state.dirtyFields?.[questionId]) || !checkIfDirty)) {
       const [isValid, validationMessage] = validateInput(answer[questionId], validation.rules);
 

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -40,7 +40,7 @@ function useForm(initialState: FormReducerState) {
     });
   }, [formState.steps]);
 
-  const validateStepAnswers = (onErrorCallback, onValidCallback) => {
+  const validateStepAnswers = (onErrorCallback: () => void, onValidCallback: () => void) => {
     dispatch({
       type: 'VALIDATE_ALL_STEP_ANSWERS',
       payload: { onErrorCallback, onValidCallback },

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -49,6 +49,9 @@ const inputTypes = {
     component: CalendarPicker,
     changeEvent: 'onSelect',
     initialValue: undefined,
+    props: {
+      showErrorMessage: true,
+    },
   },
   list: {},
   checkbox: {


### PR DESCRIPTION
## Explain the changes you’ve made

Add validation to the date input, essentially so that we can set it to be required. 

## Explain why these changes are made

We might want to be able to have a date as required. 

## Explain your solution

Slight changes to validation logic so that it correctly checks date inputs. 
Also small changes to the CalendarPicker component, so that it can show an error message and red border, in exactly the same way as the normal TextInput. Actually the Input component is used, so I'm just passing props through the CalendarPicker, and using the styling and logic of Input to display the error message. 

Also, updates the CalendarPicker to use the new useModal hook for consistency. 

## How to test the changes?

Checkout branch, then there is a new small form called Validation Test in develop, that has a required date input. So try leaving it empty and go to the next page; it should trigger validation and display the validation error correctly. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
