### PR TITLE
fix(close-dialog-blur): add background blur

### DIFF
--- a/source/components/molecules/AuthLoading.js
+++ b/source/components/molecules/AuthLoading.js
@@ -22,8 +22,8 @@ const Box = styled.View`
   align-items: center;
   justify-content: center;
   border-radius: 10px;
-  background: ${(props) => props.theme.colors.neutrals[6]};
-  padding: 16px;
+  background: ${(props) => props.theme.colors.neutrals[5]};
+  padding: 12px;
   elevation: 2;
   shadow-offset: 0px 2px;
   shadow-color: black;

--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -1,44 +1,36 @@
 import React from 'react';
 import styled from 'styled-components/native';
+import { BlurView } from '@react-native-community/blur';
 import PropTypes from 'prop-types';
 import { Modal } from 'react-native';
 import Button from '../../../atoms/Button';
 import Text from '../../../atoms/Text';
 import Card from '../../../molecules/Card';
 
-const BackgroundBlur = styled.View`
+const BackgroundBlur = styled(BlurView)`
   position: absolute;
-  z-index: 1000;
   top: 0;
   left: 0;
-  right: 0;
   bottom: 0;
-  padding: 0px;
-  background-color: rgba(0, 0, 0, 0.25);
+  right: 0;
 `;
-
 const PopupContainer = styled.View`
   position: absolute;
   z-index: 1000;
   top: 33%;
   left: 10%;
   right: 10%;
-  padding: 0px;
   width: 80%;
-  background-color: white;
-  flex-direction: column;
-  border-radius: 6px;
-  shadow-offset: 0 0;
-  shadow-opacity: 0.1;
-  shadow-radius: 6px;
-`;
-const ContentContainer = styled.View`
+  border-radius: 10px;
+  background: ${(props) => props.theme.colors.neutrals[7]};
   padding: 10px;
-  padding-bottom: 15px;
-  flex-direction: column;
-  justify-content: space-between;
-  flex: 10;
+  elevation: 2;
+  shadow-offset: 0px 2px;
+  shadow-color: black;
+  shadow-opacity: 0.3;
+  shadow-radius: 2px;
 `;
+
 const ButtonRow = styled.View`
   flex-direction: row;
   justify-content: space-evenly;
@@ -53,35 +45,38 @@ interface Props {
 }
 /** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
 const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
-  <Modal visible={visible} transparent presentationStyle="overFullScreen" animationType="fade">
-    <BackgroundBlur>
-      <PopupContainer>
-        <ContentContainer>
-          <Card colorSchema="neutral">
-            <Card.Body>
-              <Card.Title>Vill du avbryta ansökan?</Card.Title>
-              <Card.Text>
-                Ansökan sparas i 3 dagar. Efter det raderas den och du får starta en ny.
-              </Card.Text>
-            </Card.Body>
-          </Card>
-          <ButtonRow>
-            <Button colorSchema="red" onClick={closeDialog}>
-              <Text>Nej</Text>
-            </Button>
-            <Button
-              small
-              onClick={() => {
-                closeDialog();
-                closeForm();
-              }}
-            >
-              <Text>Ja</Text>
-            </Button>
-          </ButtonRow>
-        </ContentContainer>
-      </PopupContainer>
-    </BackgroundBlur>
+  <Modal
+    visible={visible}
+    transparent
+    presentationStyle="overFullScreen"
+    animationType="fade"
+    statusBarTranslucent
+  >
+    <PopupContainer>
+      <Card colorSchema="neutral">
+        <Card.Body>
+          <Card.Title>Vill du avbryta ansökan?</Card.Title>
+          <Card.Text>
+            Ansökan sparas i 3 dagar. Efter det raderas den och du får starta en ny.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <ButtonRow>
+        <Button colorSchema="red" onClick={closeDialog}>
+          <Text>Nej</Text>
+        </Button>
+        <Button
+          small
+          onClick={() => {
+            closeDialog();
+            closeForm();
+          }}
+        >
+          <Text>Ja</Text>
+        </Button>
+      </ButtonRow>
+    </PopupContainer>
+    <BackgroundBlur blurType="light" blurAmount={15} reducedTransparencyFallbackColor="white" />
   </Modal>
 );
 

--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -4,8 +4,8 @@ import { BlurView } from '@react-native-community/blur';
 import PropTypes from 'prop-types';
 import { Modal } from 'react-native';
 import Button from '../../../atoms/Button';
+import Heading from '../../../atoms/Heading';
 import Text from '../../../atoms/Text';
-import Card from '../../../molecules/Card';
 
 const BackgroundBlur = styled(BlurView)`
   position: absolute;
@@ -14,16 +14,22 @@ const BackgroundBlur = styled(BlurView)`
   bottom: 0;
   right: 0;
 `;
+
 const PopupContainer = styled.View`
-  position: absolute;
-  z-index: 1000;
-  top: 33%;
-  left: 10%;
-  right: 10%;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Dialog = styled.View`
   width: 80%;
+  height: auto;
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
   border-radius: 10px;
-  background: ${(props) => props.theme.colors.neutrals[7]};
-  padding: 10px;
+  background: ${(props) => props.theme.colors.neutrals[5]};
+  padding: 12px;
   elevation: 2;
   shadow-offset: 0px 2px;
   shadow-color: black;
@@ -31,11 +37,44 @@ const PopupContainer = styled.View`
   shadow-radius: 2px;
 `;
 
+const Content = styled.View`
+  padding: 12px;
+`;
+
+const Title = styled(Heading)`
+  color: ${(props) => props.theme.colors.neutrals[1]};
+  font-size: ${(props) => props.theme.fontSizes[4]}px;
+  margin: 0px;
+  text-align: center;
+`;
+
+const DialogText = styled(Text)`
+  margin: 12px;
+  font-size: ${(props) => props.theme.fontSizes[3]}px;
+  text-align: center;
+`;
+
+const DialogButton = styled(Button)`
+  ${({ colorSchema }) => colorSchema === 'neutral' && `background: #e5e5e5; `}
+`;
+
+const ButtonText = styled(Text)`
+  color: ${(props) => props.theme.colors.neutrals[1]};
+  font-weight: ${(props) => props.theme.fontWeights[1]};
+`;
+
 const ButtonRow = styled.View`
   flex-direction: row;
   justify-content: space-evenly;
-  padding: 15px;
-  margin-bottom: 0px;
+  margin: 0px;
+`;
+
+const ButtonWrapper = styled.View`
+  flex: 1;
+`;
+
+const ButtonDivider = styled.View`
+  width: 8px;
 `;
 
 interface Props {
@@ -53,30 +92,37 @@ const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
     statusBarTranslucent
   >
     <PopupContainer>
-      <Card colorSchema="neutral">
-        <Card.Body>
-          <Card.Title>Vill du avbryta ansökan?</Card.Title>
-          <Card.Text>
+      <Dialog>
+        <Content>
+          <Title>Vill du avbryta ansökan?</Title>
+          <DialogText>
             Ansökan sparas i 3 dagar. Efter det raderas den och du får starta en ny.
-          </Card.Text>
-        </Card.Body>
-      </Card>
-      <ButtonRow>
-        <Button colorSchema="red" onClick={closeDialog}>
-          <Text>Nej</Text>
-        </Button>
-        <Button
-          small
-          onClick={() => {
-            closeDialog();
-            closeForm();
-          }}
-        >
-          <Text>Ja</Text>
-        </Button>
-      </ButtonRow>
+          </DialogText>
+        </Content>
+        <ButtonRow>
+          <ButtonWrapper>
+            <DialogButton block z={0} colorSchema="neutral" onClick={closeDialog}>
+              <ButtonText>Nej</ButtonText>
+            </DialogButton>
+          </ButtonWrapper>
+          <ButtonDivider />
+          <ButtonWrapper>
+            <DialogButton
+              block
+              z={0}
+              colorSchema="blue"
+              onClick={() => {
+                closeDialog();
+                closeForm();
+              }}
+            >
+              <Text>Ja</Text>
+            </DialogButton>
+          </ButtonWrapper>
+        </ButtonRow>
+      </Dialog>
+      <BackgroundBlur blurType="dark" blurAmount={15} reducedTransparencyFallbackColor="white" />
     </PopupContainer>
-    <BackgroundBlur blurType="light" blurAmount={15} reducedTransparencyFallbackColor="white" />
   </Modal>
 );
 


### PR DESCRIPTION
## Explain the changes you’ve made

Small change that adds the same type of background blur effect as seen in the bankid-dialog, to the close form dialog, replacing the earlier transparent overlay without blur. 

## Explain why these changes are made

Looks a bit nicer, and is more consistent to have dialogs look the same across the app. Also follows the figma design more closely. 

## Explain your solution

Uses the same library and pretty much the same styling as the AuthLoading dialog. Very minor changes to the CloseDialog component. 

## How to test the changes?

Checkout the branch, go into any form, and try to close it to see the improved dialog. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshot
![dialog-blur](https://user-images.githubusercontent.com/7421890/108065213-f59e6500-705d-11eb-8b01-965c34f53c78.png)

