### PR TITLE
Feat/bankid sign message

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.12.1",
+    "@react-native-community/blur": "^3.6.0",
     "@react-native-community/datetimepicker": "^3.0.8",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/toolbar-android": "^0.1.0-rc.2",

--- a/source/components/molecules/AuthLoading.js
+++ b/source/components/molecules/AuthLoading.js
@@ -1,21 +1,63 @@
-import React, { useEffect, useRef } from 'react';
-import styled from 'styled-components/native';
+import { BlurView } from '@react-native-community/blur';
 import PropTypes from 'prop-types';
-import { Animated, Easing } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { Animated, Easing, View } from 'react-native';
+import styled from 'styled-components/native';
+import theme from '../../styles/theme';
+import Button from '../atoms/Button/Button';
 import Icon from '../atoms/Icon';
 import Text from '../atoms/Text';
-import Button from '../atoms/Button/Button';
+import { Modal } from './Modal';
 
-const Container = styled.View`
+const Container = styled(View)`
+  flex: 1;
   align-items: center;
+  justify-content: center;
+`;
+
+const Box = styled.View`
+  width: 70%;
+  height: auto;
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: #f5f5f5;
+  padding: 16px;
+  elevation: 2;
+  shadow-offset: 0px 2px;
+  shadow-color: black;
+  shadow-opacity: 0.3;
+  shadow-radius: 2px;
 `;
 
 const AuthActivityIndicator = styled.ActivityIndicator`
+  margin-top: 12px;
   margin-bottom: 24px;
 `;
 
 const InfoText = styled(Text)`
   margin-bottom: 24px;
+  text-align: center;
+  color: #3d3d3d;
+  font-weight: bold;
+`;
+
+const AbortButton = styled(Button)`
+  background: #e5e5e5;
+`;
+
+const ButtonText = styled(Text)`
+  color: #3d3d3d;
+  font-weight: bold;
+`;
+
+const BlurredBackground = styled(BlurView)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 `;
 
 const ResolvedIcon = styled(Icon)`
@@ -23,7 +65,7 @@ const ResolvedIcon = styled(Icon)`
 `;
 
 const AuthLoading = (props) => {
-  const { isBankidInstalled, cancelSignIn, colorSchema, isResolved } = props;
+  const { isBankidInstalled, cancelSignIn, colorSchema, isLoading, isResolved } = props;
   const fadeAnimation = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -35,24 +77,41 @@ const AuthLoading = (props) => {
     }).start();
   }, [fadeAnimation]);
 
-  if (isResolved) {
-    return (
-      <Container as={Animated.View} style={{ opacity: fadeAnimation }}>
-        <ResolvedIcon size={48} name="check-circle" colorSchema={colorSchema} />
-      </Container>
-    );
-  }
-
   return (
-    <Container as={Animated.View} style={{ opacity: fadeAnimation }}>
-      <AuthActivityIndicator size="large" color="slategray" />
-      {!isBankidInstalled && (
-        <InfoText>Väntar på att BankID ska startas på en annan enhet</InfoText>
+    <>
+      {isResolved && (
+        <Container as={Animated.View} style={{ opacity: fadeAnimation }}>
+          <ResolvedIcon size={48} name="check-circle" colorSchema={colorSchema} />
+        </Container>
       )}
-      <Button z={0} colorSchema={colorSchema} size="large" onClick={cancelSignIn} block>
-        <Text>Avbryt</Text>
-      </Button>
-    </Container>
+
+      <Modal
+        statusBarTranslucent
+        animationType="fade"
+        transparent
+        presentationStyle="overFullScreen"
+        visible={isLoading}
+      >
+        <Container>
+          <Box>
+            <AuthActivityIndicator size="large" color={theme.colors.primary[colorSchema][1]} />
+            {!isBankidInstalled ? (
+              <InfoText>Väntar på att BankID ska startas på en annan enhet</InfoText>
+            ) : (
+              <InfoText>Väntar på mobilt BankID</InfoText>
+            )}
+            <AbortButton z={0} colorSchema="neutral" size="large" onClick={cancelSignIn} block>
+              <ButtonText>Avbryt</ButtonText>
+            </AbortButton>
+          </Box>
+          <BlurredBackground
+            blurType="light"
+            blurAmount={15}
+            reducedTransparencyFallbackColor="white"
+          />
+        </Container>
+      </Modal>
+    </>
   );
 };
 
@@ -60,6 +119,7 @@ AuthLoading.propTypes = {
   isBankidInstalled: PropTypes.bool.isRequired,
   cancelSignIn: PropTypes.func.isRequired,
   isResolved: PropTypes.bool,
+  isLoading: PropTypes.bool,
   /**
    * The color schema of the component. colors is defined in the application theme.
    */
@@ -69,6 +129,7 @@ AuthLoading.propTypes = {
 AuthLoading.defaultProps = {
   colorSchema: 'neutral',
   isResolved: false,
+  isLoading: false,
 };
 
 export default AuthLoading;

--- a/source/components/molecules/AuthLoading.js
+++ b/source/components/molecules/AuthLoading.js
@@ -37,6 +37,7 @@ const AuthActivityIndicator = styled.ActivityIndicator`
 `;
 
 const InfoText = styled(Text)`
+  font-size: ${(props) => props.theme.fontSizes[3]}px;
   margin-bottom: 24px;
   text-align: center;
   color: ${(props) => props.theme.colors.neutrals[1]};

--- a/source/components/molecules/AuthLoading.js
+++ b/source/components/molecules/AuthLoading.js
@@ -22,7 +22,7 @@ const Box = styled.View`
   align-items: center;
   justify-content: center;
   border-radius: 10px;
-  background: #f5f5f5;
+  background: ${(props) => props.theme.colors.neutrals[6]};
   padding: 16px;
   elevation: 2;
   shadow-offset: 0px 2px;
@@ -39,8 +39,8 @@ const AuthActivityIndicator = styled.ActivityIndicator`
 const InfoText = styled(Text)`
   margin-bottom: 24px;
   text-align: center;
-  color: #3d3d3d;
-  font-weight: bold;
+  color: ${(props) => props.theme.colors.neutrals[1]};
+  font-weight: ${(props) => props.theme.fontWeights[1]};
 `;
 
 const AbortButton = styled(Button)`
@@ -48,8 +48,8 @@ const AbortButton = styled(Button)`
 `;
 
 const ButtonText = styled(Text)`
-  color: #3d3d3d;
-  font-weight: bold;
+  color: ${(props) => props.theme.colors.neutrals[1]};
+  font-weight: ${(props) => props.theme.fontWeights[1]};
 `;
 
 const BlurredBackground = styled(BlurView)`
@@ -60,7 +60,7 @@ const BlurredBackground = styled(BlurView)`
   right: 0;
 `;
 
-const ResolvedIcon = styled(Icon)`
+const SuccessIcon = styled(Icon)`
   color: ${(props) => props.theme.colors.primary[props.colorSchema][0]};
 `;
 
@@ -81,7 +81,7 @@ const AuthLoading = (props) => {
     <>
       {isResolved && (
         <Container as={Animated.View} style={{ opacity: fadeAnimation }}>
-          <ResolvedIcon size={48} name="check-circle" colorSchema={colorSchema} />
+          <SuccessIcon size={48} name="check-circle" colorSchema={colorSchema} />
         </Container>
       )}
 

--- a/source/components/molecules/ToastNotification/Toast.tsx
+++ b/source/components/molecules/ToastNotification/Toast.tsx
@@ -51,6 +51,7 @@ const BaseContainer = styled.View`
   shadow-offset: 0 0;
   shadow-opacity: 0.1;
   shadow-radius: 6px;
+  elevation: 2;
 `;
 const ContentContainer = styled.View`
   flex: 1;

--- a/source/components/molecules/ToastNotification/Toast.tsx
+++ b/source/components/molecules/ToastNotification/Toast.tsx
@@ -6,22 +6,32 @@ import { TouchableHighlight } from 'react-native-gesture-handler';
 import { Notification } from '../../../store/NotificationContext';
 import Text from '../../atoms/Text/Text';
 import Icon from '../../atoms/Icon/Icon';
+import theme from '../../../styles/theme';
 
 const severityStyles = {
+  neutral: {
+    foregroundColor: theme.colors.neutrals[1],
+    backgroundColor: 'transparent',
+    icon: 'info',
+  },
   success: {
-    color: 'green',
+    foregroundColor: theme.colors.neutrals[6],
+    backgroundColor: 'green',
     icon: 'check',
   },
   info: {
-    color: 'yellow',
+    foregroundColor: theme.colors.neutrals[6],
+    backgroundColor: '#F7BA70',
     icon: 'info',
   },
   warning: {
-    color: 'orange',
+    foregroundColor: theme.colors.neutrals[6],
+    backgroundColor: 'orange',
     icon: 'warning',
   },
   error: {
-    color: 'red',
+    foregroundColor: theme.colors.neutrals[6],
+    backgroundColor: theme.colors.primary.red[3],
     icon: 'error',
   },
 };
@@ -29,7 +39,7 @@ const severityStyles = {
 const BaseContainer = styled.View`
   position: absolute;
   z-index: 1000;
-  top: ${props => (props.top ? `${props.top}px` : '40px')};
+  top: ${(props) => (props.top ? `${props.top}px` : '40px')};
   left: 15%;
   right: 15%;
   bottom: 0;
@@ -54,7 +64,7 @@ const IconContainer = styled.View`
   border-top-left-radius: 6px;
   align-items: center;
   justify-content: center;
-  background-color: ${props => (props.color ? `${props.color}` : 'transparent')};
+  background-color: ${(props) => (props.color ? `${props.color}` : 'transparent')};
 `;
 const CloseButtonContainer = styled.TouchableHighlight`
   padding-horizontal: 14px;
@@ -79,7 +89,7 @@ interface Props {
 }
 
 const Toast: React.FC<Props> = ({ notification, index, onClose }) => {
-  const { color, icon } = severityStyles[notification.severity];
+  const { foregroundColor, backgroundColor, icon } = severityStyles[notification.severity];
   const { mainText, secondaryText } = notification;
 
   useEffect(() => {
@@ -91,8 +101,8 @@ const Toast: React.FC<Props> = ({ notification, index, onClose }) => {
   return (
     <BaseContainer top={40 + 70 * index}>
       {icon ? (
-        <IconContainer color={color}>
-          <Icon name={icon} />
+        <IconContainer color={backgroundColor}>
+          <Icon color={foregroundColor} name={icon} />
         </IconContainer>
       ) : null}
       <ContentContainer>
@@ -120,7 +130,7 @@ Toast.propTypes = {
   notification: PropTypes.shape({
     id: PropTypes.number,
     autoHideDuration: PropTypes.number,
-    severity: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
+    severity: PropTypes.oneOf(['success', 'info', 'warning', 'error', 'neutral']),
     mainText: PropTypes.string,
     secondaryText: PropTypes.string,
   }),

--- a/source/components/molecules/ToastNotification/Toast.tsx
+++ b/source/components/molecules/ToastNotification/Toast.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
+import { View, TouchableHighlight } from 'react-native';
 import styled from 'styled-components/native';
-import { TouchableHighlight } from 'react-native-gesture-handler';
 import { Notification } from '../../../store/NotificationContext';
 import Text from '../../atoms/Text/Text';
 import Icon from '../../atoms/Icon/Icon';
@@ -66,7 +65,7 @@ const IconContainer = styled.View`
   justify-content: center;
   background-color: ${(props) => (props.color ? `${props.color}` : 'transparent')};
 `;
-const CloseButtonContainer = styled.TouchableHighlight`
+const CloseButtonContainer = styled(View)`
   padding-horizontal: 14px;
   align-items: center;
   justify-content: center;
@@ -118,7 +117,7 @@ const Toast: React.FC<Props> = ({ notification, index, onClose }) => {
         )}
       </ContentContainer>
       <CloseButtonContainer>
-        <TouchableHighlight activeOpacity={1} onPress={onClose}>
+        <TouchableHighlight activeOpacity={0.6} onPress={onClose} underlayColor="transparent">
           <Icon name="close" />
         </TouchableHighlight>
       </CloseButtonContainer>

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -63,6 +63,7 @@ function Step({
 }) {
   const {
     isLoading,
+    isResolved,
     isRejected,
     error,
     handleCancelOrder,
@@ -207,9 +208,12 @@ function Step({
                 </>
               )}
 
-              {isLoading && (
+              {(isLoading || isResolved) && (
                 <SignStepWrapper>
                   <AuthLoading
+                    colorSchema={colorSchema || 'neutral'}
+                    isLoading={isLoading}
+                    isResolved={isResolved}
                     cancelSignIn={() => handleCancelOrder()}
                     isBankidInstalled={isBankidInstalled}
                   />

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -103,7 +103,10 @@ const StepFooter: React.FC<Props> = ({
       case 'sign': {
         return async () => {
           setSigning(true);
-          await handleSign(user.personalNumber, action?.message || 'Signering Mitt Helsingborg.');
+          await handleSign(
+            user.personalNumber,
+            action?.signMessage || 'Signering Mitt Helsingborg.'
+          );
         };
       }
       case 'backToMain': {

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import AuthContext from '../../../../store/AuthContext';
@@ -67,18 +67,21 @@ const StepFooter: React.FC<Props> = ({
   validateStepAnswers,
 }) => {
   const { user, handleSign, status, isLoading } = useContext(AuthContext);
+  const [isSigning, setSigning] = useState(false);
   const showNotification = useNotification();
 
   useEffect(() => {
     const signCase = () => {
       if (onUpdate) onUpdate(answers);
-      if (updateCaseInContext)
+      if (updateCaseInContext) {
         updateCaseInContext(answers, getStatusByType('active:submitted:viva'), currentPosition);
+      }
       if (formNavigation.next) formNavigation.next();
     };
 
-    if (status === 'signResolved') {
+    if (status === 'signResolved' && isSigning) {
       signCase();
+      setSigning(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
@@ -99,6 +102,7 @@ const StepFooter: React.FC<Props> = ({
       }
       case 'sign': {
         return async () => {
+          setSigning(true);
           await handleSign(user.personalNumber, action?.message || 'Signering Mitt Helsingborg.');
         };
       }

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import AuthContext from '../../../../store/AuthContext';
 import { Button, Text } from '../../../atoms';
-import { Action, ActionType, Question } from '../../../../types/FormTypes';
+import { Action, Question } from '../../../../types/FormTypes';
 import { CaseStatus } from '../../../../types/CaseType';
 import { FormPosition } from '../../../../containers/Form/hooks/useForm';
 import { useNotification } from '../../../../store/NotificationContext';
@@ -83,8 +83,8 @@ const StepFooter: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
 
-  const actionMap = (type: ActionType) => {
-    switch (type) {
+  const actionMap = (action: Action) => {
+    switch (action.type) {
       case 'start': {
         return formNavigation.start || null;
       }
@@ -99,7 +99,7 @@ const StepFooter: React.FC<Props> = ({
       }
       case 'sign': {
         return async () => {
-          await handleSign(user.personalNumber, 'Signering för Mitt Helsingborg');
+          await handleSign(user.personalNumber, action?.message || 'Signering Mitt Helsingborg.');
         };
       }
       case 'backToMain': {
@@ -147,7 +147,7 @@ const StepFooter: React.FC<Props> = ({
   const buttons = actions.map((action, index) => (
     <Flex key={`${index}-${action.label}`}>
       <Button
-        onClick={actionMap(action.type)}
+        onClick={actionMap(action)}
         colorSchema={action.color}
         disabled={isLoading || (action.hasCondition && checkCondition(action.conditionalOn))}
         z={0}

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -66,8 +66,7 @@ const StepFooter: React.FC<Props> = ({
   children,
   validateStepAnswers,
 }) => {
-  const { user, handleSign, status, isLoading } = useContext(AuthContext);
-  const [isSigning, setSigning] = useState(false);
+  const { user, handleSign, status, isLoading, handleSetStatus } = useContext(AuthContext);
   const showNotification = useNotification();
 
   useEffect(() => {
@@ -76,12 +75,12 @@ const StepFooter: React.FC<Props> = ({
       if (updateCaseInContext) {
         updateCaseInContext(answers, getStatusByType('active:submitted:viva'), currentPosition);
       }
+      handleSetStatus('idle');
       if (formNavigation.next) formNavigation.next();
     };
 
-    if (status === 'signResolved' && isSigning) {
+    if (status === 'signResolved') {
       signCase();
-      setSigning(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
@@ -102,7 +101,6 @@ const StepFooter: React.FC<Props> = ({
       }
       case 'sign': {
         return async () => {
-          setSigning(true);
           await handleSign(
             user.personalNumber,
             action?.signMessage || 'Signering Mitt Helsingborg.'

--- a/source/screens/LoginScreen.js
+++ b/source/screens/LoginScreen.js
@@ -160,6 +160,7 @@ function LoginScreen(props) {
     isRejected,
     isResolved,
     error,
+    handleSetError,
   } = useContext(AuthContext);
   const showNotification = useNotification();
 
@@ -210,7 +211,8 @@ function LoginScreen(props) {
    */
   useEffect(() => {
     if (isRejected && error?.message) {
-      showNotification(error.message, '', 'error');
+      showNotification(error.message, '', 'neutral');
+      handleSetError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [error]);

--- a/source/screens/LoginScreen.js
+++ b/source/screens/LoginScreen.js
@@ -263,6 +263,7 @@ function LoginScreen(props) {
             <Form>
               <AuthLoading
                 colorSchema="red"
+                isLoading={isLoading}
                 isResolved={isResolved}
                 cancelSignIn={() => handleCancelOrder()}
                 isBankidInstalled
@@ -327,6 +328,7 @@ function LoginScreen(props) {
               <Form>
                 <AuthLoading
                   colorSchema="red"
+                  isLoading={isLoading}
                   isResolved={isResolved}
                   cancelSignIn={() => handleCancelOrder()}
                   isBankidInstalled={false}

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -18,6 +18,7 @@ import {
   startSign,
   setStatus,
   checkIsBankidInstalled,
+  setError,
 } from './actions/AuthActions';
 
 const AuthContext = React.createContext();
@@ -135,10 +136,17 @@ function AuthProvider({ children, initialState }) {
   }
 
   /**
-   * Used to remove user profile data from the state.
+   * Set status.
    */
   function handleSetStatus(status) {
     dispatch(setStatus(status));
+  }
+
+  /**
+   * Set error object
+   */
+  function handleSetError(error) {
+    dispatch(setError(error));
   }
 
   /**
@@ -176,6 +184,7 @@ function AuthProvider({ children, initialState }) {
     handleSetStatus,
     isAccessTokenValid,
     handleSign,
+    handleSetError,
     isLoading: state.status === 'pending',
     isIdle: state.status === 'idle',
     isResolved: state.status === 'authResolved' || state.status === 'signResolved',

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -18,6 +18,7 @@ export const actionTypes = {
   cancelOrder: 'CANCEL_ORDER',
   signStarted: 'SIGN_STARTED',
   setStatus: 'SET_STATUS',
+  setError: 'SET_ERROR',
   signSuccess: 'SIGN_SUCCESS',
   setIsBankidInstalled: 'SET_INSTALLED',
 };
@@ -48,6 +49,15 @@ export function setStatus(status) {
   return {
     type: actionTypes.setStatus,
     status,
+  };
+}
+
+export function setError(error) {
+  return {
+    type: actionTypes.setError,
+    payload: {
+      error,
+    },
   };
 }
 

--- a/source/store/reducers/AuthReducer.js
+++ b/source/store/reducers/AuthReducer.js
@@ -115,6 +115,12 @@ export default function AuthReducer(state, action) {
         isBankidInstalled: action.isBankidInstalled,
       };
 
+    case actionTypes.setError:
+      return {
+        ...state,
+        ...payload,
+      };
+
     default:
       return state;
   }

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -73,7 +73,7 @@ export interface Action {
   color?: string;
   hasCondition?: boolean;
   conditionalOn?: string;
-  message?: string;
+  signMessage?: string;
 }
 
 export interface Banner {

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -73,6 +73,7 @@ export interface Action {
   color?: string;
   hasCondition?: boolean;
   conditionalOn?: string;
+  message?: string;
 }
 
 export interface Banner {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,6 +1449,13 @@
   dependencies:
     deep-assign "^3.0.0"
 
+"@react-native-community/blur@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/blur/-/blur-3.6.0.tgz#31c9e0f2770519c9b5c4f99418f192246f0d4db8"
+  integrity sha512-GtDBhpX2pQcjl4VopOC8FktrVufrEfYRwVeMQ2WWckqKIv2BdwvlvWvj88L1WmEdBr9UNcm3rtgz+d+YXkmirA==
+  dependencies:
+    prop-types "^15.5.10"
+
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"


### PR DESCRIPTION
## Explain the changes you’ve made

Started with a small fix and ended up in various fixes/design updates connected to the login/sign flow. Sorry about that. 

- Fixed message that is shown to the user when signing with BankID. Now we display the message from form object instead of hard coded string. 
- Implemented new design for login/sign when Bankid is loading.
- Updated Toast component with some better colors and added neutral color schema.
- Fixed bug on Android to make it possible to close Toast components.

## Explain your solution

Had to add a new package to make backgrounds blurred.

## How to test the changes?

- Install packages with 'yarn' and 'pod install'.
- Build project on ios and android.
- Login with bankid and the loading design should now be updated.
- Also test to abort an ongoing login to see the Toast message with neutral color schema. (and the Toast can now be closed on android).
- Step through the form and sign an application. The loading design is also updated here. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.