### PR TITLE
Authentication bug fix

### DIFF
--- a/source/services/AuthService.js
+++ b/source/services/AuthService.js
@@ -43,7 +43,7 @@ export async function saveAccessTokenToStorage(accessToken) {
   }
 }
 /**
- * This function saves the accessToken and it's expire time to AsyncStorage.
+ * This function removes the accessToken from AsyncStorage.
  * @param {string} accessToken json web token;
  */
 export async function removeAccessTokenFromStorage() {

--- a/source/services/AuthService.js
+++ b/source/services/AuthService.js
@@ -2,6 +2,7 @@ import env from 'react-native-config';
 import JwtDecode from 'jwt-decode';
 import StorageService, { TOKEN_KEY } from './StorageService';
 import { post, get } from '../helpers/ApiRequest';
+import { getMessage } from '../helpers/MessageHelper';
 
 /**
  * This function retrives the accessToken from AsyncStorage and decodes it.
@@ -103,6 +104,7 @@ export async function getUserProfile(accessToken) {
 
     if (decodedToken && decodedToken.personalNumber) {
       let timesRun = 0;
+
       const response = await poll(
         function () {
           timesRun += 1;
@@ -113,13 +115,16 @@ export async function getUserProfile(accessToken) {
         (response) => timesRun < 5 && response.status !== 200,
         1000
       );
+
       if (response.status === 200) {
         return [response.data.data.attributes.item, null];
       }
+
       if (response.status === 404) {
         throw new Error('404, no such user found');
       }
-      throw new Error(response);
+
+      throw new Error(getMessage('unkownError'));
     }
   } catch (error) {
     return [null, error];

--- a/source/services/AuthService.js
+++ b/source/services/AuthService.js
@@ -122,7 +122,6 @@ export async function getUserProfile(accessToken) {
       throw new Error(response);
     }
   } catch (error) {
-    console.log(error);
     return [null, error];
   }
 }

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -123,7 +123,7 @@ function AuthProvider({ children, initialState }) {
   /**
    * This function checks if the current accessToken is valid.
    */
-  async function isUserAuthenticated() {
+  async function isAccessTokenValid() {
     const decodedToken = await authService.getAccessTokenFromStorage();
 
     // TODO: Remove this condition when exp value is set on the jwt token in the api.
@@ -147,7 +147,7 @@ function AuthProvider({ children, initialState }) {
     handleAuth,
     handleCancelOrder,
     handleSetStatus,
-    isUserAuthenticated,
+    isAccessTokenValid,
     handleSign,
     isLoading: state.status === 'pending',
     isIdle: state.status === 'idle',

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -73,6 +73,9 @@ export async function addProfile() {
   } catch (error) {
     return {
       type: actionTypes.authError,
+      payload: {
+        error,
+      },
     };
   }
 }

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -71,7 +71,6 @@ export async function addProfile() {
       payload: userProfile,
     };
   } catch (error) {
-    console.error(error);
     return {
       type: actionTypes.authError,
     };

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -63,7 +63,7 @@ export async function addProfile() {
     const [userProfile, userError] = await authService.getUserProfile(decodedToken.accessToken);
 
     if (userError) {
-      throw new Error(userError);
+      throw userError;
     }
 
     return {

--- a/source/store/reducers/AuthReducer.js
+++ b/source/store/reducers/AuthReducer.js
@@ -3,7 +3,7 @@ import { actionTypes } from '../actions/AuthActions';
 export const initialState = {
   isActive: true,
   isAuthenticated: false,
-  user: {},
+  user: null,
   error: null,
   status: 'idle',
   isBankidInstalled: false,


### PR DESCRIPTION
## Explain the changes you’ve made

Fixed a bug that made it possible to log in to the app without having access to AWS. This was possible by having a jwt token stored in local storage, but the token was not valid to request our api. So i could log in without fetching the user object.  

## Explain why these changes are made

To make the app authentication a little more safe. 

## Explain your solution

I restructured the login part in SplashScreen to make sure the token is valid and user object exists before log in. 
Also did some cleanup, fixed error handling, fixed method descriptions etc.. 

## How to test the changes?

- Disable bankid and add an invalid token to .env:
USE_BANKID=false
FAKE_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJzb25hbE51bWJlciI6IjE5NTgwOTI2Mjc0MyIsImV4cCI6MTcwMzg5NTA1OSwiaWF0IjoxNzAzODk0MTU5fQ.VFXwGIfajWT6a4CasL59qQ1vOUo5S2p5OacQA4xO0TQ
- Rebuild the app.
- Try to login and it should fail to log in.
- Then change to a valid token and it should work as before to log in. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Anyhting else?
I'm not completely happy with how the auth flow is structured because its not very straightforward, with lots of magic inside side effects its hard to understand whats going on. Maybe this can be refactored in the future, didn't want to fuck things up right now 😅 