### PR TITLE
Fix/update case new data struct

### DIFF
--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -36,6 +36,13 @@ interface Props {
   ) => void;
 }
 
+export const defaultInitialPosition: FormPosition = {
+  index: 0,
+  level: 0,
+  currentMainStep: 1,
+  currentMainStepIndex: 0,
+};
+
 /**
  * The Container Component Form allows you to create, process and reuse forms. The Form component
  * is a tool to help you solve the problem of allowing end-users to interact with the
@@ -52,12 +59,6 @@ const Form: React.FC<Props> = ({
   status,
   updateCaseInContext,
 }) => {
-  const defaultInitialPosition: FormPosition = {
-    index: 0,
-    level: 0,
-    currentMainStep: 1,
-    currentMainStepIndex: 0,
-  };
 
   const initialState: FormReducerState = {
     submitted: false,

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -32,13 +32,31 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
         setForm(form);
         setFormQuestions(getFormQuestions(form));
       });
-      const answersObject = convertAnswerArrayToObject(caseData.answers);
-      caseData.answers = answersObject;
+      const answerArray = caseData?.forms?.[caseData.currentFormId]?.answers || [];
+      const answersObject = convertAnswerArrayToObject(answerArray);
+      caseData.forms = {
+        ...caseData.forms,
+        [caseData.currentFormId]: {
+          ...caseData.forms[caseData.currentFormId],
+          answers: answersObject,
+        },
+      };
       setInitialCase(caseData);
     } else if (caseId) {
       const initCase = getCase(caseId);
-      const answersObject = convertAnswerArrayToObject(initCase.answers);
-      initCase.answers = answersObject;
+      // Beware, dragons! Since we pass by reference, it seems like the answers
+      // can be converted to object form already, thus we do this check.
+      if (Array.isArray(initCase?.forms?.[initCase.currentFormId]?.answers)) {
+        const answerArray = initCase?.forms?.[initCase.currentFormId]?.answers || [];
+        const answersObject = convertAnswerArrayToObject(answerArray);
+        initCase.forms = {
+          ...initCase.forms,
+          [initCase.currentFormId]: {
+            ...initCase.forms[initCase.currentFormId],
+            answers: answersObject,
+          },
+        };
+      }
       setInitialCase(initCase);
 
       getForm(initCase.currentFormId).then(async (form) => {
@@ -90,8 +108,9 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       </SpinnerContainer>
     );
   }
-  initialPosition =
+  const initialPosition =
     initialCase?.forms?.[initialCase.currentFormId]?.currentPosition || defaultInitialPosition;
+  const initialAnswers = initialCase?.forms?.[initialCase.currentFormId]?.answers || {};
 
   return (
     <Form
@@ -102,7 +121,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       onClose={handleCloseForm}
       onStart={handleStartForm}
       onSubmit={handleSubmitForm}
-      initialAnswers={initialCase?.answers || caseData.answers || {}}
+      initialAnswers={initialAnswers}
       status={initialCase.status || getStatusByType('notStarted')}
       updateCaseInContext={updateCaseContext}
       {...props}

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -35,7 +35,8 @@ const colorSchema = 'red';
  * @param {obj} navigation
  */
 const computeCaseCardComponent = (caseData, form, caseType, navigation) => {
-  const currentStep = caseData?.currentPosition?.currentMainStep || 0;
+  const currentStep =
+    caseData?.forms?.[caseData.currentFormId]?.currentPosition?.currentMainStep || 0;
   const totalSteps = form?.stepStructure ? form.stepStructure.length : 0;
   const applicationPeriodMonth = caseData?.details?.period?.endDate
     ? getSwedishMonthNameByTimeStamp(caseData.details.period.endDate, true)
@@ -137,9 +138,8 @@ function CaseOverview(props) {
       const updateCaseItemsPromises = caseTypes.map(async (caseType) => {
         const formIds = await getFormIdsByFormTypes(caseType.formTypes);
         const formCases = getCasesByFormIds(formIds);
-
         const updatedFormCaseObjects = formCases.map(async (caseData) => {
-          const form = await getForm(caseData.formId);
+          const form = await getForm(caseData.currentFormId);
           const component = computeCaseCardComponent(caseData, form, caseType, navigation);
           return { component, ...caseData };
         });

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -29,7 +29,6 @@ const computeCaseCardComponent = (caseData, form, colorSchema, navigation) => {
     currentPosition: { currentMainStep: currentStep },
   } = caseData.forms[caseData.currentFormId];
 
-  console.log('form', form);
   const totalSteps = form?.stepStructure?.length || 0;
   const applicationPeriodMonth = getSwedishMonthNameByTimeStamp(endDate, true);
   const isNotStarted = status?.type?.includes('notStarted');

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -24,11 +24,12 @@ const SummaryHeading = styled(Text)`
 `;
 
 const computeCaseCardComponent = (caseData, form, colorSchema, navigation) => {
+  const { status, details: { period: { endDate } = {} } = {} } = caseData;
   const {
-    status,
-    currentPosition: { currentMainStep: currentStep } = {},
-    details: { period: { endDate } = {} } = {},
-  } = caseData;
+    currentPosition: { currentMainStep: currentStep },
+  } = caseData.forms[caseData.currentFormId];
+
+  console.log('form', form);
   const totalSteps = form?.stepStructure?.length || 0;
   const applicationPeriodMonth = getSwedishMonthNameByTimeStamp(endDate, true);
   const isNotStarted = status?.type?.includes('notStarted');
@@ -89,7 +90,7 @@ const CaseSummary = (props) => {
       setForm(await getForm(id));
     };
 
-    getFormObject(caseData.formId);
+    getFormObject(caseData.currentFormId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFocused, cases]);
 

--- a/source/store/CaseContext.js
+++ b/source/store/CaseContext.js
@@ -32,8 +32,17 @@ function CaseProvider({ children, initialState = defaultInitialState }) {
     dispatch(await create(form, user, Object.values(state.cases), callback));
   }
 
-  async function updateCase(caseId, data, status, currentPosition, form) {
-    dispatch(await update(caseId, data, status, currentPosition, form));
+  async function updateCase({
+    caseId,
+    formId,
+    answerObject,
+    status,
+    currentPosition,
+    formQuestions,
+  }) {
+    dispatch(
+      await update({ caseId, formId, answerObject, status, currentPosition, formQuestions })
+    );
   }
 
   function getCase(caseId) {
@@ -48,7 +57,7 @@ function CaseProvider({ children, initialState = defaultInitialState }) {
   function getCasesByFormIds(formIds) {
     const formCases = [];
     Object.values(state.cases).forEach((c) => {
-      if (formIds.includes(c.formId)) {
+      if (formIds.includes(c.currentFormId)) {
         formCases.push(c);
       }
     });

--- a/source/store/actions/CaseActions.js
+++ b/source/store/actions/CaseActions.js
@@ -10,13 +10,17 @@ export const actionTypes = {
   apiError: 'API_ERROR',
 };
 
-export async function updateCase(caseId, data, status, currentPosition, formQuestions, callback) {
-  const answers = convertAnswersToArray(data, formQuestions);
+export async function updateCase(
+  { caseId, formId, answerObject, status, currentPosition, formQuestions },
+  callback
+) {
+  const answers = convertAnswersToArray(answerObject, formQuestions);
 
   const body = {
     status,
     answers,
     currentPosition,
+    currentFormId: formId,
   };
 
   try {


### PR DESCRIPTION
## Explain the changes you’ve made

Updates the app to work with the new case data structure and the updates to the API. 
Fixes the loading of answers, the updating of case data and the display of the active cases on the CaseOverview. 
Also updates CaseSummary to use the new data structure. 

Note that this does not fix the createCase behaviour, that is left for a later task. 

## Explain your solution

Mainly updating things to match the new data structure, changing the location of where we find the answers, and changing formId --> currentFormId etc. 

Also some minor changes to the setup logic of the FormCaseScreen. 

## How to test the changes?

Setting up a proper test environment for this is a little annoying. First you need your cases-api to be updated to the fix/update-case-new-data-struct branch of the api. Then you need a case in your database with the correct new data structure, i.e. a case with 
```
currentFormId: someExistingFormsId,
forms: {
  someExistingFormsId: { answers: [...], currentPosition: { ... } }
  },
...restOfCaseData
```
Then point your app at your own AWS environment with this case set up, and this branch checked out.
The app should then work as normal, with the case showing up in the CaseOverview and CaseSummary, with answers loading and updating correctly and so on. 
It would be good to check that submitted answers land correctly in the database, and that resuming a case works. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

