### PR TITLE
Feat/card info button

### DIFF
--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.stories.js
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.stories.js
@@ -100,6 +100,27 @@ const cardData5 = {
   ],
 };
 
+const cardData6 = {
+  shadow: true,
+  outlined: false,
+  backgroundColor: 'blue',
+  colorSchema: 'blue',
+  components: [
+    { type: 'image', image: 'ICON_TELL' },
+    { type: 'subtitle', text: 'Subtitle' },
+    { type: 'title', text: 'Informationsmodal' },
+    {
+      type: 'button',
+      text: 'Se Info',
+      icon: 'help',
+      action: 'infoModal',
+      closeButtonText: 'Tillbaka',
+      markdownText: 'Hello World!',
+      heading: 'Info Modal',
+    },
+  ],
+};
+
 storiesOf('Dynamic Card Renderer', module).add('default', (props) => (
   <StoryWrapper {...props}>
     <FlexContainer>
@@ -109,6 +130,7 @@ storiesOf('Dynamic Card Renderer', module).add('default', (props) => (
       <DynamicCardRenderer {...cardData3} />
       <DynamicCardRenderer {...cardData4} />
       <DynamicCardRenderer {...cardData5} />
+      <DynamicCardRenderer {...cardData6} />
     </FlexContainer>
   </StoryWrapper>
 ));

--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.stories.js
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.stories.js
@@ -6,6 +6,32 @@ import { Text } from '../../components/atoms';
 import StoryWrapper from '../../components/molecules/StoryWrapper';
 import DynamicCardRenderer from './';
 
+const userAgreementText = `
+För att kunna handlägga din ansökan om ekonomiskt bistånd måste vi behandla följande personuppgifter om dig/er:  
+
++ För och efternamn samt mellannamn på dig, eventuell medsökande och barn 
++ Adress för dig och eventuell medsökande 
++ Personnummer för dig och eventuell medsökande 
++ Folkbokföringsadress 
++ Information om barns boendesituation samt om barnet går i skola eller står i kö till skola 
++ Inkomster och utgifter  
++ Sökt ersättning  
++ E-postadress 
++ Telefonnummer 
++ Civilstånd 
++ Medborgarskap 
++ Bostad 
++ Ekonomisk översikt.  
++ Tillgångar i form av fastighet, fordon 
++ Sysselsättning  
++ Uppgifter om hälsa. 
+ 
+
+Den rättsliga grunden för behandlingen är rättslig förpliktelse, samtycke samt myndighetsutövning och uppgift av allmänt intresse. Uppgifterna sparas under 5 år i enlighet med Arbetsmarknadsnämndens dokumenthanteringsplan för att därefter gallras.  
+
+Helsingborgs stad, Arbetsmarknadsnämnden, är personuppgiftsansvarig för den personuppgiftsbehandling som sker i e-tjänsten.  
+`;
+
 const FlexContainer = styled.ScrollView`
   background-color: #fff;
   padding: 16px;
@@ -115,8 +141,8 @@ const cardData6 = {
       icon: 'help',
       action: 'infoModal',
       closeButtonText: 'Tillbaka',
-      markdownText: 'Hello World!',
-      heading: 'Info Modal',
+      markdownText: userAgreementText,
+      heading: 'Behandling av personuppgifter i e-tjänsten Ansök om Ekonomiskt bistånd',
     },
   ],
 };

--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
@@ -58,13 +58,31 @@ const InfoButton: React.FC<InfoButtonProps> = ({ heading, markdownText, closeBut
   const [modalVisible, toggleModal] = useModal();
   return (
   <>
-  <Card.Button onClick={toggleModal}>
-    {icon && iconPosition && iconPosition === 'left' && <Icon name={icon} />}
-    <TextComponent>{text}</TextComponent>
-    {icon && (!iconPosition || iconPosition === 'right') && <Icon name={icon} />}
-  </Card.Button>
-  <InfoModal visible={modalVisible} toggleModal={toggleModal} markdownText={markdownText} heading={heading} colorSchema={colorSchema} buttonText={closeButtonText} />
+    <Card.Button onClick={toggleModal}>
+      {icon && iconPosition && iconPosition === 'left' && <Icon name={icon} />}
+      <TextComponent>{text}</TextComponent>
+      {icon && (!iconPosition || iconPosition === 'right') && <Icon name={icon} />}
+    </Card.Button>
+    <InfoModal visible={modalVisible} toggleModal={toggleModal} markdownText={markdownText} heading={heading} colorSchema={colorSchema} buttonText={closeButtonText} />
   </>);
+}
+
+/** Handles the button clicks for action types email, phone, navigate and url */
+const handleClick = (button: CardComponent & { type: 'button'}, navigation: any) => () => {
+  switch (button.action) {
+      case 'email':
+        launchEmail(button.email)
+        break;
+      case 'phone':
+        launchPhone(button.phonenumber)
+        break;
+      case 'navigate':
+        if (navigation?.navigate) navigation.navigate(button.screen) // TODO think about sending parameters here
+        break;
+      case 'url':
+        Linking.openURL(button.url);
+        break;
+    }
 }
 
 /** Maps an object to a Card child component */
@@ -96,22 +114,8 @@ const renderCardComponent = (component: CardComponent, navigation: any) => {
       return <InfoButton {...component} />
     }
 
-    switch (component.action) {
-      case 'email':
-        onClick = () => { launchEmail(component.email)};
-        break;
-      case 'phone':
-        onClick = () => { launchPhone(component.phonenumber)};
-        break;
-      case 'navigate':
-        onClick = () => { if (navigation?.navigate) navigation.navigate(component.screen) }; // TODO think about sending parameters here
-        break;
-      case 'url':
-        onClick = () => { Linking.openURL(component.url)};
-        break;
-    }
     return (
-      <Card.Button onClick={onClick}>
+      <Card.Button onClick={handleClick(component, navigation)}>
         {icon && iconPosition && iconPosition === 'left' && <Icon name={icon} />}
         <TextComponent>{text}</TextComponent>
         {icon && (!iconPosition || iconPosition === 'right') && <Icon name={icon} />}

--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
@@ -50,11 +50,11 @@ type Button = ButtonBase & (
 );
 
 type CardComponent = Image | Text | Title | Subtitle | Button;
-type InfoButtonProps =  ButtonBase & { action: 'infoModal'; heading: string; markdownText: string; closeButtonText: string; };
+type InfoModalButtonProps =  ButtonBase & { action: 'infoModal'; heading: string; markdownText: string; closeButtonText: string; };
 /***** end of types */
 
 /** The info-button gets its own component, because it involves the useModal hook */
-const InfoButton: React.FC<InfoButtonProps> = ({ heading, markdownText, closeButtonText, text, colorSchema, icon, iconPosition}) => {
+const InfoModalButton: React.FC<InfoModalButtonProps> = ({ heading, markdownText, closeButtonText, text, colorSchema, icon, iconPosition}) => {
   const [modalVisible, toggleModal] = useModal();
   return (
   <>
@@ -111,7 +111,7 @@ const renderCardComponent = (component: CardComponent, navigation: any) => {
 
     // treat info-modal separately since it doesn't fit the same pattern as the other buttons. 
     if (component.action === 'infoModal') {
-      return <InfoButton {...component} />
+      return <InfoModalButton {...component} />
     }
 
     return (


### PR DESCRIPTION
## Explain the changes you’ve made

Add the option to have a button that opens an info-modal to the dynamic card renderer. 

## Explain why these changes are made

To get a way to trigger information modals from inside a form. 

## Explain your solution

Just adds another action button type to the dynamic card renderer. 

## How to test the changes?

Checkout the branch, go into storybook and look at the last card in the Dynamic Card Renderer story. Or go into the latest version of EKB-Löpande in develop, on the first page it should have an info card with a working button that opens the legal text display. 


## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
