### PR TITLE
Handle dynamic tags for repeater fields

### DIFF
--- a/source/helpers/CaseDataConverter.js
+++ b/source/helpers/CaseDataConverter.js
@@ -89,13 +89,24 @@ export const convertAnswersToArray = (data, formQuestions) => {
           Object.entries(childItems).forEach((childItem) => {
             const [repeaterItemId, repeaterItemValue] = childItem;
             const repeaterFieldItem = other.inputs.find((obj) => obj.id === repeaterItemId);
-            const { tags: repeaterFieldItemTags } = repeaterFieldItem;
+            const { tags } = repeaterFieldItem;
+            let newTags = [];
+            if (Array.isArray(tags)) {
+              const dyanmicTagRegex = new RegExp('.+:x');
+              newTags = tags.map((tag) => {
+                if (dyanmicTagRegex.test(tag)) {
+                  const strArray = tag.split(':');
+                  return `${strArray?.[0] || tag}:${childFieldId}`;
+                }
+                return tag;
+              });
+            }
 
             answers.push(
               createAnswerObject({
                 fieldId: `${id}.${childFieldId}.${repeaterItemId}`,
                 value: repeaterItemValue,
-                tags: repeaterFieldItemTags ?? [],
+                tags: newTags,
               })
             );
           });

--- a/source/helpers/CaseDataConverter.js
+++ b/source/helpers/CaseDataConverter.js
@@ -92,9 +92,9 @@ export const convertAnswersToArray = (data, formQuestions) => {
             const { tags } = repeaterFieldItem;
             let newTags = [];
             if (Array.isArray(tags)) {
-              const dyanmicTagRegex = new RegExp('.+:x');
+              const dynamicTagRegex = new RegExp('.+:x');
               newTags = tags.map((tag) => {
-                if (dyanmicTagRegex.test(tag)) {
+                if (dynamicTagRegex.test(tag)) {
                   const strArray = tag.split(':');
                   return `${strArray?.[0] || tag}:${childFieldId}`;
                 }


### PR DESCRIPTION
## Explain the changes you’ve made

Handles dynamic tags for repeater fields. Read more on this task: https://app.clickup.com/t/g56nxw

## How to test the changes?

Add tags+dynamic tags for a repeater in Formbuilder with this example: lon,amount,group:x
Enter the form in the App and submit the form
Check the answers in DB and all repeater fields with dynamic tag "group:x" should be replaced with group:0, group:1, etc..

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.