### PR TITLE
Feat/close dialog

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -107,5 +107,13 @@
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     }
-  }
+  },
+  "overrides": [
+    {
+        "files": ["**/*.tsx"],
+        "rules": {
+            "react/prop-types": "off"
+        }
+    }
+  ],
 }

--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
@@ -26,6 +26,7 @@ export interface Props {
     back: () => void;
     down: (targetStepId: string) => void;
     up: () => void;
+    createSnapshot: () => void;
   };
 }
 
@@ -43,6 +44,7 @@ const NavigationButtonField: React.FC<Props> = ({
     // This logic could be broken out and placed elsewhere.
     switch (navigationType.type) {
       case 'navigateDown':
+        formNavigation.createSnapshot();
         formNavigation.down(navigationType.stepId);
         break;
       case 'navigateUp':

--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -5,7 +5,6 @@ import { Modal } from 'react-native';
 import Button from '../../../atoms/Button';
 import Heading from '../../../atoms/Heading';
 import Text from '../../../atoms/Text';
-import Card from '../../../molecules/Card';
 import { PrimaryColor } from '../../../../styles/themeHelpers';
 
 const BackgroundBlur = styled(BlurView)`
@@ -29,6 +28,7 @@ const Dialog = styled.View`
   align-items: center;
   justify-content: center;
   border-radius: 10px;
+  /* @ts-ignore */
   background: ${(props) => props.theme.colors.neutrals[5]};
   padding: 12px;
   elevation: 2;
@@ -59,25 +59,20 @@ const DialogButton = styled(Button)`
   ${({ colorSchema }) => colorSchema === 'neutral' && `background: #e5e5e5; `}
 `;
 
-const ButtonText = styled(Text)`
-  color: ${(props) => props.theme.colors.neutrals[1]};
-  font-weight: ${(props) => props.theme.fontWeights[1]};
-`;
-
 const ButtonRow = styled.View`
   flex-direction: row;
   justify-content: space-evenly;
   margin: 0px;
 `;
 
+const ButtonText = styled(Text)`
+  color: ${(props) => props.theme.colors.neutrals[1]};
+  font-weight: ${(props) => props.theme.fontWeights[1]};
+`;
+
 const ButtonWrapper = styled.View`
   flex: 1;
 `;
-
-const ButtonDivider = styled.View`
-  width: 8px;
-`;
-
 export interface Props {
   visible?: boolean;
   closeForm?: () => void;
@@ -91,40 +86,10 @@ export interface Props {
   }>;
 }
 
-/** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
+/** Simple popup dialog asking the user if they really want to exit the form. Partially asks the background. */
 const CloseDialog: React.FC<Props> = ({ visible, title, body, buttons }) => (
   <Modal
     visible={visible ?? false}
-    transparent
-    presentationStyle="overFullScreen"
-    animationType="fade"
-  >
-    <BackgroundBlur>
-      <PopupContainer>
-        <ContentContainer>
-          <Card colorSchema="neutral">
-            <Card.Body>
-              <Card.Title>{title}</Card.Title>
-              {body && body.length > 0 && <Card.Text>{body}</Card.Text>}
-            </Card.Body>
-          </Card>
-          <ButtonRow>
-            {buttons.map(({ text, color, clickHandler }) => (
-              /* @ts-ignore */
-              <Button
-                colorSchema={color && color.length > 0 ? color : 'blue'}
-                onClick={clickHandler}
-              >
-                <Text>{text}</Text>
-              </Button>
-            ))}
-          </ButtonRow>
-        </ContentContainer>
-      </PopupContainer>
-    </BackgroundBlur>
-const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
-  <Modal
-    visible={visible}
     transparent
     presentationStyle="overFullScreen"
     animationType="fade"
@@ -133,31 +98,23 @@ const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
     <PopupContainer>
       <Dialog>
         <Content>
-          <Title>Vill du avbryta ansökan?</Title>
-          <DialogText>
-            Ansökan sparas i 3 dagar. Efter det raderas den och du får starta en ny.
-          </DialogText>
+          <Title>{title}</Title>
+          {body && body.length > 0 ? <DialogText>{body}</DialogText> : null}
         </Content>
         <ButtonRow>
-          <ButtonWrapper>
-            <DialogButton block z={0} colorSchema="neutral" onClick={closeDialog}>
-              <ButtonText>Nej</ButtonText>
-            </DialogButton>
-          </ButtonWrapper>
-          <ButtonDivider />
-          <ButtonWrapper>
-            <DialogButton
-              block
-              z={0}
-              colorSchema="blue"
-              onClick={() => {
-                closeDialog();
-                closeForm();
-              }}
-            >
-              <Text>Ja</Text>
-            </DialogButton>
-          </ButtonWrapper>
+          {buttons.map(({ text, color, clickHandler }, index) => (
+            /* @ts-ignore */
+            <ButtonWrapper>
+              <DialogButton
+                block
+                z={0}
+                colorSchema={color && color.length > 0 ? color : 'blue'}
+                onClick={clickHandler}
+              >
+                {color === 'neutral' ? <ButtonText>{text}</ButtonText> : <Text>{text}</Text>}
+              </DialogButton>
+            </ButtonWrapper>
+          ))}
         </ButtonRow>
       </Dialog>
       <BackgroundBlur blurType="dark" blurAmount={15} reducedTransparencyFallbackColor="white" />

--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -5,6 +5,8 @@ import { Modal } from 'react-native';
 import Button from '../../../atoms/Button';
 import Heading from '../../../atoms/Heading';
 import Text from '../../../atoms/Text';
+import Card from '../../../molecules/Card';
+import { PrimaryColor } from '../../../../styles/themeHelpers';
 
 const BackgroundBlur = styled(BlurView)`
   position: absolute;
@@ -75,6 +77,7 @@ const ButtonWrapper = styled.View`
 const ButtonDivider = styled.View`
   width: 8px;
 `;
+
 export interface Props {
   visible?: boolean;
   closeForm?: () => void;
@@ -83,7 +86,7 @@ export interface Props {
   body: string;
   buttons: Array<{
     text: string;
-    color?: 'neutral' | 'blue' | 'red' | 'purple' | 'green';
+    color?: PrimaryColor;
     clickHandler: () => void;
   }>;
 }

--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import { BlurView } from '@react-native-community/blur';
-import PropTypes from 'prop-types';
 import { Modal } from 'react-native';
 import Button from '../../../atoms/Button';
 import Heading from '../../../atoms/Heading';
@@ -81,8 +80,45 @@ interface Props {
   visible: boolean;
   closeForm: () => void;
   closeDialog: () => void;
+  title: string;
+  body: string;
+  buttons: Array<{
+    text: string;
+    color: string;
+    clickHandler: () => void;
+  }>;
 }
+
 /** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
+const CloseDialog: React.FC<Props> = ({
+  visible,
+  closeForm,
+  closeDialog,
+  title,
+  body,
+  buttons,
+}) => (
+  <Modal visible={visible} transparent presentationStyle="overFullScreen" animationType="fade">
+    <BackgroundBlur>
+      <PopupContainer>
+        <ContentContainer>
+          <Card colorSchema="neutral">
+            <Card.Body>
+              <Card.Title>{title}</Card.Title>
+              {body && body.length > 0 && <Card.Text>{body}</Card.Text>}
+            </Card.Body>
+          </Card>
+          <ButtonRow>
+            {buttons.map(({ text, color, clickHandler }) => (
+              /* @ts-ignore */
+              <Button colorSchema={color} onClick={clickHandler}>
+                <Text>{text}</Text>
+              </Button>
+            ))}
+          </ButtonRow>
+        </ContentContainer>
+      </PopupContainer>
+    </BackgroundBlur>
 const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
   <Modal
     visible={visible}
@@ -125,14 +161,5 @@ const CloseDialog: React.FC<Props> = ({ visible, closeForm, closeDialog }) => (
     </PopupContainer>
   </Modal>
 );
-
-CloseDialog.propTypes = {
-  /** whether to show the dialog or not */
-  visible: PropTypes.bool,
-  /** callback to navigate out of the form */
-  closeForm: PropTypes.func,
-  /** callback to close the dialog */
-  closeDialog: PropTypes.func,
-};
 
 export default CloseDialog;

--- a/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/CloseDialog.tsx
@@ -75,30 +75,27 @@ const ButtonWrapper = styled.View`
 const ButtonDivider = styled.View`
   width: 8px;
 `;
-
-interface Props {
-  visible: boolean;
-  closeForm: () => void;
-  closeDialog: () => void;
+export interface Props {
+  visible?: boolean;
+  closeForm?: () => void;
+  closeDialog?: () => void;
   title: string;
   body: string;
   buttons: Array<{
     text: string;
-    color: string;
+    color?: 'neutral' | 'blue' | 'red' | 'purple' | 'green';
     clickHandler: () => void;
   }>;
 }
 
 /** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
-const CloseDialog: React.FC<Props> = ({
-  visible,
-  closeForm,
-  closeDialog,
-  title,
-  body,
-  buttons,
-}) => (
-  <Modal visible={visible} transparent presentationStyle="overFullScreen" animationType="fade">
+const CloseDialog: React.FC<Props> = ({ visible, title, body, buttons }) => (
+  <Modal
+    visible={visible ?? false}
+    transparent
+    presentationStyle="overFullScreen"
+    animationType="fade"
+  >
     <BackgroundBlur>
       <PopupContainer>
         <ContentContainer>
@@ -111,7 +108,10 @@ const CloseDialog: React.FC<Props> = ({
           <ButtonRow>
             {buttons.map(({ text, color, clickHandler }) => (
               /* @ts-ignore */
-              <Button colorSchema={color} onClick={clickHandler}>
+              <Button
+                colorSchema={color && color.length > 0 ? color : 'blue'}
+                onClick={clickHandler}
+              >
                 <Text>{text}</Text>
               </Button>
             ))}

--- a/source/components/organisms/Step/CloseDialog/FormDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/FormDialog.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import CloseDialog, { Props as CloseDialogProps } from './CloseDialog';
 
-type DialogTemplateKeyType = 'mainStep' | 'subStep';
+type TemplateKeys = 'mainStep' | 'subStep';
 
 const DIALOG_TEMPLATES: {
-  [DialogTemplateKeyType: string]: CloseDialogProps;
+  [TemplateKeys: string]: CloseDialogProps;
 } = {
   mainStep: {
     title: 'Vill du avbryta ansökan',
@@ -42,10 +42,10 @@ const DIALOG_TEMPLATES: {
 };
 
 interface Props extends Partial<CloseDialogProps> {
-  template: DialogTemplateKeyType;
+  template: TemplateKeys;
 }
 
-/** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
+/** Template wrapper for CloseDialog within Form */
 const FormDialog = ({ template, ...props }: Props) => (
   <CloseDialog {...DIALOG_TEMPLATES[template]} {...props} />
 );

--- a/source/components/organisms/Step/CloseDialog/FormDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/FormDialog.tsx
@@ -45,7 +45,7 @@ interface Props extends Partial<CloseDialogProps> {
   template: TemplateKeys;
 }
 
-/** Template wrapper for CloseDialog within Form */
+/** Template wrapper for CloseDialog within Form. Override template by forwarding props to CloseDialog */
 const FormDialog = ({ template, ...props }: Props) => (
   <CloseDialog {...DIALOG_TEMPLATES[template]} {...props} />
 );

--- a/source/components/organisms/Step/CloseDialog/FormDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/FormDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+
 import CloseDialog, { Props as CloseDialogProps } from './CloseDialog';
 
 type TemplateKeys = 'mainStep' | 'subStep';

--- a/source/components/organisms/Step/CloseDialog/FormDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/FormDialog.tsx
@@ -13,7 +13,7 @@ const DIALOG_TEMPLATES: {
     buttons: [
       {
         text: 'Nej',
-        color: 'red',
+        color: 'neutral',
         clickHandler: () => {},
       },
       {
@@ -29,7 +29,7 @@ const DIALOG_TEMPLATES: {
     buttons: [
       {
         text: 'Nej',
-        color: 'red',
+        color: 'neutral',
         clickHandler: () => {},
       },
       {

--- a/source/components/organisms/Step/CloseDialog/FormDialog.tsx
+++ b/source/components/organisms/Step/CloseDialog/FormDialog.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import CloseDialog, { Props as CloseDialogProps } from './CloseDialog';
+
+type DialogTemplateKeyType = 'mainStep' | 'subStep';
+
+const DIALOG_TEMPLATES: {
+  [DialogTemplateKeyType: string]: CloseDialogProps;
+} = {
+  mainStep: {
+    title: 'Vill du avbryta ansökan',
+    body: 'Ansökan sparas i 3 dagar. Efter det raderas den och du får starta en ny.',
+    buttons: [
+      {
+        text: 'Nej',
+        color: 'red',
+        clickHandler: () => {},
+      },
+      {
+        text: 'Ja',
+        color: 'blue',
+        clickHandler: () => {},
+      },
+    ],
+  },
+  subStep: {
+    title: 'Vill du stänga ner utan att spara?',
+    body: '',
+    buttons: [
+      {
+        text: 'Nej',
+        color: 'red',
+        clickHandler: () => {},
+      },
+      {
+        text: 'Ja',
+        color: 'blue',
+        clickHandler: () => {},
+      },
+    ],
+  },
+};
+
+interface Props extends Partial<CloseDialogProps> {
+  template: DialogTemplateKeyType;
+}
+
+/** Simple popup dialog asking the user if they really want to exit the form. Partially masks the background. */
+const FormDialog = ({ template, ...props }: Props) => (
+  <CloseDialog {...DIALOG_TEMPLATES[template]} {...props} />
+);
+
+export default FormDialog;

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -123,7 +123,7 @@ function Step({
     mainStep: [
       {
         text: 'Nej',
-        color: 'red',
+        color: 'neutral',
         clickHandler: () => setDialogIsVisible(false),
       },
       {
@@ -137,7 +137,7 @@ function Step({
     subStep: [
       {
         text: 'Nej',
-        color: 'red',
+        color: 'neutral',
         clickHandler: () => setDialogIsVisible(false),
       },
       {

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -8,7 +8,6 @@ import AuthContext from '../../../store/AuthContext';
 import Progressbar from '../../atoms/Progressbar/Progressbar';
 import { AuthLoading } from '../../molecules';
 import BackNavigation from '../../molecules/BackNavigation/BackNavigation';
-import CloseDialog from './CloseDialog/CloseDialog';
 import Banner from './StepBanner/StepBanner';
 import StepDescription from './StepDescription/StepDescription';
 import StepFooter from './StepFooter/StepFooter';
@@ -74,7 +73,6 @@ function Step({
     handleSetError,
   } = useContext(AuthContext);
 
-  const [closeDialogVisible, setCloseDialogVisible] = useState(false);
   const showNotification = useNotification();
 
   /**
@@ -118,19 +116,20 @@ function Step({
   const [fadeValue] = useState(new Animated.Value(0));
 
   const isDirtySubStep = JSON.stringify(answers) !== JSON.stringify(answerSnapshot) && isSubstep;
-  const [dialogTemplate, setDialogTemplate] = useState('mainStep');
 
-  const dialogButtons = {
+  const [dialogIsVisible, setDialogIsVisible] = useState(false);
+  const [dialogTemplate, setDialogTemplate] = useState('mainStep');
+  const dialogButtonProps = {
     mainStep: [
       {
         text: 'Nej',
         color: 'red',
-        clickHandler: () => setCloseDialogVisible(false),
+        clickHandler: () => setDialogIsVisible(false),
       },
       {
         text: 'Ja',
         clickHandler: () => {
-          setCloseDialogVisible(false);
+          setDialogIsVisible(false);
           closeForm();
         },
       },
@@ -139,7 +138,7 @@ function Step({
       {
         text: 'Nej',
         color: 'red',
-        clickHandler: () => setCloseDialogVisible(false),
+        clickHandler: () => setDialogIsVisible(false),
       },
       {
         text: 'Ja',
@@ -168,7 +167,7 @@ function Step({
     ? () => {
         if (isDirtySubStep) {
           if (dialogTemplate !== 'subStep') setDialogTemplate('subStep');
-          setCloseDialogVisible(true);
+          setDialogIsVisible(true);
           return;
         }
 
@@ -189,9 +188,9 @@ function Step({
           }}
         >
           <FormDialog
-            visible={closeDialogVisible}
+            visible={dialogIsVisible}
             template={dialogTemplate}
-            buttons={dialogButtons[dialogTemplate]}
+            buttons={dialogButtonProps[dialogTemplate]}
           />
 
           {!isSubstep && (
@@ -203,7 +202,7 @@ function Step({
                 if (isLastMainStep) {
                   closeForm();
                 } else {
-                  setCloseDialogVisible(true);
+                  setDialogIsVisible(true);
                 }
               }}
               colorSchema={colorSchema || 'blue'}
@@ -295,7 +294,7 @@ function Step({
           isSubstep={isSubstep}
           primary={false}
           onBack={backButtonBehavior}
-          onClose={() => setCloseDialogVisible(true)}
+          onClose={() => setDialogIsVisible(true)}
           colorSchema={colorSchema || 'blue'}
         />
       )}

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -65,6 +65,7 @@ const Form: React.FC<Props> = ({
     steps,
     user,
     formAnswers: initialAnswers,
+    formAnswerSnapshot: {},
     validations: {},
     dirtyFields: {},
     connectivityMatrix,
@@ -78,6 +79,9 @@ const Form: React.FC<Props> = ({
     handleSubmit,
     handleBlur,
     validateStepAnswers,
+    createSnapshot,
+    restoreSnapshot,
+    deleteSnapshot,
   } = useForm(initialState);
 
   formNavigation.close = () => {
@@ -105,6 +109,7 @@ const Form: React.FC<Props> = ({
             text: description,
           }}
           answers={formState.formAnswers}
+          answerSnapshot={formState.formAnswerSnapshot}
           validation={formState.validations}
           validateStepAnswers={validateStepAnswers}
           status={status}

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -471,26 +471,17 @@ export function dirtyField(
   }
   return state;
 }
-/**
- * Create snapshot of answers
- * @param state 
- */
+
 export const createSnapshot = (state: FormReducerState) => ({
   ...state,
   formAnswerSnapshot: JSON.parse(JSON.stringify(state.formAnswers)),
 });
 
-/**
- * Restore snapshot of answers
- * @param state 
- */
 export const restoreSnapshot = (state: FormReducerState) => {
-  // Make sure snapshot is not empty to avoid data loss (THIS CHECK HAS LIMITATIONS: eg. Will not restore forms without answers)
   if (Object.entries(state.formAnswerSnapshot).length <= 0) {
     return state;
   }
 
-  // Bail if no changes
   if (JSON.stringify(state.formAnswers) === JSON.stringify(state.formAnswerSnapshot)) {
     return state;
   }
@@ -502,10 +493,6 @@ export const restoreSnapshot = (state: FormReducerState) => {
   };
 }
 
-/**
- * Delete snapshot of answers
- * @param state 
- */
 export const deleteSnapshot = (state: FormReducerState) => ({
   ...state,
   formAnswerSnapshot: {},

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -471,3 +471,42 @@ export function dirtyField(
   }
   return state;
 }
+/**
+ * Create snapshot of answers
+ * @param state 
+ */
+export const createSnapshot = (state: FormReducerState) => ({
+  ...state,
+  formAnswerSnapshot: JSON.parse(JSON.stringify(state.formAnswers)),
+});
+
+/**
+ * Restore snapshot of answers
+ * @param state 
+ */
+export const restoreSnapshot = (state: FormReducerState) => {
+  // Make sure snapshot is not empty to avoid data loss (THIS CHECK HAS LIMITATIONS: eg. Will not restore forms without answers)
+  if (Object.entries(state.formAnswerSnapshot).length <= 0) {
+    return state;
+  }
+
+  // Bail if no changes
+  if (JSON.stringify(state.formAnswers) === JSON.stringify(state.formAnswerSnapshot)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    formAnswers: JSON.parse(JSON.stringify(state.formAnswerSnapshot)),
+    formAnswerSnapshot: {},
+  };
+}
+
+/**
+ * Delete snapshot of answers
+ * @param state 
+ */
+export const deleteSnapshot = (state: FormReducerState) => ({
+  ...state,
+  formAnswerSnapshot: {},
+});

--- a/source/containers/Form/hooks/formReducer.ts
+++ b/source/containers/Form/hooks/formReducer.ts
@@ -182,17 +182,14 @@ function formReducer(state: FormReducerState, action: Action) {
       return getAllQuestions(state);
     }
 
-    /** Create snapshot of current answers */
     case 'CREATE_SNAPSHOT': {
       return createSnapshot(state);
     }
 
-    /** Restore answers snapshot */
     case 'RESTORE_SNAPSHOT': {
       return restoreSnapshot(state);
     }
 
-    /** Delete answers snapshot */
     case 'DELETE_SNAPSHOT': {
       return deleteSnapshot(state);
     }

--- a/source/containers/Form/hooks/formReducer.ts
+++ b/source/containers/Form/hooks/formReducer.ts
@@ -15,6 +15,9 @@ import {
   validateAllStepAnswers,
   dirtyField,
   goBackToMainFormAndNext,
+  createSnapshot,
+  restoreSnapshot,
+  deleteSnapshot,
 } from './formActions';
 
 type Action =
@@ -70,6 +73,15 @@ type Action =
   | {
       type: 'SUBMIT_FORM';
       payload: { callback: (formAnswers: Record<string, any>) => void };
+    }
+  | {
+      type: 'CREATE_SNAPSHOT';
+    }
+  | {
+      type: 'RESTORE_SNAPSHOT';
+    }
+  | {
+      type: 'DELETE_SNAPSHOT';
     };
 
 /**
@@ -168,6 +180,21 @@ function formReducer(state: FormReducerState, action: Action) {
     /** Update the list of all questions */
     case 'GET_ALL_QUESTIONS': {
       return getAllQuestions(state);
+    }
+
+    /** Create snapshot of current answers */
+    case 'CREATE_SNAPSHOT': {
+      return createSnapshot(state);
+    }
+
+    /** Restore answers snapshot */
+    case 'RESTORE_SNAPSHOT': {
+      return restoreSnapshot(state);
+    }
+
+    /** Delete answers snapshot */
+    case 'DELETE_SNAPSHOT': {
+      return deleteSnapshot(state);
     }
 
     default:

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -17,6 +17,7 @@ export interface FormReducerState {
   user: User;
   connectivityMatrix: StepperActions[][];
   formAnswers: Record<string, any>;
+  formAnswerSnapshot: Record<string, any>;
   validations: Record<string, any>;
   dirtyFields: Record<string, any>;
   numberOfMainSteps?: number;
@@ -46,6 +47,30 @@ function useForm(initialState: FormReducerState) {
       payload: { onErrorCallback, onValidCallback },
     });
   };
+
+  /**
+   * Function for creating snapshot
+   */
+  const createSnapshot = () =>
+    dispatch({
+      type: 'CREATE_SNAPSHOT',
+    });
+
+  /**
+   * Function for deleting snapshot
+   */
+  const deleteSnapshot = () =>
+    dispatch({
+      type: 'DELETE_SNAPSHOT',
+    });
+
+  /**
+   * Function for restoring & deleting snapshot
+   */
+  const restoreSnapshot = () =>
+    dispatch({
+      type: 'RESTORE_SNAPSHOT',
+    });
 
   /**
    * Function for going forward in the form
@@ -132,7 +157,6 @@ function useForm(initialState: FormReducerState) {
    */
   const handleBlur = (answer: Record<string, any>, questionId: string) => {
     dispatch({ type: 'DIRTY_FIELD', payload: { answer, id: questionId } });
-    dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId, checkIfDirty: true } });
   };
   /**
    * Function for updating answer.
@@ -152,6 +176,9 @@ function useForm(initialState: FormReducerState) {
     goToMainForm,
     goToMainFormAndNext,
     isLastStep,
+    createSnapshot,
+    restoreSnapshot,
+    deleteSnapshot,
   };
 
   return {

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -48,33 +48,21 @@ function useForm(initialState: FormReducerState) {
     });
   };
 
-  /**
-   * Function for creating snapshot
-   */
   const createSnapshot = () =>
     dispatch({
       type: 'CREATE_SNAPSHOT',
     });
 
-  /**
-   * Function for deleting snapshot
-   */
   const deleteSnapshot = () =>
     dispatch({
       type: 'DELETE_SNAPSHOT',
     });
 
-  /**
-   * Function for restoring & deleting snapshot
-   */
   const restoreSnapshot = () =>
     dispatch({
       type: 'RESTORE_SNAPSHOT',
     });
 
-  /**
-   * Function for going forward in the form
-   */
   const goToNextStep = () =>
     dispatch({
       type: 'GO_NEXT',

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -157,6 +157,7 @@ function useForm(initialState: FormReducerState) {
    */
   const handleBlur = (answer: Record<string, any>, questionId: string) => {
     dispatch({ type: 'DIRTY_FIELD', payload: { answer, id: questionId } });
+    dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId, checkIfDirty: true } });
   };
   /**
    * Function for updating answer.


### PR DESCRIPTION
## Explain the changes you’ve made

- Refactor: CloseDialog (replace hard-coded content with props)
- Refactor: Dialog implementation within Step
- Add: FormDialog component
- Add: state, actions & implementation for 'snapshotting' form answers
- Eslint: Disable prop-types linting within .tsx files
 
## Explain why these changes are made

- To allow users to discard changes done within a subform by pressing the X in the rop right corner.
- To make sure users cannot pass validation by pressing X

## Explain your solution

What to say, it's really great? uh no, it's the greatest!

## How to test the changes?

1. Start a form containing atleast 1 SummaryList component
2. Add an item with values to a SummaryList & hit save
3. Make sure item is visible & has correct values in the list after hitting save
4. Edit the same item again, this time hit X button in top right corner without making any changes
5. **Expected behaviour: should return to main step without a prompt (since we made no changes)**
6. Repeat step 4 but this time make some changes & hit X button
7. **Expected behaviour: Should display dialog asking the using wheter to discard or continue editing - choose to continue editing**
8. **Expected behaviour: Shoud close dialog and stay at the same substep - hit X button (one last time) & discard changes**
9. **Expected behaviour: Should return to main step and changes made within sub step should not be visible**

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Known limitations:

- Snapshot implementation does not account for forms with empty answers object (i believe we can live with this right now)
- Snapshot implementation does not account for save/restore JS-specific defintions (like date) within state.answers because of deep cloning through JSON
- Snapshot callbacks are forwarded through formNavigation
- Starting a form within a sub step may give a prompt even though you have not made any changes (which should never happen as the user shouldn't be able to start from a sub step).
- Exiting the application while editing a sub step may not restore answers correctly 
