### PR TITLE
fix(validation): a few small fixes of validation behaviour

### DIFF
--- a/source/components/molecules/CheckboxField/CheckboxField.tsx
+++ b/source/components/molecules/CheckboxField/CheckboxField.tsx
@@ -76,6 +76,7 @@ interface CheckBoxProps {
   size?: 'small' | 'medium' | 'large';
   value: boolean | string;
   onChange?: (value: boolean) => void;
+  onBlur?: (value: boolean) => void;
   help?: { text: string; size?: number; heading?: string; tagline?: string; url?: string };
   error?: { isValid: boolean; message: string };
 }
@@ -87,6 +88,7 @@ const CheckboxField: React.FC<CheckBoxProps> = ({
   size,
   value,
   onChange,
+  onBlur,
   help,
   error,
   ...other
@@ -98,7 +100,12 @@ const CheckboxField: React.FC<CheckBoxProps> = ({
   } else {
     boolValue = value === 'true';
   }
-  const update = () => onChange(!boolValue);
+  const update = () => { 
+    onChange(!boolValue);
+    if (onBlur) {
+      onBlur(!boolValue);
+    }
+  }
   const validColorSchema = getValidColorSchema(colorSchema);
   return (
     <>

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -130,9 +130,9 @@ function useForm(initialState: FormReducerState) {
   /**
    * Function to trigger when a form field looses focus.
    */
-  const handleBlur = (answer: Record<string, any>, questionId) => {
-    dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId } });
+  const handleBlur = (answer: Record<string, any>, questionId: string) => {
     dispatch({ type: 'DIRTY_FIELD', payload: { answer, id: questionId } });
+    dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId, checkIfDirty: true } });
   };
   /**
    * Function for updating answer.

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -58,6 +58,7 @@ const inputTypes = {
   checkbox: {
     component: CheckboxField,
     changeEvent: 'onChange',
+    blurEvent: 'onBlur',
     helpInComponent: true,
     helpProp: 'help',
     props: {},

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -33,6 +33,8 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
         setForm(form);
         setFormQuestions(getFormQuestions(form));
       });
+      const answersObject = convertAnswerArrayToObject(caseData.answers);
+      caseData.answers = answersObject;
       setInitialCase(caseData);
     } else if (caseId) {
       const initCase = getCase(caseId);


### PR DESCRIPTION
## Explain the changes you’ve made

Two small fixes to validation behaviour. Fixes the validation of required checkboxes so that they display an error if the user toggles them on and then off again. Secondly, fixes the behaviour of validation of editable list, so that it doesn't display errors on fields the user has not touched. 

Also fixes the format of initial answers object when starting a new form from the dev-screen. 

## Explain your solution

The Checkbox was never set as dirty, which meant that no validation error was displayed until the user tried to go to the next screen (which dirties all fields on the step). This is fixed by giving it an 'onBlur' behaviour that triggers when the user clicks it, which in turn means that it is dirtied as soon as the user clicks it. 

The editable list also had trouble with validation of non-dirty fields behaving wrong. This was because when validating from an onBlur event, we didn't check if the field was dirty, which we should be doing. So here I just changed the order so that we first dirty the field, and then only validate dirty field also when it is triggered by an onBlur event.

Finally, when starting a new form, the FormCaseScreen was setting the answers-object as an array, rather than an object, which lead to weird behaviour. This only triggers when starting new cases from the developer screen. 

## How to test the changes?

Checkout this branch, and go into the test-form on Development. Try toggling the checkbox on the first page, it's marked as required and should thus display an error when empty (after having been toggled). 

Also try the editable list of personal info. Every field except the first is marked as required, so check that the validation errors only show up after a field has been touched by the user. Also try the validation in general, check that nothing else was broken by these changes. 


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
