### PR TITLE
fix(various): fix various smaller errors that was setting of warnings

### DIFF
--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -33,7 +33,7 @@ const StyledTextInput = styled.TextInput<InputProps>`
 `;
 
 const StyledErrorText = styled(Text)`
-  font-size: ${({ theme }) => theme.fontSizes[3]};
+  font-size: ${({ theme }) => theme.fontSizes[3]}px;
   color: ${(props) => props.theme.textInput.errorTextColor};
   font-weight: ${({ theme }) => theme.fontWeights[0]};
   padding-top: 8px;

--- a/source/components/atoms/Label/Label.tsx
+++ b/source/components/atoms/Label/Label.tsx
@@ -8,7 +8,7 @@ import { StyleProp, TextStyle } from 'react-native';
 import { PrimaryColor, getValidColorSchema } from '../../../styles/themeHelpers';
 
 const LabelText = styled(Text)<{size: 'small' | 'medium' | 'large'; color: PrimaryColor }>`
-  font-size: ${props => props.theme.label[props.size].font};
+  font-size: ${props => props.theme.label[props.size].font}px;
   color: ${props => props.theme.label.colors[props.color].text};
   text-transform: uppercase;
   font-weight: bold;
@@ -16,20 +16,20 @@ const LabelText = styled(Text)<{size: 'small' | 'medium' | 'large'; color: Prima
   padding-top: 5px;
 `;
 const LabelBorder = styled.View<{size: 'small' | 'medium' | 'large'; color: PrimaryColor; underline?: boolean; }>`
-  padding-bottom: ${props => props.theme.label[props.size].paddingBottom};
+  padding-bottom: ${props => props.theme.label[props.size].paddingBottom}px;
   border-bottom-color: ${props => props.theme.label.colors[props.color].underline};
   border-bottom-width: ${props => {
     if (props.underline === false) {
-      return '0px';
+      return 0;
     }
     return theme.label[props.size].lineWidth;
-  }};
+  }}px;
   margin-bottom: ${props => {
     if (props.underline === false) {
-      return '0px';
+      return 0;
     }
     return theme.label[props.size].marginBottom;
-  }};
+  }}px;
   align-self: flex-start;
   margin-right: 8px;
 `;

--- a/source/components/molecules/CheckboxField/CheckboxField.tsx
+++ b/source/components/molecules/CheckboxField/CheckboxField.tsx
@@ -59,7 +59,7 @@ const CheckboxFieldText = styled(Text)<{ size: 'small' | 'medium' | 'large' }>`
 `;
 
 const StyledErrorText = styled(Text)`
-  font-size: ${({ theme }) => theme.fontSizes[3]};
+  font-size: ${({ theme }) => theme.fontSizes[3]}px;
   color: ${(props) => props.theme.textInput.errorTextColor};
   font-weight: ${({ theme }) => theme.fontWeights[0]};
   margin-left: -50px;

--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -19,7 +19,7 @@ const ListBodyFieldLabel = styled(Heading)<{ colorSchema: string }>`
   margin-top: 5px;
   margin-left: 3px;
   font-weight: ${(props) => props.theme.fontWeights[1]};
-  font-size: ${(props) => props.theme.fontSizes[3]};
+  font-size: ${(props) => props.theme.fontSizes[3]}px;
   color: ${(props) => props.theme.colors.primary[props.colorSchema][1]};
 `;
 

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -80,7 +80,7 @@ export type ImageStatus = 'loading' | 'uploaded' | 'error';
 
 interface Props {
   buttonText: string;
-  value: Image[];
+  value: Image[] | string;
   onChange: (value: Record<string, any>[]) => void;
   colorSchema?: PrimaryColor;
   maxImages?: number;
@@ -93,7 +93,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: oldImages, onChange
   const [choiceModalVisible, toggleModal] = useModal();
 
   useEffect(() => {
-    if (oldImages) {
+    if (oldImages && typeof oldImages !== 'string') {
       setImages(oldImages);
     }
   }, [oldImages]);
@@ -182,7 +182,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: oldImages, onChange
   const addImageFromCamera = () => {
     ImagePicker.openCamera({
       cropping: true,
-      includeBase64: true,
+      includeBase64: false,
     })
       .then((image) => {
         const length = addImagesToState([image]);

--- a/source/components/molecules/PersonField/PersonField.tsx
+++ b/source/components/molecules/PersonField/PersonField.tsx
@@ -32,15 +32,15 @@ const PersonFieldDetails = styled.View`
 
 const PersonFieldInfoName = styled(Text)`
   font-weight: ${props => props.theme.fontWeights[1]};
-  font-size: ${props => props.theme.fontSizes[4]};
+  font-size: ${props => props.theme.fontSizes[4]}px;
 `
 const PersonFieldInfoRelation = styled(Text)`
-  font-weight: ${props => props.theme.fontWeights[1]};
+  font-weight: ${props => props.theme.fontWeights[1]}px;
   color: ${props => props.theme.colors.primary.blue[1]};
 `
 const PersonFieldInfoPNO = styled(Text)`
 margin-top: 6px;
-  font-size: ${props => props.theme.fontSizes[3]};
+  font-size: ${props => props.theme.fontSizes[3]}px;
 `
 const PersonFieldDivider = styled.View<{colorSchema: string}>`
   height: 2px;

--- a/source/components/organisms/Step/StepDescription/StepDescription.js
+++ b/source/components/organisms/Step/StepDescription/StepDescription.js
@@ -27,7 +27,7 @@ const StepDescriptionTagline = styled(Text)`
 const StepDescriptionText = styled(Text)`
   line-height: ${(props) => props.theme.typography[props.type].lineHeight}px;
   margin-top: 16px;
-  font-size: ${(props) => props.theme.fontSizes[3]};
+  font-size: ${(props) => props.theme.fontSizes[3]}px;
 `;
 
 function StepDescription({

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -14,7 +14,7 @@ const SumLabel = styled(Heading)<{ colorSchema: string }>`
   margin-top: 5px;
   margin-left: 3px;
   font-weight: ${props => props.theme.fontWeights[1]};
-  font-size: ${props => props.theme.fontSizes[3]};
+  font-size: ${props => props.theme.fontSizes[3]}px;
   color: ${props => props.theme.colors.primary[props.colorSchema][1]};
 `;
 const SumText = styled(Text)`

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -86,7 +86,7 @@ const DeleteButtonHighligth = styled(TouchableHighlight)`
 `;
 
 const ValidationErrorMessage = styled(Text)`
-  font-size: ${({ theme }) => theme.fontSizes[3]};
+  font-size: ${({ theme }) => theme.fontSizes[3]}px;
   color: ${(props) => props.theme.textInput.errorTextColor};
   font-weight: ${({ theme }) => theme.fontWeights[0]};
   margin-top: 8px;

--- a/source/styles/theme.js
+++ b/source/styles/theme.js
@@ -461,22 +461,22 @@ const theme = {
   },
   label: {
     small: {
-      font: '12px',
-      paddingBottom: '3px',
-      lineWidth: '2px',
-      marginBottom: '6px',
+      font: 12,
+      paddingBottom: 3,
+      lineWidth: 2,
+      marginBottom: 6,
     },
     medium: {
-      font: '14px',
-      paddingBottom: '7px',
-      lineWidth: '3px',
-      marginBottom: '12px',
+      font: 14,
+      paddingBottom: 7,
+      lineWidth: 3,
+      marginBottom: 12,
     },
     large: {
-      font: '18px',
-      paddingBottom: '10px',
-      lineWidth: '4px',
-      marginBottom: '18px',
+      font: 18,
+      paddingBottom: 10,
+      lineWidth: 4,
+      marginBottom: 18,
     },
     colors: {
       purple: {


### PR DESCRIPTION
## Explain the changes you’ve made

Fixed various smaller things, to get rid of a number of warnings about font-size expecting units, and a wrong parameter in ImageUploader that was appending base64 data to the answer object which I apparently forgot to change. 
Also changed how Label sizes were set in the theme, to make it consistent with how we set other theme sizes as numbers and not strings. 

## How to test the changes?

Run the app, hopefully there is a few less warnings about missing/wrong font-sizes. But of course, there's still plenty of other warnings left. And you can also check that the answer-object returned from ImageUploader no longer contains the entire image when you take a photo with the camera.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
