### PR TITLE
Fix/prevent sent in status change

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,7 +17,8 @@ target 'MittHelsingborg' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  #use_flipper!
+  use_flipper!({ 'Flipper-Folly' => '2.3.0' })
   post_install do |installer|
     flipper_post_install(installer)
 

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -67,7 +67,26 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [caseData, getForm]);
 
-  function handleCloseForm() {
+  const handleCloseForm = () => {
+    /* This works to set the case status as submitted, but only when a user opens a submitted case.
+     * To trigger it, the user first needs to submit a case and sign it, then click the X button to close.
+     * Once opened, click the X to close again, and this will run.
+     *
+     * It should run on the first close, but the current logic won't work, as it's impossible to know that the case
+     *    has gone through the final signing step, due to an issue where the initialCase data doesn't exist, i.e
+     *    the status is set to "not started" and the form and answer objects are empty.
+     */
+    const currentStep = initialCase?.forms?.[initialCase.currentFormId]?.currentPosition?.currentMainStep || 0;
+    const totalSteps = form?.stepStructure ? form.stepStructure.length : 0;
+
+    if (currentStep === totalSteps) {
+      if (updateCase && initialCase.status.type.includes('ongoing')) {
+        const currentForm = initialCase?.forms?.[initialCase.currentFormId];
+
+        updateCaseContext(currentForm.answers, getStatusByType('active:submitted', currentForm.currentPosition));
+      }
+    }
+
     navigation.popToTop();
   }
 

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -68,27 +68,8 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
   }, [caseData, getForm]);
 
   const handleCloseForm = () => {
-    /* This works to set the case status as submitted, but only when a user opens a submitted case.
-     * To trigger it, the user first needs to submit a case and sign it, then click the X button to close.
-     * Once opened, click the X to close again, and this will run.
-     *
-     * It should run on the first close, but the current logic won't work, as it's impossible to know that the case
-     *    has gone through the final signing step, due to an issue where the initialCase data doesn't exist, i.e
-     *    the status is set to "not started" and the form and answer objects are empty.
-     */
-    const currentStep = initialCase?.forms?.[initialCase.currentFormId]?.currentPosition?.currentMainStep || 0;
-    const totalSteps = form?.stepStructure ? form.stepStructure.length : 0;
-
-    if (currentStep === totalSteps) {
-      if (updateCase && initialCase.status.type.includes('ongoing')) {
-        const currentForm = initialCase?.forms?.[initialCase.currentFormId];
-
-        updateCaseContext(currentForm.answers, getStatusByType('active:submitted', currentForm.currentPosition));
-      }
-    }
-
     navigation.popToTop();
-  }
+  };
 
   const updateCaseContext = (answerObject, status, currentPosition) => {
     // If the case is submitted, we should not actually update its data...
@@ -101,6 +82,28 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
         currentPosition,
         formQuestions,
       };
+
+      // We set the initial case to prevent desync issues with the above logic.
+      // If we don't, the case will be updated all the time, because the initialCase
+      //    still has the "not started" status.
+      setInitialCase({
+        ...initialCase,
+        status,
+        forms: {
+          ...initialCase.forms,
+          [initialCase.currentFormId]: {
+            ...initialCase.forms[initialCase.currentFormId],
+            answers: {
+              ...initialCase.forms[initialCase.currentFormId].answers,
+              ...answerObject,
+            },
+            currentPosition: {
+              ...initialCase.forms[initialCase.currentFormId].currentPosition,
+              ...currentPosition,
+            },
+          },
+        },
+      });
       updateCase(caseData);
     }
   };
@@ -109,14 +112,12 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
    * Function for handling behavior when a form starts
    * TO BE IMPLEMENTED
    * */
-  function handleStartForm() {
-    return null;
-  }
+  const handleStartForm = () => null;
 
   // TODO: Update case on form submit.
-  function handleSubmitForm() {
+  const handleSubmitForm = () => {
     navigation.popToTop();
-  }
+  };
 
   if (!form?.steps) {
     return (


### PR DESCRIPTION
## Explain the changes you’ve made

I fixed the bug where the status of sent in cases would change back to "Pågående" from "Inskickat" if the user clicked the cross/close button in the last step of the form.

For more info, see #fd4ew7

## Explain why these changes are made

This change is made to give the user the correct information about their case.

## Explain your solution

The bug is fixed by disallowing the case to change status once it's been submitted.
This is done by assisting the existing if statement, by setting the `initialCase` state variable when the `updateCaseContext` function is called.

## How to test the changes?

1. Checkout this branch
2. Load up the application in iOS simulator using `yarn ios`
3. Start a new case
4. Complete the case, sign it and press the "X" button.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

