### PR TITLE
Increase camera timout

### DIFF
--- a/ios/MittHelsingborg/Info.plist
+++ b/ios/MittHelsingborg/Info.plist
@@ -48,6 +48,8 @@
 	<string/>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Denna appen har tillgång till dina bilder.</string>
+  <key>NSCameraUsageDescription</key>
+  <string>Denna appen har tillgång till kamera för att ta bilder.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -95,20 +95,20 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
     }
     const data: Blob = await getBlob(image.path);
     const filename = (image.path as string).split('/').pop();
-    const uploadResponse = await uploadFile({ 
+    const uploadResponse = await uploadFile({
       endpoint: 'users/me/attachments',
       fileName: filename,
       fileType: (imageFileType as 'jpg' | 'jpeg' | 'png'),
       data
     });
-    
+
     if (uploadResponse.error) {
       updatedImages[index].errorMessage = uploadResponse.message;
     } else {
       updatedImages[index].uploadedFileName = uploadResponse.uploadedFileName;
       updatedImages[index].url = uploadResponse.url;
     }
-    onChange(updatedImages); 
+    onChange(updatedImages);
   };
 
   const addImagesFromLibrary = () => {
@@ -184,11 +184,11 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
               colorSchema={validColorSchema}
               block
               variant="outlined"
-              onClick={() => { 
+              onClick={() => {
                 toggleModal();
                 /** There's an issue on iOS with triggering the library before the modal has closed,
                  * so as a simple fix, we add a timeout (since toggleModal is async) */
-                setTimeout(addImageFromCamera, 100); 
+                setTimeout(addImageFromCamera, 700);
               }}
             >
               <Icon name="camera-alt" />
@@ -202,7 +202,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
                 toggleModal();
                 /** There's an issue on iOS with triggering the library before the modal has closed,
                  * so as a simple fix, we add a timeout (since toggleModal is async) */
-                setTimeout(addImagesFromLibrary, 100);
+                setTimeout(addImagesFromLibrary, 700);
               }}
             >
               <Icon name="add-photo-alternate" />


### PR DESCRIPTION
## Explain the changes you’ve made
Triggering camera first after modal gets hidden.

## Explain your solution
Increased timeout before triggering camera.
Camera was attached to modal component and when the modal disappeared, so would the camera view. A simple solution is to set a timer before triggering camera view, this will attach the camera to view that triggered the modal.

## How to test the changes?
Test by deploying to iOS device and try triggering camera in form "Test form for Image Viewer component".

## Was this feature tested in the following environments?
- [x] Building the Application on a iOS device.