### PR TITLE
hotfix(Input): pass value prop to input

### DIFF
--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -49,6 +49,7 @@ const Input: React.FC<InputProps> = React.forwardRef(
     return (
       <>
         <StyledTextInput
+          value={value}
           multiline /** Temporary fix to make field scrollable inside scrollview */
           numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
           onBlur={handleBlur}


### PR DESCRIPTION
In the date-validation PR (which did pass review), value was destructured from the props in the Input component, and since it was only passed as part of {...other}, this meant that it was no longer passed, which breaks all text inputs in the app! 