### PR TITLE
Fix/contrast disabled button

### DIFF
--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -138,6 +138,7 @@ const ButtonText = styled(Text)`
   color: ${(props) =>
     props.variant === 'outlined' ? props.theme.colors.neutrals[1] : props.theme.colors.neutrals[7]};
   ${(props) =>
+    props.disabled &&
     Styles.disabled &&
     `
       color: ${props.theme.colors.neutrals[4]};

--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -105,8 +105,7 @@ Styles.fullWidth = css`
 
 /* Styles for a disabled button */
 Styles.disabled = css`
-  opacity: 0.2;
-  background-color: ${(props) => props.theme.colors.neutrals[1]};
+  background-color: ${(props) => props.theme.colors.neutrals[5]};
 `;
 
 const ButtonBase = styled.View`
@@ -139,6 +138,11 @@ const ButtonText = styled(Text)`
   color: ${(props) =>
     props.variant === 'outlined' ? props.theme.colors.neutrals[1] : props.theme.colors.neutrals[7]};
   ${(props) =>
+    Styles.disabled &&
+    `
+      color: ${props.theme.colors.neutrals[4]};
+    `}
+  ${(props) =>
     props.variant === 'link' &&
     `
     color: ${
@@ -146,6 +150,7 @@ const ButtonText = styled(Text)`
         ? `${props.theme.colors.neutrals[2]}`
         : `${props.theme.colors.primary[props.colorSchema][1]}`
     };
+    
   `}
 `;
 
@@ -277,7 +282,7 @@ Button.defaultProps = {
   icon: false,
   z: 1,
   size: 'medium',
-  disabled: false,
+  disabled: true,
   variant: 'contained',
 };
 

--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -33,6 +33,7 @@ Styles.outlined = css`
       ? props.theme.colors.neutrals[5]
       : props.theme.colors.complementary[props.colorSchema][1]};
   ${Styles.elevation[0]}
+  ${(props) => props.disabled && `border: 2px solid ${props.theme.colors.neutrals[4]}}`};
 `;
 
 const ButtonIcon = styled(Icon)`
@@ -137,12 +138,7 @@ const ButtonText = styled(Text)`
   font-weight: ${(props) => props.theme.fontWeights[1]};
   color: ${(props) =>
     props.variant === 'outlined' ? props.theme.colors.neutrals[1] : props.theme.colors.neutrals[7]};
-  ${(props) =>
-    props.disabled &&
-    Styles.disabled &&
-    `
-      color: ${props.theme.colors.neutrals[4]};
-    `}
+  ${(props) => props.disabled && `color: ${props.theme.colors.neutrals[4]};`}
   ${(props) =>
     props.variant === 'link' &&
     `
@@ -216,6 +212,7 @@ const Button = (props) => {
         colorSchema,
         size,
         variant,
+        disabled,
       });
     }
 

--- a/source/components/atoms/Button/Button.js
+++ b/source/components/atoms/Button/Button.js
@@ -282,7 +282,7 @@ Button.defaultProps = {
   icon: false,
   z: 1,
   size: 'medium',
-  disabled: true,
+  disabled: false,
   variant: 'contained',
 };
 

--- a/source/components/atoms/Button/Button.stories.js
+++ b/source/components/atoms/Button/Button.stories.js
@@ -175,6 +175,11 @@ const ButtonColors = (injectProps) => (
         <Text>Green</Text>
       </Button>
     </Flex>
+    <Flex>
+      <Button colorSchema="neutral" {...injectProps} disabled>
+        <Text>Disable</Text>
+      </Button>
+    </Flex>
   </FlexContainer>
 );
 


### PR DESCRIPTION
This line can be removed: Read this short article before you start writing https://www.pullrequest.com/blog/writing-a-great-pull-request-description/


## Explain the changes you’ve made
Increased the contrast for the disable button, so it works for Android. 
Changed the background color and text color.
Removed opacity because affect readability on text. 

## Explain why these changes are made
Was bad contrast on disable buttons on Android devices. 

## Explain your solution
Changed colors on both background and text to look like buttons in Figma skiss.


## How to test the changes?

Concrete example:
1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command`yarn ios`
4. navigate to Contained buttons.

## Was this feature tested in the following environments?
- [] Storybook on a Android simulator.



