### PR TITLE
fix(validation-empty-fields): fix validation of empty fields

### DIFF
--- a/source/helpers/ValidationHelper.js
+++ b/source/helpers/ValidationHelper.js
@@ -40,7 +40,7 @@ export const validateInput = (value, rules) =>
   rules.reduce(
     (acc, rule) => {
       const [valid] = acc;
-      let valueArray = acc;
+      const valueArray = acc;
 
       /**
        * Validator only accepts strings.
@@ -61,6 +61,11 @@ export const validateInput = (value, rules) =>
       const validationMethodArgs = rule.arg || Object.keys(ruleArgs).map((key) => ruleArgs[key]);
       const validationMethod =
         typeof rule.method === 'string' ? validator[rule.method] : rule.method;
+      /** For any other rule than the isEmpty, an empty value should be treated as valid. */
+      if (validationMethod !== validator.isEmpty && valid === true && valueToValidate === '') {
+        return [true, ''];
+      }
+
       const isValidationRuleMeet =
         validationMethod(valueToValidate, validationMethodArgs) === rule.validWhen;
 
@@ -68,14 +73,13 @@ export const validateInput = (value, rules) =>
        * Only return true if the current and previous rule is met
        */
       if (valid === true && isValidationRuleMeet) {
-        valueArray = [true, ''];
+        return [true, ''];
       }
-
       /**
        * Only change the  true if the current and previous rule is met
        */
       if (!isValidationRuleMeet) {
-        valueArray = [false, rule.message];
+        return [false, rule.message];
       }
       return valueArray;
     },


### PR DESCRIPTION
## Explain the changes you’ve made

Rules like isNumeric treated empty answers as invalid, which is not the desired behaviour. Only the isEmpty (i.e. the field is required) rule should trigger on a field that is left empty. This adds some logic to the validateInput function to get this behaviour. 

## Explain why these changes are made

Fields that are not required should not be marked as incorrect when left empty.

## Explain your solution

Adds a check in the input validation, so that all rules except the special isEmpty rule treats empty fields as valid automatically. 

## How to test the changes?

The place where this bug was discovered was in the EKB-löpande form, on the 'Pengar från Inneboende' page under incomes. Here, it should be okay to leave any of the input fields empty, and when clicking save, it should not trigger a validation error. So to test this, one can first try this on the develop branch and see what behaviour was there before, then check out this branch, and then try again. It should fix it so that empty fields are okay, and does not trigger any validation error when clicking 'Spara'. 


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
