### PR TITLE
fix(resume-case): fix bug that prevented loading the answers when resuming

### DIFF
--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ActivityIndicator } from 'react-native';
 import styled from 'styled-components';
 import Form from '../containers/Form/Form';
-import { getFormQuestions } from '../helpers/CaseDataConverter';
+import { getFormQuestions, convertAnswerArrayToObject } from '../helpers/CaseDataConverter';
 import generateInitialCaseAnswers from '../store/actions/dynamicFormData';
 import AuthContext from '../store/AuthContext';
 import FormContext from '../store/FormContext';
@@ -35,12 +35,11 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       setInitialCase(caseData);
     } else if (caseId) {
       const initCase = getCase(caseId);
-      getForm(initCase.formId).then(async (form) => {
-        const [status, latestCase, relevantCases] = await getCasesByFormIds([form.id]);
-        const initialAnswersObject = generateInitialCaseAnswers(form, user, relevantCases);
-        initCase.data = initialAnswersObject;
-        setInitialCase(initCase);
+      const answersObject = convertAnswerArrayToObject(initCase.answers);
+      initCase.answers = answersObject;
+      setInitialCase(initCase);
 
+      getForm(initCase.formId).then(async (form) => {
         setForm(form);
         setFormQuestions(getFormQuestions(form));
       });
@@ -87,7 +86,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       onClose={handleCloseForm}
       onStart={handleStartForm}
       onSubmit={handleSubmitForm}
-      initialAnswers={initialCase?.data || caseData.data || {}}
+      initialAnswers={initialCase?.answers || caseData.answers || {}}
       status={initialCase.status || 'ongoing'}
       updateCaseInContext={updateCaseContext}
       {...props}

--- a/source/store/CaseContext.js
+++ b/source/store/CaseContext.js
@@ -39,7 +39,6 @@ const oldCaseLimit = 4 * 30 * 24 * 60 * 60 * 1000; // cases older than 4 months 
 function CaseProvider({ children, initialState = defaultInitialState }) {
   const [state, dispatch] = useReducer(CaseReducer, initialState);
   const { user } = useContext(AuthContext);
-  // console.log('reducer state', state);
   async function createCase(form, callback = (response) => {}) {
     dispatch(await create(form, user, Object.values(state.cases), callback));
   }


### PR DESCRIPTION
## Explain the changes you’ve made

Fix a logic bug that prevented the loading of entered answers when resuming a case, causing us to start from nothing instead of loading already filled answers. 

## Explain your solution

The bug came from using the code meant for starting a new case from scratch (which involves loading data from the user profile and previous cases), also when resuming. This caused the form to not show the entered answers, even though they were correctly saved in the database. The fix was to simply not use this logic when resuming a case, as it should only be used when creating a new one from scratch. 

## How to test the changes?

Checkout this branch, go into a case, say from the caseOverview screen, and enter some answers. Then exit the form without completing it, and then resume it. The answers you entered should be saved and show up in the correct fields. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
