### PR TITLE
fix(summary-list-checkboxes): fix summary list to display checkboxes

### DIFF
--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -218,7 +218,7 @@ const SummaryList: React.FC<Props> = ({
           addToSum(numericValue);
         }
       } 
-      if (['text', 'number', 'date'].includes(item.type)) {
+      if (['text', 'number', 'date', 'checkbox'].includes(item.type)) {
         listItems.push(
           <SummaryListItemComponent
               item={item}

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -145,10 +145,7 @@ const InputComponent = React.forwardRef(({ input, editable, value, onInputBlur, 
         />
       );
     case 'checkbox':
-      const checked = value as boolean;
-      return (
-        <Checkbox checked={checked} colorSchema={colorSchema} disabled={!editable} onChange={() => changeFromInput(!checked)} />
-      )
+      return null;
     default:
       return (
         <SmallInput

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from "react";
 import { View, TouchableHighlight } from "react-native";
 import styled from "styled-components/native";
 import PropTypes from "prop-types";
-import { Text, Icon, Checkbox, Input } from "../../atoms";
+import { Text, Icon, Input } from "../../atoms";
 import { SummaryListItem as SummaryListItemType } from "./SummaryList";
 import CalendarPicker from '../../molecules/CalendarPicker/CalendarPickerForm';
 import { colorPalette } from '../../../styles/palette';


### PR DESCRIPTION
## Explain the changes you’ve made

Fixes a bug where checkboxes were not displayed in the SummaryList.
 
To solve this, Maria cleverly put them as Text-inputs in the formbuilder, which makes them show up, but has the unwanted sideeffect that the user can enter text on them in the summary list. This fixes the bug, so now these answers can be put as the correct type, and it should behave correctly without any text input. 

## Explain your solution

The checkbox answer type was already implemented in the SummaryListItem, to display a clickable checkbox in the list, but after discussing with Niko, we arrived at the conclusion that it's better to not display any checkbox next to the label, since it can be confusing. If the user no longer want the post, the whole line can be removed via the cross. 

So I just change the checkbox case to not have any input component. 
I also change a check in the SummaryList to include the 'checkbox' type; this is the bug that made the checkbox type not show up in the summary  list. 

## How to test the changes?

Checkout the branch. Then go into the EKB-löpande form (latest version) and go to the income page. Find the "Pengar från Myndigheter" option and check some of the boxes, then go back to the summary. They should show up in the list, and it should not be possible in the edit-mode to enter anything in the input field. Check also that deleting such a line works correctly. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
