### PR TITLE
feat(ekb-completion-form-type): add EKB-completion as a formType for stickprov

### DIFF
--- a/source/assets/formTypes.js
+++ b/source/assets/formTypes.js
@@ -1,4 +1,4 @@
-const FormTypes = ['EKB-recurring', 'EKB-new'];
+const FormTypes = ['EKB-recurring', 'EKB-new', 'EKB-completion'];
 
 export const FormTypesDescription = {
   'EKB-recurring': {
@@ -8,6 +8,10 @@ export const FormTypesDescription = {
   'EKB-new': {
     name: 'EKB grundansökan',
     description: 'Första ansökan om ekonomiskt bistånd. Större, mer omfattande.',
+  },
+  'EKB-completion': {
+    name: 'EKB komplettering',
+    description: 'När en ansökan behöver kompletteras med bankutdrag eller kvitton',
   },
 };
 

--- a/source/store/CaseContext.js
+++ b/source/store/CaseContext.js
@@ -19,7 +19,7 @@ const CaseDispatch = React.createContext();
 export const caseTypes = [
   {
     name: 'Ekonomiskt Bistånd',
-    formTypes: ['EKB-recurring'],
+    formTypes: ['EKB-recurring', 'EKB-completion', 'EKB-new'],
     icon: 'ICON_EKB',
     navigateTo: 'CaseSummary',
   },


### PR DESCRIPTION
## Explain the changes you’ve made

Adds a form type for completions, i.e. stickprov. 

## Explain why these changes are made

Since we use formTypes as a way to avoid hard-coding uuid's, we need one for stickprov as well as for the recurrent and new.

## Explain your solution

Just adds it to the same file that defines the other formTypes. 

## How to test the changes?

No real way to test this, as it's just forward-looking in order to set up infrastructure for the Stickprov. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
