### PR TITLE
Fix/case back button

### DIFF
--- a/source/navigator/BottomBarNavigator.js
+++ b/source/navigator/BottomBarNavigator.js
@@ -33,6 +33,12 @@ const BottomBarStack = () => (
           tabBarIconInactive: () => <TabBarImage source={require('../images/task_3x_gray.png')} />,
           tabBarLabel: 'Ärende',
         }}
+        listeners={({ navigation }) => ({
+          tabPress: (e) => {
+            e.preventDefault();
+            navigation.navigate('UserEvents', { screen: 'CaseOverview' });
+          },
+        })}
       />
       <Tab.Screen
         name="Chat"

--- a/source/navigator/CaseNavigator.js
+++ b/source/navigator/CaseNavigator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import styled from 'styled-components/native';
-import { Platform } from 'react-native';
+import { TouchableOpacity, Platform } from 'react-native';
 import CaseOverview from '../screens/caseScreens/CaseOverview';
 import CaseSummary from '../screens/caseScreens/CaseSummary';
 import { Icon } from '../components/atoms';
@@ -13,27 +13,39 @@ const BackIcon = styled(Icon)`
   ${Platform.OS === 'ios' && 'margin-left: 16px;'}
 `;
 
-const CaseNavigator = () => (
-  <Stack.Navigator screenOptions={{ headerShown: true }}>
-    <Stack.Screen
-      name="CaseOverview"
-      component={CaseOverview}
-      options={{ title: 'Ärenden', headerShown: false }}
-    />
-    <Stack.Screen
-      name="CaseSummary"
-      component={CaseSummary}
-      options={({ route }) => ({
-        title: route.params.name || 'Ärenden',
-        headerBackImage: () => <BackIcon name="arrow-back" />,
-        headerBackTitle: '',
-        headerTruncatedBackTitle: '',
-        headerStyle: {
-          backgroundColor: theme.colors.neutrals[5],
-        },
-      })}
-    />
-  </Stack.Navigator>
-);
+const CaseNavigator = ({ navigation }) => {
+  const BackButton = () => (
+    <TouchableOpacity
+      onPress={() => {
+        navigation.navigate('CaseOverview');
+      }}
+    >
+      <BackIcon name="arrow-back" />
+    </TouchableOpacity>
+  );
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: true }}>
+      <Stack.Screen
+        name="CaseOverview"
+        component={CaseOverview}
+        options={{ title: 'Ärenden', headerShown: false }}
+      />
+      <Stack.Screen
+        name="CaseSummary"
+        component={CaseSummary}
+        options={({ route }) => ({
+          title: route.params.name || 'Ärenden',
+          // headerBackImage: () => <BackIcon name="arrow-back" />,
+          headerLeft: () => <BackButton />,
+          headerBackTitle: '',
+          headerTruncatedBackTitle: '',
+          headerStyle: {
+            backgroundColor: theme.colors.neutrals[5],
+          },
+        })}
+      />
+    </Stack.Navigator>
+  );
+};
 
 export default CaseNavigator;

--- a/source/navigator/CaseNavigator.js
+++ b/source/navigator/CaseNavigator.js
@@ -28,7 +28,7 @@ const CaseNavigator = ({ navigation }) => {
   );
 
   return (
-    <Stack.Navigator screenOptions={{ headerShown: true }}>
+    <Stack.Navigator screenOptions={{ headerShown: true }} initialRouteName="CaseOverview">
       <Stack.Screen
         name="CaseOverview"
         component={CaseOverview}

--- a/source/navigator/CaseNavigator.js
+++ b/source/navigator/CaseNavigator.js
@@ -2,16 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { createStackNavigator } from '@react-navigation/stack';
 import styled from 'styled-components/native';
-import { Platform } from 'react-native';
 import CaseOverview from '../screens/caseScreens/CaseOverview';
 import CaseSummary from '../screens/caseScreens/CaseSummary';
 import { Icon } from '../components/atoms';
 
 const Stack = createStackNavigator();
 
-const BackIcon = styled(Icon)`
-  ${Platform.OS === 'ios' && 'margin-left: 16px;'}
-`;
 const TouchWrapper = styled.TouchableOpacity`
   margin-left: 16px;
   margin-top: 3px;
@@ -27,7 +23,7 @@ const CaseNavigator = ({ navigation }) => {
         navigation.navigate('CaseOverview');
       }}
     >
-      <BackIcon name="arrow-back" />
+      <Icon name="arrow-back" />
     </TouchWrapper>
   );
 

--- a/source/navigator/CaseNavigator.js
+++ b/source/navigator/CaseNavigator.js
@@ -1,28 +1,36 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { createStackNavigator } from '@react-navigation/stack';
 import styled from 'styled-components/native';
-import { TouchableOpacity, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import CaseOverview from '../screens/caseScreens/CaseOverview';
 import CaseSummary from '../screens/caseScreens/CaseSummary';
 import { Icon } from '../components/atoms';
-import theme from '../styles/theme';
 
 const Stack = createStackNavigator();
 
 const BackIcon = styled(Icon)`
   ${Platform.OS === 'ios' && 'margin-left: 16px;'}
 `;
+const TouchWrapper = styled.TouchableOpacity`
+  margin-left: 16px;
+  margin-top: 3px;
+  border-radius: 17px;
+  padding: 5px;
+`;
 
 const CaseNavigator = ({ navigation }) => {
   const BackButton = () => (
-    <TouchableOpacity
+    <TouchWrapper
+      activeOpacity={0.2}
       onPress={() => {
         navigation.navigate('CaseOverview');
       }}
     >
       <BackIcon name="arrow-back" />
-    </TouchableOpacity>
+    </TouchWrapper>
   );
+
   return (
     <Stack.Navigator screenOptions={{ headerShown: true }}>
       <Stack.Screen
@@ -35,17 +43,13 @@ const CaseNavigator = ({ navigation }) => {
         component={CaseSummary}
         options={({ route }) => ({
           title: route.params.name || 'Ärenden',
-          // headerBackImage: () => <BackIcon name="arrow-back" />,
           headerLeft: () => <BackButton />,
-          headerBackTitle: '',
-          headerTruncatedBackTitle: '',
-          headerStyle: {
-            backgroundColor: theme.colors.neutrals[5],
-          },
         })}
       />
     </Stack.Navigator>
   );
 };
-
+CaseNavigator.propTypes = {
+  navigation: PropTypes.object,
+};
 export default CaseNavigator;


### PR DESCRIPTION
## Explain the changes you’ve made

The back button on the case details view disappeared if you went to another view and then back. This fixes that, by rendering a 'static' back button that points to the case overview screen. 

## Explain why these changes are made

To prevent the user getting stuck in a details view. 

## Explain your solution

The usual stack navigator shows a dynamic back-button in the header, and if you leave the stack, then "back" no longer points within the stack, so they hide the back button. So to get around this, I just put a static header button instead, that always points to the CaseOverview page. 

## How to test the changes?

Checkout branch, go into the EKB details page, and then change view by the bottom bar. When going back to the details page, the back arrow should still be there. Also check that the back-arrow looks okay, and that it works. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
