### PR TITLE
feat(image-uploader-delete): add functionality to delete files

### DIFF
--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -5,6 +5,7 @@ import { Image as CropPickerImage } from 'react-native-image-crop-picker';
 import styled from 'styled-components/native';
 import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
 import ImageItem from './ImageItem';
+import { deleteUploadedFile } from '../../../helpers/FileUpload';
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -34,7 +35,10 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
   const [horizontalScrollPercentage, setHorizontalScrollPercentage] = useState(0);
 
   const deleteImageFromCloudStorage = async (image: Image) => {
-    console.log('Placeholder: not implemented yet in API, want to delete image ', image.path);
+    deleteUploadedFile({
+      endpoint: 'users/me/attachments',
+      fileName: image.uploadedFileName,
+    });
   };
   const removeImage = (image: Image) => {
     const answer: Image[] = answers[image.questionId];

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -5,7 +5,6 @@ import { Image as CropPickerImage } from 'react-native-image-crop-picker';
 import styled from 'styled-components/native';
 import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
 import ImageItem from './ImageItem';
-import { deleteUploadedFile } from '../../../helpers/FileUpload';
 import { remove } from '../../../helpers/ApiRequest';
 
 const Wrapper = styled.View`

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/native';
 import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
 import ImageItem from './ImageItem';
 import { deleteUploadedFile } from '../../../helpers/FileUpload';
+import { remove } from '../../../helpers/ApiRequest';
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -35,10 +36,7 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
   const [horizontalScrollPercentage, setHorizontalScrollPercentage] = useState(0);
 
   const deleteImageFromCloudStorage = async (image: Image) => {
-    deleteUploadedFile({
-      endpoint: 'users/me/attachments',
-      fileName: image.uploadedFileName,
-    });
+    remove(`users/me/attachments/${image.uploadedFileName}`);
   };
   const removeImage = (image: Image) => {
     const answer: Image[] = answers[image.questionId];

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -101,7 +101,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
     if (uploadResponse.error) {
       updatedImages[index].errorMessage = uploadResponse.message;
     } else {
-      updatedImages[index].uploadedFileName = uploadResponse.uploadedFilename;
+      updatedImages[index].uploadedFileName = uploadResponse.uploadedFileName;
       updatedImages[index].url = uploadResponse.url;
     }
     onChange(updatedImages); 
@@ -115,7 +115,6 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
 
     try {
       launchImageLibrary(libraryOptions, (response) => {
-        console.log('response object:', response);
         if (response?.didCancel) return;
 
         const imageToAdd: Image = {

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -64,3 +64,28 @@ export const uploadFile = async ({
     return { error: true, message: error.message, ...error.response };
   }
 };
+
+interface FileDeleteParams {
+  endpoint: string;
+  fileName: string;
+}
+export const deleteUploadedFile = async ({ endpoint, fileName }: FileDeleteParams) => {
+  const requestUrl = await buildServiceUrl(`${endpoint}/${fileName}`);
+  const token = await StorageService.getData(ACCESS_TOKEN_KEY);
+  const bearer = token || '';
+
+  try {
+    await axios({
+      url: requestUrl,
+      method: 'delete',
+      headers: {
+        Authorization: bearer,
+      },
+    });
+
+    return { status: 200, deletedFile: fileName };
+  } catch (error) {
+    console.log('axios error', error);
+    return { error: true, message: error.message, ...error.response };
+  }
+};

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -64,28 +64,3 @@ export const uploadFile = async ({
     return { error: true, message: error.message, ...error.response };
   }
 };
-
-interface FileDeleteParams {
-  endpoint: string;
-  fileName: string;
-}
-export const deleteUploadedFile = async ({ endpoint, fileName }: FileDeleteParams) => {
-  const requestUrl = await buildServiceUrl(`${endpoint}/${fileName}`);
-  const token = await StorageService.getData(ACCESS_TOKEN_KEY);
-  const bearer = token || '';
-
-  try {
-    await axios({
-      url: requestUrl,
-      method: 'delete',
-      headers: {
-        Authorization: bearer,
-      },
-    });
-
-    return { status: 200, deletedFile: fileName };
-  } catch (error) {
-    console.log('axios error', error);
-    return { error: true, message: error.message, ...error.response };
-  }
-};


### PR DESCRIPTION
## Explain the changes you’ve made

Adds functionality to use the attachments-delete endpoint to remove uploaded files from the ImageDisplay component. 

## Explain why these changes are made

If you upload the wrong image by accident, it's obviously good if you can delete it. 

## Explain your solution

Implements a small helper-function to send delete requests, and then uses it in the ImageDisplay component to delete an uploaded file when the user removes the file from the list. Also fixes a typo in the ImageUploader, uploadedFilename->  uploadedFileName.

## How to test the changes?

Checkout the branch, and go into a form that has an ImageUploader. Then open the S3 bucket (called attachments-s3-{some id}) in your AWS console. Then try uploading a file, and check that it appears in the S3. Then, remove it by pressing the x button, and again check that it is removed from the S3 bucket. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
