### PR TITLE
fix(validation-repeater-date): fix validation of empty repeater field answers

### DIFF
--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -72,7 +72,14 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
         type: LayoutAnimation.Types.easeInEaseOut,
       },
     });
-    setLocalAnswers(prev => [...prev, {}]);
+    // construct a new answer object from the inputs, where each answer is an empty string to start
+    const newAnswers = {};
+    inputs.forEach(input => {
+      newAnswers[input.id] = '';
+    })
+    const updatedAnswers = [...localAnswers, newAnswers];
+    onChange(updatedAnswers);
+    setLocalAnswers(updatedAnswers);
   };
 
   const validColorSchema = getValidColorSchema(colorSchema);


### PR DESCRIPTION
## Explain the changes you’ve made

The validation of isRequired for repeater field inputs was not working as intended; for dates but also for other text inputs. This fixes that, so that all repeater fields that are marked as required will trigger the validation correctly. 

## Explain your solution

The issue was that when adding a new repeater item, the answer object we created was completely empty. So when validating, if the object did not contain an answer, that answer was not validated. Explicitly, if we for salary wanted an object with { amount, date }, but the user only filled in the amount, then the answer object just looked like { amount: 4000 }, the date object being completely absent, and thus not checked at all during validation. 

My solution for this is to change the behaviour when adding a new repeater item, so that instead of adding an empty object, we add an object with all the desired inputs in place from the start, i.e. we add { amount: '', date: ''} instead of {}. This guarantees that all the answers exists, and thus that the validation can validate all answers, and in particular return invalid if some answer that's marked as required is still equal to empty string. 

## How to test the changes?

In the EKB-löpande form, under for example Lön under Incomes, we have a repeater with two fields, amount and date. Both are marked to be required, so you can first check the behaviour in the develop branch. Note that if you add an item, and do not touch any of the fields, and then click save, there is no validation, and nothing shows up in the summary list either.

 Then checkout this branch, and check if the validation behaviour when filling out the fields, and when clicking save, is improved. When this branch is checked out, you should not be able to click the save button while any of the fields are empty. Also try adding more than one repeater item, and check that validation works correctly for all of them. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

