### PR TITLE
Feat/refresh cases

### DIFF
--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from '../../atoms/Icon/Icon';
 
 const BackNavigationWrapper = styled.View({
@@ -17,7 +16,7 @@ const BackNavigationWrapper = styled.View({
   zIndex: 999,
 });
 
-const BackNavigationSingleWrapper = styled.View((props) => ({
+const BackNavigationSingleWrapper = styled.View(() => ({
   position: 'absolute',
   flexDirection: 'row',
   padding: 0,

--- a/source/components/molecules/BackNavigation/BackNavigation.js
+++ b/source/components/molecules/BackNavigation/BackNavigation.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from '../../atoms/Icon/Icon';
 
 const BackNavigationWrapper = styled.View({
+  position: 'absolute',
   flexDirection: 'row',
   padding: 0,
   margin: 0,
@@ -16,6 +18,7 @@ const BackNavigationWrapper = styled.View({
 });
 
 const BackNavigationSingleWrapper = styled.View((props) => ({
+  position: 'absolute',
   flexDirection: 'row',
   padding: 0,
   margin: 0,
@@ -23,7 +26,6 @@ const BackNavigationSingleWrapper = styled.View((props) => ({
   top: 0,
   zIndex: 999,
   right: 0,
-  position: props.isSubstep ? 'absolute' : 'relative',
 }));
 
 const BackButton = styled.View((props) => ({
@@ -88,7 +90,7 @@ const BackNavigation = ({
       ) : null}
     </BackNavigationWrapper>
   ) : (
-    <BackNavigationSingleWrapper isSubstep={isSubstep} style={style}>
+    <BackNavigationSingleWrapper style={style}>
       <CloseButton
         primary={primary}
         colorSchema={colorSchema}

--- a/source/components/molecules/ScreenWrapper.tsx
+++ b/source/components/molecules/ScreenWrapper.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { StyleProp, ViewStyle } from 'react-native';
 
-const Container = styled(KeyboardAwareScrollView)`
+const Container = styled.View`
   flex: 1;
   background-color: ${(props) => props.theme.colors.neutrals[6]};
 `;

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -1,18 +1,19 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { Animated } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import styled from 'styled-components/native';
+import { getStatusByType } from '../../../assets/mock/caseStatuses';
 import FormField from '../../../containers/FormField';
 import AuthContext from '../../../store/AuthContext';
+import { useNotification } from '../../../store/NotificationContext';
 import Progressbar from '../../atoms/Progressbar/Progressbar';
 import { AuthLoading } from '../../molecules';
 import BackNavigation from '../../molecules/BackNavigation/BackNavigation';
+import FormDialog from './CloseDialog/FormDialog';
 import Banner from './StepBanner/StepBanner';
 import StepDescription from './StepDescription/StepDescription';
 import StepFooter from './StepFooter/StepFooter';
-import { getStatusByType } from '../../../assets/mock/caseStatuses';
-import FormDialog from './CloseDialog/FormDialog';
-import { useNotification } from '../../../store/NotificationContext';
 
 const StepContainer = styled.View`
   background: ${(props) => props.theme.colors.neutrals[7]};
@@ -180,119 +181,111 @@ function Step({
 
   return (
     <StepContainer>
-      <Animated.View
-        style={{
-          opacity: fadeValue,
-        }}
-      >
-        <FormDialog
-          visible={dialogIsVisible}
-          template={dialogTemplate}
-          buttons={dialogButtonProps[dialogTemplate]}
-        />
-
-        {!isSubstep && (
-          <StepBackNavigation
-            showBackButton={isBackBtnVisible}
-            isSubstep={isSubstep}
-            onBack={backButtonBehavior}
-            onClose={() => {
-              if (isLastMainStep) {
-                closeForm();
-              } else {
-                setDialogIsVisible(true);
-              }
-            }}
-            colorSchema={colorSchema || 'blue'}
+      <KeyboardAwareScrollView>
+        <Animated.View
+          style={{
+            opacity: fadeValue,
+          }}
+        >
+          <FormDialog
+            visible={dialogIsVisible}
+            template={dialogTemplate}
+            buttons={dialogButtonProps[dialogTemplate]}
           />
-        )}
 
-        <StepContentContainer>
-          {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
-            <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
-          )}
-          {currentPosition.level === 0 && (
-            <Progressbar
-              currentStep={currentPosition.currentMainStep}
-              totalStepNumber={totalStepNumber}
-            />
-          )}
-          <StepBody>
-            {!isLoading && (
-              <>
-                <StepDescription
-                  theme={theme}
-                  currentStep={
-                    currentPosition.level === 0 ? currentPosition.currentMainStep : undefined
-                  }
-                  totalStepNumber={totalStepNumber}
-                  colorSchema={colorSchema || 'blue'}
-                  {...description}
-                />
-                {questions && (
-                  <StepFieldListWrapper>
-                    {questions.map((field) => (
-                      <FormField
-                        key={`${field.id}`}
-                        onChange={
-                          status.type.includes('ongoing') || status.type.includes('notStarted')
-                            ? onFieldChange
-                            : null
-                        }
-                        onBlur={onFieldBlur}
-                        inputType={field.type}
-                        value={answers[field.id] || ''}
-                        answers={answers}
-                        validationErrors={validation}
-                        colorSchema={field.color && field.color !== '' ? field.color : colorSchema}
-                        id={field.id}
-                        formNavigation={formNavigation}
-                        {...field}
-                      />
-                    ))}
-                  </StepFieldListWrapper>
-                )}
-              </>
+          <StepContentContainer>
+            {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
+              <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
             )}
-
-            {(isLoading || isResolved) && (
-              <SignStepWrapper>
-                <AuthLoading
-                  colorSchema={colorSchema || 'neutral'}
-                  isLoading={isLoading}
-                  isResolved={isResolved}
-                  cancelSignIn={() => handleCancelOrder()}
-                  isBankidInstalled={isBankidInstalled}
-                />
-              </SignStepWrapper>
+            {currentPosition.level === 0 && (
+              <Progressbar
+                currentStep={currentPosition.currentMainStep}
+                totalStepNumber={totalStepNumber}
+              />
             )}
-          </StepBody>
-          {actions && actions.length > 0 ? (
-            <StepFooter
-              actions={actions}
-              caseStatus={status}
-              answers={answers}
-              allQuestions={allQuestions}
-              formNavigation={formNavigation}
-              currentPosition={currentPosition}
-              onUpdate={onFieldChange}
-              updateCaseInContext={updateCaseInContext}
-              validateStepAnswers={validateStepAnswers}
-            />
-          ) : null}
-        </StepContentContainer>
-      </Animated.View>
+            <StepBody>
+              {!isLoading && (
+                <>
+                  <StepDescription
+                    theme={theme}
+                    currentStep={
+                      currentPosition.level === 0 ? currentPosition.currentMainStep : undefined
+                    }
+                    totalStepNumber={totalStepNumber}
+                    colorSchema={colorSchema || 'blue'}
+                    {...description}
+                  />
+                  {questions && (
+                    <StepFieldListWrapper>
+                      {questions.map((field) => (
+                        <FormField
+                          key={`${field.id}`}
+                          onChange={
+                            status.type.includes('ongoing') || status.type.includes('notStarted')
+                              ? onFieldChange
+                              : null
+                          }
+                          onBlur={onFieldBlur}
+                          inputType={field.type}
+                          value={answers[field.id] || ''}
+                          answers={answers}
+                          validationErrors={validation}
+                          colorSchema={
+                            field.color && field.color !== '' ? field.color : colorSchema
+                          }
+                          id={field.id}
+                          formNavigation={formNavigation}
+                          {...field}
+                        />
+                      ))}
+                    </StepFieldListWrapper>
+                  )}
+                </>
+              )}
 
-      {isSubstep && (
-        <StepBackNavigation
-          showBackButton={isBackBtnVisible}
-          isSubstep={isSubstep}
-          primary={false}
-          onBack={backButtonBehavior}
-          onClose={() => setDialogIsVisible(true)}
-          colorSchema={colorSchema || 'blue'}
-        />
-      )}
+              {(isLoading || isResolved) && (
+                <SignStepWrapper>
+                  <AuthLoading
+                    colorSchema={colorSchema || 'neutral'}
+                    isLoading={isLoading}
+                    isResolved={isResolved}
+                    cancelSignIn={() => handleCancelOrder()}
+                    isBankidInstalled={isBankidInstalled}
+                  />
+                </SignStepWrapper>
+              )}
+            </StepBody>
+            {actions && actions.length > 0 ? (
+              <StepFooter
+                actions={actions}
+                caseStatus={status}
+                answers={answers}
+                allQuestions={allQuestions}
+                formNavigation={formNavigation}
+                currentPosition={currentPosition}
+                onUpdate={onFieldChange}
+                updateCaseInContext={updateCaseInContext}
+                validateStepAnswers={validateStepAnswers}
+              />
+            ) : null}
+          </StepContentContainer>
+        </Animated.View>
+      </KeyboardAwareScrollView>
+
+      <StepBackNavigation
+        showBackButton={isBackBtnVisible}
+        primary={!isSubstep}
+        isSubstep={isSubstep}
+        onBack={backButtonBehavior}
+        onClose={() => {
+          if (isLastMainStep) {
+            closeForm();
+          } else {
+            setDialogIsVisible(true);
+          }
+        }}
+        colorSchema={colorSchema || 'blue'}
+      />
     </StepContainer>
   );
 }

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import { Animated } from 'react-native';
 import styled from 'styled-components/native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import FormField from '../../../containers/FormField';
 import AuthContext from '../../../store/AuthContext';
 import Progressbar from '../../atoms/Progressbar/Progressbar';
@@ -181,112 +180,108 @@ function Step({
 
   return (
     <StepContainer>
-      <KeyboardAwareScrollView>
-        <Animated.View
-          style={{
-            opacity: fadeValue,
-          }}
-        >
-          <FormDialog
-            visible={dialogIsVisible}
-            template={dialogTemplate}
-            buttons={dialogButtonProps[dialogTemplate]}
-          />
+      <Animated.View
+        style={{
+          opacity: fadeValue,
+        }}
+      >
+        <FormDialog
+          visible={dialogIsVisible}
+          template={dialogTemplate}
+          buttons={dialogButtonProps[dialogTemplate]}
+        />
 
-          {!isSubstep && (
-            <StepBackNavigation
-              showBackButton={isBackBtnVisible}
-              isSubstep={isSubstep}
-              onBack={backButtonBehavior}
-              onClose={() => {
-                if (isLastMainStep) {
-                  closeForm();
-                } else {
-                  setDialogIsVisible(true);
-                }
-              }}
-              colorSchema={colorSchema || 'blue'}
+        {!isSubstep && (
+          <StepBackNavigation
+            showBackButton={isBackBtnVisible}
+            isSubstep={isSubstep}
+            onBack={backButtonBehavior}
+            onClose={() => {
+              if (isLastMainStep) {
+                closeForm();
+              } else {
+                setDialogIsVisible(true);
+              }
+            }}
+            colorSchema={colorSchema || 'blue'}
+          />
+        )}
+
+        <StepContentContainer>
+          {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
+            <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
+          )}
+          {currentPosition.level === 0 && (
+            <Progressbar
+              currentStep={currentPosition.currentMainStep}
+              totalStepNumber={totalStepNumber}
             />
           )}
-
-          <StepContentContainer>
-            {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
-              <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
+          <StepBody>
+            {!isLoading && (
+              <>
+                <StepDescription
+                  theme={theme}
+                  currentStep={
+                    currentPosition.level === 0 ? currentPosition.currentMainStep : undefined
+                  }
+                  totalStepNumber={totalStepNumber}
+                  colorSchema={colorSchema || 'blue'}
+                  {...description}
+                />
+                {questions && (
+                  <StepFieldListWrapper>
+                    {questions.map((field) => (
+                      <FormField
+                        key={`${field.id}`}
+                        onChange={
+                          status.type.includes('ongoing') || status.type.includes('notStarted')
+                            ? onFieldChange
+                            : null
+                        }
+                        onBlur={onFieldBlur}
+                        inputType={field.type}
+                        value={answers[field.id] || ''}
+                        answers={answers}
+                        validationErrors={validation}
+                        colorSchema={field.color && field.color !== '' ? field.color : colorSchema}
+                        id={field.id}
+                        formNavigation={formNavigation}
+                        {...field}
+                      />
+                    ))}
+                  </StepFieldListWrapper>
+                )}
+              </>
             )}
-            {currentPosition.level === 0 && (
-              <Progressbar
-                currentStep={currentPosition.currentMainStep}
-                totalStepNumber={totalStepNumber}
-              />
-            )}
-            <StepBody>
-              {!isLoading && (
-                <>
-                  <StepDescription
-                    theme={theme}
-                    currentStep={
-                      currentPosition.level === 0 ? currentPosition.currentMainStep : undefined
-                    }
-                    totalStepNumber={totalStepNumber}
-                    colorSchema={colorSchema || 'blue'}
-                    {...description}
-                  />
-                  {questions && (
-                    <StepFieldListWrapper>
-                      {questions.map((field) => (
-                        <FormField
-                          key={`${field.id}`}
-                          onChange={
-                            status.type.includes('ongoing') || status.type.includes('notStarted')
-                              ? onFieldChange
-                              : null
-                          }
-                          onBlur={onFieldBlur}
-                          inputType={field.type}
-                          value={answers[field.id] || ''}
-                          answers={answers}
-                          validationErrors={validation}
-                          colorSchema={
-                            field.color && field.color !== '' ? field.color : colorSchema
-                          }
-                          id={field.id}
-                          formNavigation={formNavigation}
-                          {...field}
-                        />
-                      ))}
-                    </StepFieldListWrapper>
-                  )}
-                </>
-              )}
 
-              {(isLoading || isResolved) && (
-                <SignStepWrapper>
-                  <AuthLoading
-                    colorSchema={colorSchema || 'neutral'}
-                    isLoading={isLoading}
-                    isResolved={isResolved}
-                    cancelSignIn={() => handleCancelOrder()}
-                    isBankidInstalled={isBankidInstalled}
-                  />
-                </SignStepWrapper>
-              )}
-            </StepBody>
-            {actions && actions.length > 0 ? (
-              <StepFooter
-                actions={actions}
-                caseStatus={status}
-                answers={answers}
-                allQuestions={allQuestions}
-                formNavigation={formNavigation}
-                currentPosition={currentPosition}
-                onUpdate={onFieldChange}
-                updateCaseInContext={updateCaseInContext}
-                validateStepAnswers={validateStepAnswers}
-              />
-            ) : null}
-          </StepContentContainer>
-        </Animated.View>
-      </KeyboardAwareScrollView>
+            {(isLoading || isResolved) && (
+              <SignStepWrapper>
+                <AuthLoading
+                  colorSchema={colorSchema || 'neutral'}
+                  isLoading={isLoading}
+                  isResolved={isResolved}
+                  cancelSignIn={() => handleCancelOrder()}
+                  isBankidInstalled={isBankidInstalled}
+                />
+              </SignStepWrapper>
+            )}
+          </StepBody>
+          {actions && actions.length > 0 ? (
+            <StepFooter
+              actions={actions}
+              caseStatus={status}
+              answers={answers}
+              allQuestions={allQuestions}
+              formNavigation={formNavigation}
+              currentPosition={currentPosition}
+              onUpdate={onFieldChange}
+              updateCaseInContext={updateCaseInContext}
+              validateStepAnswers={validateStepAnswers}
+            />
+          ) : null}
+        </StepContentContainer>
+      </Animated.View>
 
       {isSubstep && (
         <StepBackNavigation

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -23,8 +23,7 @@ const StepContainer = styled.View`
 const StepContentContainer = styled.View``;
 
 const StepBackNavigation = styled(BackNavigation)`
-  padding: 24px;
-  position: absolute;
+  padding: 24px 24px 0px 24px;
 `;
 
 const StepBanner = styled(Banner)`

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -11,7 +11,6 @@ import { evaluateConditionalExpression } from '../../../../helpers/conditionPars
 import { getStatusByType } from '../../../../assets/mock/caseStatuses';
 
 const ActionContainer = styled.View`
-  flex: 1;
   background-color: ${(props) => props.theme.colors.neutrals[5]};
 `;
 

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,23 +1,15 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { InteractionManager, View } from 'react-native';
+import { InteractionManager, StatusBar } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import styled from 'styled-components/native';
 import { Modal, useModal } from '../../components/molecules/Modal';
+import ScreenWrapper from '../../components/molecules/ScreenWrapper';
 import Step from '../../components/organisms/Step/Step';
 import { evaluateConditionalExpression } from '../../helpers/conditionParser';
-import theme from '../../styles/theme';
 import { CaseStatus } from '../../types/CaseType';
 import { Step as StepType, StepperActions } from '../../types/FormTypes';
 import { User } from '../../types/UserTypes';
 import useForm, { FormPosition, FormReducerState } from './hooks/useForm';
-
-const FormScreenWrapper = styled(KeyboardAwareScrollView)`
-  flex: 1;
-  background-color: ${(props) => props.theme.colors.neutrals[6]};
-`;
 
 interface Props {
   initialPosition?: FormPosition;
@@ -143,23 +135,20 @@ const Form: React.FC<Props> = ({
     }
   }, [mainStep, scrollViewRef]);
 
-  const colorSchema = formState?.steps[formState.currentPosition.currentMainStepIndex]?.colorSchema || 'blue';
-
   return (
-    <FormScreenWrapper
-      innerRef={(ref) => {
-        setRef((ref as unknown) as ScrollView);
-      }}
-    >
-      <SafeAreaView
-        style={{ backgroundColor: theme.colors.complementary[colorSchema || 'blue'][0] }}
-        edges={['top', 'right', 'left']}
-      />
-      {stepComponents[formState.currentPosition.currentMainStepIndex]}
+    <>
+      <ScreenWrapper
+        innerRef={(ref) => {
+          setRef((ref as unknown) as ScrollView);
+        }}
+      >
+        <StatusBar hidden={true} />
+        {stepComponents[formState.currentPosition.currentMainStepIndex]}
+      </ScreenWrapper>
       <Modal visible={formState.currentPosition.level > 0} hide={toggleModal}>
         {stepComponents[formState.currentPosition.index]}
       </Modal>
-    </FormScreenWrapper>
+    </>
   );
 };
 

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,22 +1,22 @@
-import React, { useEffect, useState } from 'react';
-import { InteractionManager } from 'react-native';
 import PropTypes from 'prop-types';
-import styled from 'styled-components/native';
-import Step from '../../components/organisms/Step/Step';
-import { ScreenWrapper } from '../../components/molecules';
-import { Step as StepType, StepperActions } from '../../types/FormTypes';
-import { CaseStatus } from '../../types/CaseType';
-import { User } from '../../types/UserTypes';
-import useForm, { FormReducerState, FormPosition } from './hooks/useForm';
-import { Modal, useModal } from '../../components/molecules/Modal';
+import React, { useEffect, useState } from 'react';
+import { InteractionManager, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import theme from '../../styles/theme';
+import styled from 'styled-components/native';
+import { Modal, useModal } from '../../components/molecules/Modal';
+import Step from '../../components/organisms/Step/Step';
 import { evaluateConditionalExpression } from '../../helpers/conditionParser';
+import theme from '../../styles/theme';
+import { CaseStatus } from '../../types/CaseType';
+import { Step as StepType, StepperActions } from '../../types/FormTypes';
+import { User } from '../../types/UserTypes';
+import useForm, { FormPosition, FormReducerState } from './hooks/useForm';
 
-const FormScreenWrapper = styled(ScreenWrapper)`
-  padding: 0;
+const FormScreenWrapper = styled(KeyboardAwareScrollView)`
   flex: 1;
+  background-color: ${(props) => props.theme.colors.neutrals[6]};
 `;
 
 interface Props {

--- a/source/screens/DevFeaturesScreen.js
+++ b/source/screens/DevFeaturesScreen.js
@@ -11,7 +11,8 @@ import StorageService from '../services/StorageService';
 
 const Container = styled.ScrollView`
   flex: 1;
-  padding: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
 `;
 
 const FieldWrapper = styled.View`

--- a/source/screens/ProfileScreen.js
+++ b/source/screens/ProfileScreen.js
@@ -14,7 +14,8 @@ const ProfileScreenWrapper = styled(ScreenWrapper)`
 
 const Container = styled.ScrollView`
   flex: 1;
-  padding: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
 `;
 
 const BottomContainer = styled.View`
@@ -22,6 +23,7 @@ const BottomContainer = styled.View`
   margin-bottom: 16px;
   flex: 1;
   justify-content: flex-end;
+  padding-bottom: 16px;
 `;
 
 const SignOutButton = styled(Button)`

--- a/source/store/CaseContext.js
+++ b/source/store/CaseContext.js
@@ -69,12 +69,9 @@ function CaseProvider({ children, initialState = defaultInitialState }) {
     dispatch(remove(caseId));
   }
 
-  const fetchCases = useCallback(
-    async function loadCases(callback = () => {}) {
-      dispatch(await fetch(callback));
-    },
-    [dispatch]
-  );
+  const fetchCases = async () => {
+    dispatch(await fetch());
+  };
 
   useEffect(() => {
     if (user) {
@@ -84,7 +81,7 @@ function CaseProvider({ children, initialState = defaultInitialState }) {
   }, [user]);
 
   return (
-    <CaseState.Provider value={{ cases: state.cases, getCase, getCasesByFormIds }}>
+    <CaseState.Provider value={{ cases: state.cases, getCase, getCasesByFormIds, fetchCases }}>
       <CaseDispatch.Provider value={{ createCase, updateCase, deleteCase }}>
         {children}
       </CaseDispatch.Provider>

--- a/source/store/actions/CaseActions.js
+++ b/source/store/actions/CaseActions.js
@@ -95,14 +95,12 @@ export function deleteCase(caseId) {
   };
 }
 
-export async function fetchCases(callback) {
+export async function fetchCases() {
   try {
     const response = await get('/cases');
     if (response?.data?.data?.attributes?.cases) {
       const cases = {};
       response.data.data.attributes.cases.forEach((c) => (cases[c.id] = c));
-
-      callback(cases);
       return {
         type: actionTypes.fetchCases,
         payload: cases,


### PR DESCRIPTION
## Explain the changes you’ve made

- Added functionality to refresh case overview screen automatically when screen renders. 
- Also added functionality to manually refresh the screen by swiping the case list down.
- Hide statusbar in forms.
- Fixed floating back+close button in forms.

## Explain why these changes are made

So the users can see updates on their cases.

## Explain your solution

Implemented native method RefreshControl to make the swipe down refresh. 
In order to make it work I had to change the ScreenWrapper from being a Scrollview to View, which is correct in my opinion. But this change affected lots of other components that I had to fix. So I wrapped some components in KeyboardAwareScrollView where it was needed. I also fixed back navigation in forms so it's floating. And i removed the statusbar in forms according to design. 

## How to test the changes?

Navigate to CaseOverview screen.
Change a case status name in your DB.
Refresh screen by swiping down and the case should now display the new status.
Change status again  in DB and this time navigate to another screen and back to case status, this should also trigger a refresh. 

Finally open a form to see the floating close buttons and hidden Statusbar. Everything else should work like before. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.

## Screenshots

https://user-images.githubusercontent.com/21363149/108843639-40c6f380-75db-11eb-8e34-c8d4593c217d.mov


