### PR TITLE
feat(last-step-close): change behaviour of close button on last main step

### DIFF
--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -23,7 +23,7 @@ const BackNavigationSingleWrapper = styled.View((props) => ({
   top: 0,
   zIndex: 999,
   right: 0,
-  position: props.inSubstep ? 'absolute' : 'relative',
+  position: props.isSubstep ? 'absolute' : 'relative',
 }));
 
 const BackButton = styled.View((props) => ({
@@ -68,10 +68,10 @@ const BackNavigation = ({
   onClose,
   showBackButton,
   showCloseButton,
-  inSubstep,
+  isSubstep,
   primary,
 }) =>
-  !inSubstep ? (
+  !isSubstep ? (
     <BackNavigationWrapper style={style}>
       {showBackButton ? (
         <BackButton colorSchema={colorSchema} onStartShouldSetResponder={onBack}>
@@ -88,7 +88,7 @@ const BackNavigation = ({
       ) : null}
     </BackNavigationWrapper>
   ) : (
-    <BackNavigationSingleWrapper inSubstep={inSubstep} style={style}>
+    <BackNavigationSingleWrapper isSubstep={isSubstep} style={style}>
       <CloseButton
         primary={primary}
         colorSchema={colorSchema}
@@ -108,7 +108,7 @@ BackNavigation.propTypes = {
   onClose: PropTypes.func,
   showBackButton: PropTypes.bool,
   showCloseButton: PropTypes.bool,
-  inSubstep: PropTypes.bool,
+  isSubstep: PropTypes.bool,
   primary: PropTypes.bool,
 };
 

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -92,10 +92,10 @@ function Step({
       formNavigation.close(() => {});
     }
   };
-  const inSubstep = currentPosition.level !== 0;
-  const inLastMainStep =
+  const isSubstep = currentPosition.level !== 0;
+  const isLastMainStep =
     currentPosition.level === 0 && currentPosition.currentMainStep === totalStepNumber;
-  const backButtonBehavior = inSubstep ? formNavigation.goToMainForm : formNavigation.back;
+  const backButtonBehavior = isSubstep ? formNavigation.goToMainForm : formNavigation.back;
 
   const [fadeValue] = useState(new Animated.Value(0));
 
@@ -126,13 +126,13 @@ function Step({
             closeDialog={() => setCloseDialogVisible(false)}
           />
 
-          {!inSubstep && (
+          {!isSubstep && (
             <StepBackNavigation
               showBackButton={isBackBtnVisible}
-              inSubstep={inSubstep}
+              isSubstep={isSubstep}
               onBack={backButtonBehavior}
               onClose={() => {
-                if (inLastMainStep) {
+                if (isLastMainStep) {
                   closeForm();
                 } else {
                   setCloseDialogVisible(true);
@@ -221,10 +221,10 @@ function Step({
         </Animated.View>
       </KeyboardAwareScrollView>
 
-      {inSubstep && (
+      {isSubstep && (
         <StepBackNavigation
           showBackButton={isBackBtnVisible}
-          inSubstep={inSubstep}
+          isSubstep={isSubstep}
           primary={false}
           onBack={backButtonBehavior}
           onClose={() => setCloseDialogVisible(true)}

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -93,6 +93,8 @@ function Step({
     }
   };
   const inSubstep = currentPosition.level !== 0;
+  const inLastMainStep =
+    currentPosition.level === 0 && currentPosition.currentMainStep === totalStepNumber;
   const backButtonBehavior = inSubstep ? formNavigation.goToMainForm : formNavigation.back;
 
   const [fadeValue] = useState(new Animated.Value(0));
@@ -129,7 +131,13 @@ function Step({
               showBackButton={isBackBtnVisible}
               inSubstep={inSubstep}
               onBack={backButtonBehavior}
-              onClose={() => setCloseDialogVisible(true)}
+              onClose={() => {
+                if (inLastMainStep) {
+                  closeForm();
+                } else {
+                  setCloseDialogVisible(true);
+                }
+              }}
               colorSchema={colorSchema || 'blue'}
             />
           )}


### PR DESCRIPTION
## Explain the changes you’ve made

Change the behaviour of the x-button in the form on the last main step so that it closes the form directly, without showing a confirmation dialog.

## Explain your solution

Add a small check whether or not the user is on the last main step, and if so, change the behaviour of the close button to not show the modal. 

## How to test the changes?

Checkout branch, go into any form, go to last step and click the cross. Also check that the dialog still appears on other steps. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.