### PR TITLE
fix(nav-button-group-margins): fix margins so that horizontal nav-groups go all the way out

### DIFF
--- a/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
+++ b/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
@@ -10,6 +10,10 @@ import { HorizontalScrollIndicator } from '../../atoms';
 
 const ScrollContainer = styled.ScrollView`
   padding-bottom: 16px;
+  ${(props) =>
+    props.horizontal &&
+    `margin-right: -24px;
+    margin-left: -24px;`}
 `;
 interface Props {
   buttons: ButtonProps[];


### PR DESCRIPTION
## What I changed
Fixes a wish from the designers that the horizontal nav-button-group should go all the way to the sides of the screen. So I compensate for the margin of the step body by a negative margin, if the group is in horizontal mode (since otherwise we don't want this).

## how to test
Open a form with horizontal nav-groups, like the EKB-löpande, and check that it looks okay.