### PR TITLE
fix(update-bankid-login): updates bankid login logic to match updated api

### DIFF
--- a/source/helpers/ApiRequest.js
+++ b/source/helpers/ApiRequest.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import StorageService, { TOKEN_KEY } from '../services/StorageService';
+import StorageService, { ACCESS_TOKEN_KEY } from '../services/StorageService';
 import { buildServiceUrl } from './UrlHelper';
 
 /**
@@ -20,7 +20,7 @@ const request = async (endpoint, method, data, headers, userId) => {
   if (userId) {
     bearer = userId;
   } else {
-    const token = await StorageService.getData(TOKEN_KEY);
+    const token = await StorageService.getData(ACCESS_TOKEN_KEY);
     bearer = token || '';
   }
 

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import StorageService, { TOKEN_KEY } from '../services/StorageService';
+import StorageService, { ACCESS_TOKEN_KEY } from '../services/StorageService';
 import { buildServiceUrl } from './UrlHelper';
 
 export const getBlob = async (fileUri: string) => {
@@ -28,7 +28,7 @@ export const uploadFile = async ({
 }: FileUploadParams) => {
   const requestUrl = buildServiceUrl(endpoint);
 
-  const token = await StorageService.getData(TOKEN_KEY);
+  const token = await StorageService.getData(ACCESS_TOKEN_KEY);
   const bearer = token || '';
 
   // Merge custom headers

--- a/source/services/StorageService.js
+++ b/source/services/StorageService.js
@@ -9,7 +9,8 @@ import AsyncStorage from '@react-native-community/async-storage';
 
 // Storage key definitions
 export const SHOW_SPLASH_SCREEN = '@app:show_splash_screen';
-export const TOKEN_KEY = '@app:accessToken';
+export const ACCESS_TOKEN_KEY = '@app:accessToken';
+export const REFRESH_TOKEN_KEY = '@app:refreshToken';
 export const TEMP_TOKEN_KEY = '@app:tempAccessToken';
 export const USER_KEY = '@app:user';
 export const ORDER_KEY = '@app:orderRef';

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -1,7 +1,7 @@
 import env from 'react-native-config';
 import bankid from '../../services/BankidService';
 import * as authService from '../../services/AuthService';
-import StorageService, { TOKEN_KEY } from '../../services/StorageService';
+import StorageService, { ACCESS_TOKEN_KEY } from '../../services/StorageService';
 import { UrlHelper } from '../../helpers';
 
 const { canOpenUrl } = UrlHelper;
@@ -23,7 +23,7 @@ export const actionTypes = {
 
 export async function mockedAuth() {
   try {
-    await StorageService.saveData(TOKEN_KEY, env.FAKE_TOKEN);
+    await StorageService.saveData(ACCESS_TOKEN_KEY, env.FAKE_TOKEN);
     return {
       type: actionTypes.loginSuccess,
     };
@@ -158,10 +158,8 @@ export async function checkOrderStatus(autoStartToken, orderRef, isUserAuthentic
     }
 
     // Tries to grant a token from the authorization endpoint in the api.
-    const { personalNumber } = response.data.attributes.completionData.user;
-
-    // eslint-disable-next-line no-unused-vars
-    const [__, grantTokenError] = await authService.grantAccessToken(personalNumber);
+    const { authorizationCode } = response.data.attributes;
+    const [, grantTokenError] = await authService.grantAccessToken(authorizationCode);
     if (grantTokenError) {
       throw new Error(grantTokenError);
     }


### PR DESCRIPTION
## Explain the changes you’ve made

Updates the login slightly, matching the new request and response formats that the updated auth-api wants. 

## Explain why these changes are made

To make the app work against newest api. 

## Explain your solution

Logically there's nothing fancy in this change, it's mostly slight changes to the formats of responses and requests. 
I also add a key for saving the refresh token to storage, and change the name of the TOKEN_KEY to ACCESS_TOKEN_KEY, and add a REFRESH_TOKEN_KEY following the same logic. 

In this, the refresh token is not yet used for anything, but it will be used later for renewing the session. 

## How to test the changes?

Testing this is somewhat involved. You need to point the app to your AWS environment, which needs to be up to date with dev, set the correct API key etc., and set USE_BANKID=true in your .env file. Then you need a test bankid user that's able to sign; set your FAKE_PERSONAL_NUMBER to match that, and unless you have a navet certificate, that user also needs to exist in your user database. With all this in place, you should be able to log in using bankid, it should work as before.

I tested this on my aws environment, and used the bankid on other device instead of bankid on the phone (since that's how I managed to get the bankid test env. working), so it would be great to test it also on an actual phone (even though it should work just the same).  

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Comment

The login logic, and how we create a new user etc., all of it feels a bit too complicated. Of course not something we should think about right now (had to stop myself from thinking about how to refactor), but something to make a note of for the future.