### PR TITLE
feat(select-required): fix validation logic for non-text inputs, and …

### DIFF
--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -56,6 +56,15 @@ const Select: React.FC<Props> = React.forwardRef(({
   style,
 }, ref) => {
   const currentItem = items.find(item => item.value === value);
+  const handleValueChange = (itemValue: any) => {
+    if (onValueChange && typeof onValueChange === 'function') {
+      onValueChange(itemValue ? itemValue.toString() : null);
+    }
+    if (onBlur) {
+      onBlur(currentItem?.value);
+    }
+  }
+
   return (
     <Wrapper style={style}>
       <RNPickerSelect
@@ -63,14 +72,7 @@ const Select: React.FC<Props> = React.forwardRef(({
         placeholder={{ label: placeholder, value: null }}
         disabled={!editable}
         value={currentItem?.value || null}
-        onValueChange={(itemValue, _itemIndex) => {
-          if (typeof onValueChange === 'function') {
-            onValueChange(itemValue ? itemValue.toString() : null);
-          }
-          if (onBlur) {
-            onBlur(currentItem?.value);
-          }
-        }}
+        onValueChange={handleValueChange}
         items={items}
         ref={ref as React.LegacyRef<RNPickerSelect>}
         />

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -56,7 +56,7 @@ const Select: React.FC<Props> = React.forwardRef(({
   style,
 }, ref) => {
   const currentItem = items.find(item => item.value === value);
-  const handleValueChange = (itemValue: any) => {
+  const handleValueChange = (itemValue: string | number | boolean) => {
     if (onValueChange && typeof onValueChange === 'function') {
       onValueChange(itemValue ? itemValue.toString() : null);
     }

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import RNPickerSelect from 'react-native-picker-select';
 import theme from '../../../styles/theme';
+import Text from '../Text';
 
 // This library requires styling to follow the pattern here,
 // thus we have to use this rather than styled components
@@ -25,7 +26,12 @@ const pickerSelectStyles = StyleSheet.create({
 const Wrapper = styled.View`
   margin-bottom: 30px;
 `;
-
+const StyledErrorText = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSizes[3]}px;
+  color: ${(props) => props.theme.textInput.errorTextColor};
+  font-weight: ${({ theme }) => theme.fontWeights[0]};
+  padding-top: 8px;
+`;
 interface Props {
   items: { label: string; value: string }[];
   onValueChange: (value: string, index?: number) => void;
@@ -33,14 +39,20 @@ interface Props {
   value: string;
   editable?: boolean;
   style?: ViewStyle;
+  onBlur: (value: string) => void;
+  showErrorMessage?: boolean;
+  error?: { isValid: boolean; message: string };
 }
 
 const Select: React.FC<Props> = React.forwardRef(({
   items,
   onValueChange,
+  onBlur,
   placeholder,
   value,
   editable = true,
+  showErrorMessage = true,
+  error,
   style,
 }, ref) => {
   const currentItem = items.find(item => item.value === value);
@@ -55,10 +67,14 @@ const Select: React.FC<Props> = React.forwardRef(({
           if (typeof onValueChange === 'function') {
             onValueChange(itemValue ? itemValue.toString() : null);
           }
+          if (onBlur) {
+            onBlur(currentItem?.value);
+          }
         }}
         items={items}
         ref={ref as React.LegacyRef<RNPickerSelect>}
-      />
+        />
+      {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
     </Wrapper>
   );
 });
@@ -81,6 +97,11 @@ Select.propTypes = {
   placeholder: PropTypes.string,
   /** Style properties for the inputbox */
   style: PropTypes.shape({}),
+  error: PropTypes.shape({
+    isValid: PropTypes.bool.isRequired,
+    message: PropTypes.string.isRequired,
+  }),
+  showErrorMessage: PropTypes.bool,
 };
 
 Select.defaultProps = {

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -260,11 +260,10 @@ export function validateAnswer(
   const question = allQuestions.find(q => q.id === questionId);
   if (!question) return state;
 
-  if (['text', 'number', 'date', 'checkbox'].includes(question.type)) {
+  if (['text', 'number', 'date', 'checkbox', 'select'].includes(question.type)) {
     const { validation } = question;
     if (validation && ((checkIfDirty && state.dirtyFields?.[questionId]) || !checkIfDirty)) {
       const [isValid, validationMessage] = validateInput(answer[questionId], validation.rules);
-
       return {
         ...state,
         validations: {
@@ -357,7 +356,7 @@ export function validateAllStepAnswers( state: FormReducerState, onErrorCallback
   for (const questionIndex in currentStepQuestions) {
     const question = currentStepQuestions[questionIndex]
 
-    if (['text', 'number', 'date', 'checkbox'].includes(question.type)) {
+    if (['text', 'number', 'date', 'checkbox', 'select'].includes(question.type)) {
       if (state.validations[question.id]?.isValid === false) {
         allInputsValid = false;
 
@@ -425,7 +424,7 @@ export function dirtyField(
   const question = allQuestions.find(q => q.id === questionId);
   if (!question) return state;
 
-  if (['text', 'number', 'date', 'checkbox'].includes(question.type)) {
+  if (['text', 'number', 'date', 'checkbox', 'select'].includes(question.type)) {
     return {
       ...state,
       dirtyFields: {

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -83,6 +83,7 @@ const inputTypes = {
   select: {
     component: Select,
     changeEvent: 'onValueChange',
+    blurEvent: 'onBlur',
     props: {},
   },
   radioGroup: {

--- a/source/helpers/ValidationHelper.js
+++ b/source/helpers/ValidationHelper.js
@@ -47,7 +47,8 @@ export const validateInput = (value, rules) =>
        */
       let valueToValidate = String(value);
       /**
-       * If the value comes from a checkbox or select input, we want the following values to count as empty, so that the isEmpty rule can be applied correctly.
+       * If the value comes from a checkbox or select input, we want the following values to count as empty,
+       * so that the isEmpty rule can be applied correctly.
        */
       if (value === false || value === undefined || value === null) {
         valueToValidate = '';

--- a/source/helpers/ValidationHelper.js
+++ b/source/helpers/ValidationHelper.js
@@ -45,8 +45,13 @@ export const validateInput = (value, rules) =>
       /**
        * Validator only accepts strings.
        */
-      const valueToValidate = String(value);
-
+      let valueToValidate = String(value);
+      /**
+       * If the value comes from a checkbox or select input, we want the following values to count as empty, so that the isEmpty rule can be applied correctly.
+       */
+      if (value === false || value === undefined || value === null) {
+        valueToValidate = '';
+      }
       /**
        * Retrieve the validation method defined in the rule from the validator.js package and execute.
        * An array of args will be created if multiple args defined. Single arg will be passed as is.


### PR DESCRIPTION
## Explain the changes you’ve made

Made it possible to validate the Select input component, which really means that it's possible to set it to be required. As part of this, a small change is made to the validation logic, which improves the way the validation helper handles non-text inputs. 

## Explain why these changes are made

We need it in the form. 

## Explain your solution

In the validation logic, I add 'select' as one of the valid options. 
In the validation helper, in order to deal with non-string inputs like the select (and also the checkbox, and possibly others), I add a small check that, if the incoming value is a boolean false, undefined or null, we treat it as an empty string. This lets the isEmpty rule work correctly for these cases; since otherwise these values were converted to the strings 'false', 'undefined', 'null', which of course are not empty, even though the field is.

The validation happens on the onBlur event, which for the select has no obvious counterpart, so I set it to run in the onValueChange, after the value has been changed. 

## How to test the changes?

In the dev-aws environment, there's a Test form, in which I've set the select component on the first page to be required. So the easiest way to test is to have your app pointed to dev, and then find the Test form in the developers options page (reached by a button under the profile page). Then, an error message should be displayed if this select is toggled from empty to non-empty and then back to empty, or if it's left empty and the user tries to go to the next page. 
Be aware that other things on the page are also required.  

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.