### PR TITLE
hotfix(use-focus-effect): fixes an error with a useFocusEffect

### DIFF
--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -143,14 +143,16 @@ function CaseOverview(props) {
     }, [])
   );
 
-  useFocusEffect(() => {
-    Animated.timing(fadeAnimation, {
-      toValue: 1,
-      easing: Easing.ease,
-      duration: 200,
-      useNativeDriver: true,
-    }).start();
-  }, [fadeAnimation]);
+  useFocusEffect(
+    useCallback(() => {
+      Animated.timing(fadeAnimation, {
+        toValue: 1,
+        easing: Easing.ease,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+    }, [fadeAnimation])
+  );
 
   useEffect(() => {
     const updateItems = async () => {


### PR DESCRIPTION
Fixes an error with a useFocusEffect on the CaseOverview screen. The previous call to the useFocusEffect uses the correct pattern (wrapping the function in a useCallback), so that was probably just forgotten here, which causes an error. 