### PR TITLE
feat(repeater-max-rows): disable add button if item count is >= maxRows

### DIFF
--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -29,6 +29,7 @@ interface Props {
   onBlur?: (answers: Record<string, any> | string | number, fieldId?: string) => void;
   colorSchema: PrimaryColor;
   error?: Record<string, {isValid: boolean, validationMessage: string}>[];
+  maxRows?: number;
 }
 const emptyInput: Record<string, string | number>[] = [];
 
@@ -39,9 +40,9 @@ function isRecordArray(value: string | Record<string,string|number>[]): value is
  * Repeater field component, for adding multiple copies of a particular kind of input.
  * The input-prop specifies the form of each input-group.
  */
-const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChange, onBlur, colorSchema, value, error }) => {
+const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChange, onBlur, colorSchema, value, error, maxRows }) => {
   const [localAnswers, setLocalAnswers] = useState( isRecordArray(value) ? value : emptyInput);
-  
+
   const changeFromInput = (index: number) => (input: InputRow) => (text: string) => {
     localAnswers[index][input.id] = text;
     onChange(localAnswers);
@@ -100,10 +101,11 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
       />
     );
   });
+
   return (
     <Fieldset legend={heading} colorSchema={validColorSchema} empty={listItems.length === 0}>
        {listItems}
-      <AddButton onClick={addAnswer} colorSchema={"green"} block variant="outlined">
+      <AddButton onClick={addAnswer} colorSchema={"green"} block variant="outlined" disabled={maxRows && listItems.length >= maxRows}>
         <Icon name="add" color="green" />
         <Text>{addButtonText || 'Lägg till'}</Text>
       </AddButton>


### PR DESCRIPTION
## Explain the changes you’ve made

- RepeaterField: Disable add button when items >= maxRows 

## Related PR's
https://github.com/helsingborg-stad/mitt-helsingborg-form-builder/pull/52