### PR TITLE
Fix/step validation

### DIFF
--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -98,14 +98,6 @@ const StepFooter: React.FC<Props> = ({
       case 'submit': {
         return onSubmit || null;
       }
-      case 'sign': {
-        return async () => {
-          await handleSign(
-            user.personalNumber,
-            action?.signMessage || 'Signering Mitt Helsingborg.'
-          );
-        };
-      }
       case 'backToMain': {
         return formNavigation.goToMainForm;
       }
@@ -122,7 +114,17 @@ const StepFooter: React.FC<Props> = ({
               8000
             );
           };
-          const onValidCallback = () => {
+
+          const onValidCallback = async () => {
+            if (action.type === 'sign') {
+              await handleSign(
+                user.personalNumber,
+                action?.signMessage || 'Signering Mitt Helsingborg.'
+              );
+
+              return;
+            }
+
             if (formNavigation.next) formNavigation.next();
           };
 


### PR DESCRIPTION
## Explain the changes you’ve made

* Add: recursiveValidationReducer method for reducing validation object/arrays to a boolean value 
* Refactor: validateAllStepAnswers to support validation of SummaryList using recursiveValidationReducer
* Fix: StepFooter to support validation before signing 

## Explain why these changes are made

* Before this fix users could edit a SummaryList and bypass validation when moving to another step or signing (last step). 
* Question type SummaryList is the 'black sheep' since it contains references to other questions it does not validate itself but rather other questions (existing in other steps)

## Explain your solution

* validateAllStepAnswers now treat all questions as an array item, since summaryList include items
* validateAllStepAnswers is generalized and does not care about the question type anymore (expect for summaryList)
* recursiveValidationReducer will find infinite deep array/object mix and return false once 1 items ha isValid: false

## How to test the changes?

1. Start a form with a SummaryList
2. Go to the SummaryList add an item - for example salary
3. After saving the SummaryList items, try edit the salary post - remove the numbers and add a comma ","
4. Try navigating to next step and validation should trigger, correct the value and you should be able to continue the form.
5. Navigate to the last step, edit one item from the summary list (add comma) and try sign the form which should trigger an validation error
6. Fix value (replace comma with numbers) then try signing and it should work as before

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.