### PR TITLE
Feat/renew session

### DIFF
--- a/source/navigator/CustomStackNavigator.tsx
+++ b/source/navigator/CustomStackNavigator.tsx
@@ -11,7 +11,7 @@ import { Modal } from 'react-native';
 import AuthContext from '../store/AuthContext';
 import Card from '../components/molecules/Card/Card';
 import Text from '../components/atoms/Text/Text';
-import useTouchActivity from '../hooks/useTouchActivity';
+import useTouchActivity, { UseTouchParameters } from '../hooks/useTouchActivity';
 
 const FlexWrapper = styled.View`
   flex: 1;
@@ -65,7 +65,7 @@ const CustomStackNavigator = ({
     screenOptions,
     initialRouteName,
   });
-  const { handleLogout, isAuthenticated } = useContext(AuthContext);
+  const { handleLogout, isAuthenticated, handleRefreshSession } = useContext(AuthContext);
 
   const handleEndUserSession = async () => {
     if (isAuthenticated) {
@@ -74,17 +74,28 @@ const CustomStackNavigator = ({
     }
   };
 
-  const { isActive, panResponder, updateIsActive, updateLatestTouchTime } = useTouchActivity(
-    parseInt(env.INACTIVITY_TIME),
-    5000,
-    true,
-    60000,
-    handleEndUserSession
-  );
+  const touchParameters: UseTouchParameters = {
+    inactivityTime: parseInt(env.INACTIVITY_TIME),
+    intervalDelay: 5000,
+    logoutDelay: 60000,
+    logOut: handleEndUserSession,
+    refreshInterval: 60000 * 10,
+    refreshSession: handleRefreshSession,
+  };
+  const {
+    isActive,
+    panResponder,
+    updateIsActive,
+    updateLatestTouchTime,
+    updateLatestRefreshTime,
+  } = useTouchActivity(touchParameters);
 
   const handleContinueUserSession = () => {
     updateIsActive(true);
     updateLatestTouchTime();
+
+    handleRefreshSession();
+    updateLatestRefreshTime();
   };
 
   const NavigatorContextComponent = (

--- a/source/services/AuthService.js
+++ b/source/services/AuthService.js
@@ -82,6 +82,30 @@ export async function grantAccessToken(authorizationCode) {
   }
 }
 
+export async function refreshTokens() {
+  try {
+    const oldRefreshToken = await StorageService.getData(REFRESH_TOKEN_KEY);
+    const response = await post(
+      '/auth/token',
+      {
+        grant_type: 'refresh_token',
+        refresh_token: oldRefreshToken,
+      },
+      { 'x-api-key': env.MITTHELSINGBORG_IO_APIKEY }
+    );
+
+    if (response.status !== 200) {
+      throw new Error(response.data);
+    }
+    const { accessToken, refreshToken } = response.data.data.attributes;
+    const decodedAccessToken = await saveTokensToStorage(accessToken, refreshToken);
+    return [decodedAccessToken, null];
+  } catch (error) {
+    console.error(error);
+    return [null, error];
+  }
+}
+
 async function wait(ms = 1000) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -101,9 +101,12 @@ function AuthProvider({ children, initialState }) {
 
   /**
    * This function triggers an action to refresh the users session credentials.
+   * Only trigger if the user is authenticated already.
    */
   async function handleRefreshSession() {
-    dispatch(await refreshSession());
+    if (state.isAuthenticated) {
+      dispatch(await refreshSession());
+    }
   }
   /**
    * Used to save user profile data to the state.

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -8,6 +8,7 @@ import {
   cancelOrder,
   loginFailure,
   loginSuccess,
+  refreshSession,
   checkOrderStatus,
   removeProfile,
   addProfile,
@@ -99,6 +100,12 @@ function AuthProvider({ children, initialState }) {
   }
 
   /**
+   * This function triggers an action to refresh the users session credentials.
+   */
+  async function handleRefreshSession() {
+    dispatch(await refreshSession());
+  }
+  /**
    * Used to save user profile data to the state.
    * @param {object} profile a user profile object
    */
@@ -142,6 +149,7 @@ function AuthProvider({ children, initialState }) {
   const contextValues = {
     handleLogin,
     handleLogout,
+    handleRefreshSession,
     handleAddProfile,
     handleRemoveProfile,
     handleAuth,

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -9,6 +9,7 @@ const { canOpenUrl } = UrlHelper;
 export const actionTypes = {
   loginSuccess: 'LOGIN_SUCCESS',
   loginFailure: 'LOGIN_FAILURE',
+  refreshSession: 'REFRESH_CREDENTIALS',
   addProfile: 'ADD_PROFILE',
   removeProfile: 'REMOVE_PROFILE',
   authStarted: 'AUTH_STARTED',
@@ -83,6 +84,21 @@ export async function addProfile() {
 export function removeProfile() {
   return {
     type: actionTypes.removeProfile,
+  };
+}
+
+export async function refreshSession() {
+  const [, refreshError] = await authService.refreshTokens();
+  if (refreshError) {
+    return {
+      type: actionTypes.authError,
+      payload: {
+        error: refreshError.data,
+      },
+    };
+  }
+  return {
+    type: actionTypes.refreshSession,
   };
 }
 

--- a/source/store/reducers/AuthReducer.js
+++ b/source/store/reducers/AuthReducer.js
@@ -35,6 +35,12 @@ export default function AuthReducer(state, action) {
         autoStartToken: undefined,
       };
 
+    case actionTypes.refreshSession:
+      return {
+        ...state,
+        isAuthenticated: true,
+      };
+
     case actionTypes.addProfile:
       return {
         ...state,


### PR DESCRIPTION
## Explain the changes you’ve made

Implement logic for renewing the users session (i.e. the auth-credentials), and trigger these at some interval using the touchActivity logic. 

## Explain why these changes are made

To keep the user logged in while he/she is active, and also if the inactivity warning is triggered and you choose to remain active. 

## Explain your solution

This PR is dependent on the fix/update-bankid-login , sorry about that, but I want to put this code out there because I want feedback; I feel like something is missing in the logic.

Anyhow, I Implement a new action in the AuthContext, called refreshSession, which in turn triggers an authService function that tries to use the existing refresh token to get new ones from the api, and store the updated tokens in local storage. This feels a bit roundabout, but it's following similar patterns as the rest of this logic, so.

The refreshSession is then triggered in the useTouchActivity hook, at some set interval, so that while the user is active, we automatically refresh tokens every ten minutes, to keep the user logged in. Of course if the user is inactive, we do not refresh the tokens. 

I also refactored the useTouchActivity hook slightly, to accept a parameter object to make it clearer.

## How to test the changes?

Point the app to your personal AWS environment, that should be updated to dev of the helsinborg-io-api, and set it to use bank-id. Then log in, and wait for a refresh to happen. 

Probably a good idea to log something from the refreshToken method, like the api-response, and turn down the refreshInterval value to something smaller. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
