### PR TITLE
fix(date-save-format): change the format we save dates in

### DIFF
--- a/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
+++ b/source/components/molecules/CalendarPicker/CalendarPickerForm.tsx
@@ -41,8 +41,8 @@ const DateInput = styled(Input)<{ transparent: boolean }>`
 `;
 
 interface PropInterface {
-  onSelect: (date: string) => void;
-  value: string;
+  onSelect: (date: number) => void;
+  value: number;
   editable?: boolean;
   transparent?: boolean;
   style?: React.CSSProperties;
@@ -63,7 +63,7 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
   const [modalVisible, toggleModal] = useModal();
 
   const handleCalendarDateChange = (selectedDate: moment.Moment) => {
-    onSelect(selectedDate.format('Y-MM-DD'));
+    onSelect(selectedDate.toDate().valueOf());
     toggleModal();
   };
 
@@ -72,7 +72,7 @@ const CalendarPickerForm: React.FC<PropInterface> = ({
       <TouchableOpacity disabled={!editable} onPress={toggleModal}>
         <DateInput
           placeholder="Välj datum"
-          value={value}
+          value={value ? moment.utc(value).format('Y-MM-DD') : ''}
           multiline /** Temporary fix to make field scrollable inside scrollview */
           numberOfLines={1} /** Temporary fix to make field scrollable inside scrollview */
           editable={false}
@@ -133,7 +133,7 @@ CalendarPickerForm.propTypes = {
    * Calendar date change callback.
    */
   onSelect: PropTypes.func,
-  value: PropTypes.string,
+  value: PropTypes.number,
   /** Turn the input field of. Defaults to true. */
   editable: PropTypes.bool,
   /** Turn the background of input field transparent */

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -98,7 +98,7 @@ const InputComponent = React.forwardRef(
       case 'date':
         return (
           <CalendarPicker
-            date={value && value !== '' ? value[input.key] : state[input.key]}
+            value={value && value !== '' ? value[input.key] : state[input.key]}
             onSelect={(date) => onChange(input.key, date)}
             onBlur={onInputBlur}
             editable={editable}

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -82,7 +82,7 @@ interface InputComponentProps {
   input: InputRow;
   colorSchema: PrimaryColor;
   value: string | number | boolean;
-  onChange: (value: string) => void;
+  onChange: (value: string | number) => void;
   onBlur: () => void;
 }
 
@@ -119,7 +119,7 @@ const InputComponent = React.forwardRef(({input, colorSchema, value, onChange, o
       return (
         <CalendarPicker
           colorSchema={colorSchema}
-          value={value as string}
+          value={value as number}
           onSelect={onChange}
           editable={true}
           transparent

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -137,7 +137,7 @@ const InputComponent = React.forwardRef(({ input, editable, value, onInputBlur, 
       return (
         <CalendarPicker
           colorSchema={colorSchema}
-          value={value as string}
+          value={value as number}
           onSelect={changeFromInput}
           editable={editable}
           transparent


### PR DESCRIPTION
## Explain the changes you’ve made

Change so that the dates input from the form are saved as milliseconds (utc format), instead of as formatted strings.

## Explain why these changes are made

We were saving some other timestamps in this format, and it's good to streamline and use the same date format everywhere. Also, the UTC format is nice because it's universal, and avoids issues from varying ways of formatting a timestamp as a string. 

## Explain your solution

Change the logic of what the CalendarPicker saves to the formState, so that it passes the utc number value instead of a YY-MM-DD string, and add some logic to correctly format the value before displaying it. Also update some prop types, and correct what seems like a typo in the EditableList component. 


This is a first step in this change of date handling, there also needs to be corresponding changes in the pdf generator (to format the incoming dates), as well as in vada, so that viva gets correctly formatted dates. Since there is no type information saved on the answers, this will need to be based on the tag, presumably all date fields should have the tag 'date', for example. 

## How to test the changes?

Checkout this branch, and then go into any form (like the EKB löpande), that uses a date picker. See that it works as before. Then you can inspect (by logging, or checking the database) that the date answer is now saved as a utc number. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

