### PR TITLE
Fix/fake user refresh token

### DIFF
--- a/source/services/AuthService.js
+++ b/source/services/AuthService.js
@@ -67,7 +67,7 @@ export async function grantAccessToken(authorizationCode) {
     });
 
     if (response.status !== 200) {
-      throw new Error(response.data);
+      throw new Error(response?.data?.data?.message);
     }
     const { accessToken, refreshToken } = response.data.data.attributes;
     const decodedAccessToken = await saveTokensToStorage(accessToken, refreshToken);
@@ -91,7 +91,7 @@ export async function refreshTokens() {
     );
 
     if (response.status !== 200) {
-      throw new Error(response.data);
+      throw new Error(response?.data?.data?.message);
     }
     const { accessToken, refreshToken } = response.data.data.attributes;
     const decodedAccessToken = await saveTokensToStorage(accessToken, refreshToken);

--- a/source/services/AuthService.js
+++ b/source/services/AuthService.js
@@ -81,13 +81,10 @@ export async function grantAccessToken(authorizationCode) {
 export async function refreshTokens() {
   try {
     const oldRefreshToken = await StorageService.getData(REFRESH_TOKEN_KEY);
-    const response = await post(
-      '/auth/token',
-      {
-        grant_type: 'refresh_token',
-        refresh_token: oldRefreshToken,
-      },
-    );
+    const response = await post('/auth/token', {
+      grant_type: 'refresh_token',
+      refresh_token: oldRefreshToken,
+    });
 
     if (response.status !== 200) {
       throw new Error(response?.data?.data?.message);

--- a/source/services/AuthService.js
+++ b/source/services/AuthService.js
@@ -87,7 +87,6 @@ export async function refreshTokens() {
         grant_type: 'refresh_token',
         refresh_token: oldRefreshToken,
       },
-      { 'x-api-key': env.MITTHELSINGBORG_IO_APIKEY }
     );
 
     if (response.status !== 200) {

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -24,7 +24,11 @@ export const actionTypes = {
 
 export async function mockedAuth() {
   try {
-    await StorageService.saveData(ACCESS_TOKEN_KEY, env.FAKE_TOKEN);
+    const [, grantTokenError] = await authService.grantAccessToken(env.FAKE_TOKEN);
+    if (grantTokenError) {
+      throw new Error(grantTokenError);
+    }
+
     return {
       type: actionTypes.loginSuccess,
     };

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -93,7 +93,7 @@ export async function refreshSession() {
     return {
       type: actionTypes.authError,
       payload: {
-        error: refreshError.data,
+        error: refreshError,
       },
     };
   }


### PR DESCRIPTION
## Explain the changes you’ve made

Fixed bug that caused app to crash when refresh token is triggered for a user that is logged in with fake token.

## Explain your solution

I define an authorization token as fake token instead of access token. This way we can generate a pair of access + refresh tokens with fake user. 

## How to test the changes?

Update env variables:
- USE_BANKID=false
- INACTIVITY_TIME=10000 (this will trigger refresh token method after 10 seconds)
- Generate an authorization token and replace with your current FAKE_TOKEN env variable. 

Rebuild app.
Log in with your fake user.
Stay inactive until being prompted with question to stay logged in and click "Ja".
(Token will now refresh)
Stay inactive again and this time click "Nej", you will now be kicked out. 

Activate bankid (USE_BANKID=true) and repeat the steps above. 

Hopefully everything works like intended and no crashes appear. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.