### PR TITLE
Feat/image upload resume

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -212,6 +212,8 @@ dependencies {
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 
+    implementation project(':react-native-fs')
+
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'MittHelsingborg'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
+include ':react-native-fs'
+project(':react-native-fs').projectDir = new File(settingsDir, '../node_modules/react-native-fs/android')

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-native-document-picker": "^5.0.0",
     "react-native-elements": "^3.0.0-alpha.1",
     "react-native-exception-handler": "^2.10.9",
+    "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.9.0",
     "react-native-image-crop-picker": "^0.35.2",
     "react-native-image-pan-zoom": "^2.1.12",

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -46,6 +46,13 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
     deleteImageFromCloudStorage(image);
   };
 
+  const updateImage = (image: Image) => (newImage: Image) => {
+    const answer: Image[] = answers[image.questionId];
+    const index = answer.findIndex((img) => img.uploadedFileName === image.uploadedFileName);
+    answer[index] = newImage;
+    onChange(answer, image.questionId);
+  };
+
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     setHorizontalScrollPercentage(
       event.nativeEvent.contentOffset.x /
@@ -63,6 +70,7 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
               onRemove={() => {
                 removeImage(image);
               }}
+              onChange={updateImage(image)}
             />
           ))}
       </Container>

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -5,7 +5,7 @@ import { Image as CropPickerImage } from 'react-native-image-crop-picker';
 import styled from 'styled-components/native';
 import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
 import ImageItem from './ImageItem';
-import { remove } from '../../../helpers/ApiRequest';
+import { deleteUploadedFile } from '../../../helpers/FileUpload';
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -35,7 +35,10 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
   const [horizontalScrollPercentage, setHorizontalScrollPercentage] = useState(0);
 
   const deleteImageFromCloudStorage = async (image: Image) => {
-    remove(`users/me/attachments/${image.uploadedFileName}`);
+    deleteUploadedFile({
+      endpoint: 'users/me/attachments',
+      fileName: image.uploadedFileName,
+    });
   };
   const removeImage = (image: Image) => {
     const answer: Image[] = answers[image.questionId];

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -5,7 +5,6 @@ import { Image as CropPickerImage } from 'react-native-image-crop-picker';
 import styled from 'styled-components/native';
 import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
 import ImageItem from './ImageItem';
-import { deleteUploadedFile } from '../../../helpers/FileUpload';
 import { remove } from '../../../helpers/ApiRequest';
 
 const Wrapper = styled.View`

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/native';
 import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
 import ImageItem from './ImageItem';
 import { deleteUploadedFile } from '../../../helpers/FileUpload';
+import { remove } from '../../../helpers/ApiRequest';
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -35,10 +36,7 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
   const [horizontalScrollPercentage, setHorizontalScrollPercentage] = useState(0);
 
   const deleteImageFromCloudStorage = async (image: Image) => {
-    deleteUploadedFile({
-      endpoint: 'users/me/attachments',
-      fileName: image.uploadedFileName,
-    });
+    remove(`users/me/attachments/${image.uploadedFileName}`);
   };
   const removeImage = (image: Image) => {
     const answer: Image[] = answers[image.questionId];

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -52,7 +52,6 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
         (event.nativeEvent.contentSize.width - event.nativeEvent.layoutMeasurement.width)
     );
   };
-
   return (
     <Wrapper>
       <Container horizontal onScroll={handleScroll} showsHorizontalScrollIndicator={false}>

--- a/source/components/molecules/ImageDisplay/ImageItem.tsx
+++ b/source/components/molecules/ImageDisplay/ImageItem.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/native';
 import ImageZoom from 'react-native-image-pan-zoom';
-import { existsAssets, exists, readFile } from 'react-native-fs';
+import { readFile } from 'react-native-fs';
 import {
   TouchableOpacity,
   Dimensions,

--- a/source/components/molecules/ImageDisplay/ImageItem.tsx
+++ b/source/components/molecules/ImageDisplay/ImageItem.tsx
@@ -13,6 +13,7 @@ import {
 import { Icon, Button, Text } from '../../atoms';
 import { Modal, useModal } from '../Modal';
 import { Image } from './ImageDisplay';
+import { downloadFile } from '../../../helpers/FileUpload';
 
 const DefaultItem = styled.TouchableOpacity`
   margin-bottom: 20px;
@@ -55,6 +56,24 @@ const ImageIcon = styled.Image`
   width: 126px;
   height: 178px;
 `;
+const ActivityWrapper = styled.View`
+  width: 126px;
+  height: 178px;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+const ActivityWrapperModal = styled.View<{width: number; height: number}>`
+  width: ${props => props.width}px;
+  height: ${props => props.height}px;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+const ActivityIndicator = styled.ActivityIndicator`
+  margin-top: 12px;
+  margin-bottom: 24px;
+`;
 
 type FileStatus =
   | 'checkLocalFile'
@@ -65,24 +84,36 @@ type FileStatus =
 interface Props {
   image: Image;
   onRemove: () => void;
+  onChange?: (image: Image) => void;
 }
-
-const ImageItem: React.FC<Props> = ({ image, onRemove }) => {
+const ImageItem: React.FC<Props> = ({ image, onRemove, onChange }) => {
   const [modalVisible, toggleModal] = useModal();
   const [fileStatus, setFileStatus] = useState<FileStatus>('checkLocalFile');
   const [downloadedFilePath, setDownloadedFilePath] = useState('');
 
-  const downloadImage = async () => {
-    console.log('download file, to be implemented...');
-  };
-
   useEffect(() => {
+    const downloadImage = async () => {
+      const downloadPath = await downloadFile({
+        endpoint: 'users/me/attachments',
+        filename: image.uploadedFileName,
+      });
+      setDownloadedFilePath(downloadPath);
+      setFileStatus('downloadedFileAvailable');
+      image.path = downloadPath;
+      if (onChange) {
+        // update answer object with path to the newly downloaded file
+        onChange(image);
+      }
+    };
     const checkStatus = async () => {
       if (fileStatus === 'checkLocalFile') {
         try {
+          // check if the file exists in cache, by trying to read it.
           await readFile(image.path, 'base64');
           setFileStatus('localFileAvailable');
-        } catch (fileNotFoundError) {
+        } catch (fileNotFound) {
+          // if we don't find the file, set status to 'downloading',
+          // and start downloading
           setFileStatus('downloading');
           downloadImage();
         }
@@ -90,7 +121,7 @@ const ImageItem: React.FC<Props> = ({ image, onRemove }) => {
     };
 
     checkStatus();
-  }, [fileStatus, image.path]);
+  }, [fileStatus, image, onChange]);
 
   const handleRemove = (event: GestureResponderEvent) => {
     event.stopPropagation();
@@ -107,19 +138,25 @@ const ImageItem: React.FC<Props> = ({ image, onRemove }) => {
             </TouchableOpacity>
           </DeleteBackground>
           <IconContainer>
-            {fileStatus === 'checkLocalFile' && <Text>Checking</Text>}
-            {image && image?.path && fileStatus === 'localFileAvailable' && (
-              <ImageIcon source={{ uri: image.path }} />
+            {fileStatus === 'checkLocalFile' && (
+              <ActivityWrapper>
+                <ActivityIndicator size="large" color="#555555" />
+              </ActivityWrapper>
             )}
-            {fileStatus === 'downloading' && <Text>Downloading</Text>}
-            {image && image?.path && fileStatus === 'downloadedFileAvailable' && (
+            {fileStatus === 'localFileAvailable' && <ImageIcon source={{ uri: image.path }} />}
+            {fileStatus === 'downloading' && (
+              <ActivityWrapper>
+                <ActivityIndicator size="large" color="gray" />
+              </ActivityWrapper>
+            )}
+            {fileStatus === 'downloadedFileAvailable' && downloadedFilePath !== '' && (
               <ImageIcon source={{ uri: downloadedFilePath }} />
             )}
           </IconContainer>
         </Flex>
       </DefaultItem>
       <Modal visible={modalVisible} hide={toggleModal}>
-        {image && image?.path && fileStatus === 'localFileAvailable' && (
+        {(fileStatus === 'localFileAvailable' || fileStatus === 'downloadedFileAvailable') && (
           <ImageZoom
             cropWidth={Dimensions.get('window').width}
             cropHeight={Dimensions.get('window').height * 0.89}
@@ -137,31 +174,19 @@ const ImageItem: React.FC<Props> = ({ image, onRemove }) => {
           >
             <RNImage
               style={{ width: image.width, height: image.height }}
-              source={{ uri: image.path }}
+              source={{
+                uri: fileStatus === 'localFileAvailable' ? image.path : downloadedFilePath,
+              }}
             />
           </ImageZoom>
         )}
-        {image && fileStatus === 'downloadedFileAvailable' && (
-          <ImageZoom
-            cropWidth={Dimensions.get('window').width}
-            cropHeight={Dimensions.get('window').height * 0.89}
-            imageWidth={image.width}
-            imageHeight={image.height}
-            panToMove
-            enableCenterFocus={false}
-            centerOn={{
-              x: 0,
-              y: 0,
-              scale: Dimensions.get('window').width / image.width,
-              duration: 10,
-            }}
-            minScale={Dimensions.get('window').width / image.width}
-          >
-            <RNImage
-              style={{ width: image.width, height: image.height }}
-              source={{ uri: downloadedFilePath }}
-            />
-          </ImageZoom>
+        {(fileStatus === 'downloading' || fileStatus === 'checkLocalFile') && (
+          <ActivityWrapperModal
+            width={Dimensions.get('window').width}
+            height={Dimensions.get('window').height * 0.89}
+            >
+            <ActivityIndicator size="large" color="gray" />
+          </ActivityWrapperModal>
         )}
         <ButtonWrapper>
           <Button colorSchema="red" onClick={toggleModal}>
@@ -176,6 +201,7 @@ const ImageItem: React.FC<Props> = ({ image, onRemove }) => {
 ImageItem.propTypes = {
   image: PropTypes.object,
   onRemove: PropTypes.func,
+  onChange: PropTypes.func,
 };
 
 export default ImageItem;

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -155,7 +155,6 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
       });
   };
 
-  console.log('images from uploader:', images);
   const validColorSchema = getValidColorSchema(colorSchema);
   return (
     <>

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -155,6 +155,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
       });
   };
 
+  console.log('images from uploader:', images);
   const validColorSchema = getValidColorSchema(colorSchema);
   return (
     <>

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -72,3 +72,28 @@ export const uploadFile = async ({
     return { error: true, message: error.message, ...error.response };
   }
 };
+
+interface FileDeleteParams {
+  endpoint: string;
+  fileName: string;
+}
+export const deleteUploadedFile = async ({ endpoint, fileName }: FileDeleteParams) => {
+  const requestUrl = await buildServiceUrl(`${endpoint}/${fileName}`);
+  const token = await StorageService.getData(ACCESS_TOKEN_KEY);
+  const bearer = token || '';
+
+  try {
+    await axios({
+      url: requestUrl,
+      method: 'delete',
+      headers: {
+        Authorization: bearer,
+      },
+    });
+
+    return { status: 200, deletedFile: fileName };
+  } catch (error) {
+    console.log('axios error', error);
+    return { error: true, message: error.message, ...error.response };
+  }
+};

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -72,3 +72,37 @@ export const uploadFile = async ({
     return { error: true, message: error.message, ...error.response };
   }
 };
+
+const MimeTypes = {
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  pdf: 'application/pdf',
+};
+
+interface FileDownloadParams {
+  endpoint: string;
+  filename: string;
+}
+
+export const downloadFile = async ({ endpoint, filename }: FileDownloadParams) => {
+  const fileEnding = filename.split('.').pop();
+  const mime = MimeTypes[fileEnding];
+  const requestUrl = await buildServiceUrl(`${endpoint}/${filename}`);
+  const token = await StorageService.getData(ACCESS_TOKEN_KEY);
+  const bearer = token || '';
+
+  try {
+    const downloadResponse = await axios({
+      url: requestUrl,
+      method: 'get',
+      headers: {
+        Authorization: bearer,
+        Accept: mime,
+      },
+    });
+    console.log(downloadResponse);
+  } catch (error) {
+    console.log('axios download error: ', error);
+    return { error: true, message: error.message, ...error.response };
+  }
+};

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import RNFetchBlob from 'rn-fetch-blob';
 import StorageService, { ACCESS_TOKEN_KEY } from '../services/StorageService';
 import { buildServiceUrl } from './UrlHelper';
 
@@ -91,16 +92,15 @@ export const downloadFile = async ({ endpoint, filename }: FileDownloadParams) =
   const token = await StorageService.getData(ACCESS_TOKEN_KEY);
   const bearer = token || '';
 
+  const { dirs } = RNFetchBlob.fs;
   try {
-    const downloadResponse = await axios({
-      url: requestUrl,
-      method: 'get',
-      headers: {
-        Authorization: bearer,
-        Accept: mime,
-      },
+    const downloadResult = await RNFetchBlob.config({
+      path: `${dirs.CacheDir}/${filename}`,
+    }).fetch('GET', requestUrl, {
+      Authorization: bearer,
+      Accept: mime,
     });
-    console.log(downloadResponse);
+    return `file://${downloadResult.path()}`;
   } catch (error) {
     console.log('axios download error: ', error);
     return { error: true, message: error.message, ...error.response };

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -72,28 +72,3 @@ export const uploadFile = async ({
     return { error: true, message: error.message, ...error.response };
   }
 };
-
-interface FileDeleteParams {
-  endpoint: string;
-  fileName: string;
-}
-export const deleteUploadedFile = async ({ endpoint, fileName }: FileDeleteParams) => {
-  const requestUrl = await buildServiceUrl(`${endpoint}/${fileName}`);
-  const token = await StorageService.getData(ACCESS_TOKEN_KEY);
-  const bearer = token || '';
-
-  try {
-    await axios({
-      url: requestUrl,
-      method: 'delete',
-      headers: {
-        Authorization: bearer,
-      },
-    });
-
-    return { status: 200, deletedFile: fileName };
-  } catch (error) {
-    console.log('axios error', error);
-    return { error: true, message: error.message, ...error.response };
-  }
-};

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -56,7 +56,6 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
             answers: answersObject,
           },
         };
-      }
       setInitialCase(initCase);
 
       getForm(initCase.currentFormId).then(async (form) => {

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -56,12 +56,13 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
             answers: answersObject,
           },
         };
-      setInitialCase(initCase);
+        setInitialCase(initCase);
 
-      getForm(initCase.currentFormId).then(async (form) => {
-        setForm(form);
-        setFormQuestions(getFormQuestions(form));
-      });
+        getForm(initCase.currentFormId).then(async (form) => {
+          setForm(form);
+          setFormQuestions(getFormQuestions(form));
+        });
+      }
     }
   }, [caseData, caseId, getForm, getCase, user, getCasesByFormIds]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,7 +3699,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-64@^0.1.0:
+base-64@0.1.0, base-64@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,7 +3699,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-64@0.1.0:
+base-64@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
@@ -10679,6 +10679,14 @@ react-native-fit-image@^1.5.5:
   dependencies:
     prop-types "^15.5.10"
 
+react-native-fs@^2.16.6:
+  version "2.16.6"
+  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.16.6.tgz#2901789a43210a35a0ef0a098019bbef3af395fd"
+  integrity sha512-ZWOooD1AuFoAGY3HS2GY7Qx2LZo4oIg6AK0wbC68detxwvX75R/q9lRqThXNKP6vIo2VHWa0fYUo/SrLw80E8w==
+  dependencies:
+    base-64 "^0.1.0"
+    utf8 "^3.0.0"
+
 react-native-gesture-handler@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.9.0.tgz#e441b1c0277c3fd4ca3e5c58fdd681e2f0ceddf0"
@@ -12904,6 +12912,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Explain the changes you’ve made

Added logic for resuming a form that contains uploaded images. 

## Explain your solution

When displaying an image, we first check if it exists in the place where it was last seen (i.e. if it is still cached, essentially). If so, we use it from there, just as before. If it does not exist in cache, we instead download it from the users-api, and save it in cache, displaying the cached file. We also update the stored path for the image, so that if the same image is shown later in the form, it is not downloaded again. 


## How to test the change

Testing this is a little tricky. Your AWS environment must have the users-api deployed from the 'feat/get-attachment' branch found [here](https://github.com/helsingborg-stad/helsingborg-io-sls-api/pull/159). 

Then the easiest way to test functionality is to go into a form that has an imageUploader component, like Stickprov or the test form for imageUpload that exists in develop. Then, upload a picture. Then, find the cache-files for the simulator, and manually clear them. Restarting the simulator might also clear the cache, but it seems like this is not guaranteed. 

For iOS, this seems to be in ~/Library/Developer/CoreSimulator/Devices/{{Device Code}} , and then find the apps folder from there, and it should be in <Application_Home>/Library/Caches. There's probably a way to do it from XCode as well, but I don't know. 

For Android, in AndroidStudio go to the View menu -> Tool Windows -> Device File Explorer . In the file explorer that opens up, on my device the cache folder was found under user/0/com.mitthelsingborg/cache . When you add files, they will show up here, and you can remove files from there as well. 

After removing say all the files from the cache, you can then go between steps in the form, and when you go back to the page containing the image uploader, you should see a spinning indicator, showing that the file is being downloaded, and then the correct picture should appear. And if you go between steps again, it should not be downloaded again. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
