### PR TITLE
Feature/multiple images

### DIFF
--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TouchableOpacity } from 'react-native';
-import ImagePicker from 'react-native-image-crop-picker';
-import {launchImageLibrary, ImageLibraryOptions} from 'react-native-image-picker';
+import ImagePicker, { Options } from 'react-native-image-crop-picker';
+// import {launchImageLibrary, ImageLibraryOptions} from 'react-native-image-picker';
 import styled from 'styled-components/native';
 import { Text, Button, Icon, Label } from '../../atoms';
 import { Modal, useModal } from '../Modal';
@@ -78,6 +78,12 @@ interface Props {
   id: string;
 }
 
+const asyncForEach = async (array: any[], callback: Function) => {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array)
+  }
+}
+
 const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, onChange, colorSchema, maxImages, id }) => {
   const [choiceModalVisible, toggleModal] = useModal();
 
@@ -111,32 +117,57 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
     onChange(updatedImages);
   };
 
-  const addImagesFromLibrary = () => {
-    const libraryOptions: ImageLibraryOptions = {
-      mediaType: 'photo',
-      includeBase64: false,
-      maxWidth: 800,
-      maxHeight: 800,
-      quality: 0.5
-    };
+  const addImagesFromLibrary = async () => {
+    // const libraryOptions: ImageLibraryOptions = {
+    //   mediaType: 'photo',
+    //   includeBase64: false,
+    //   maxWidth: 800,
+    //   maxHeight: 800,
+    //   quality: 0.5
+    // };
 
     try {
-      launchImageLibrary(libraryOptions, (response) => {
-        if (response?.didCancel) return;
+      // launchImageLibrary(libraryOptions, (response) => {
+      //   if (response?.didCancel) return;
 
+      //   const imageToAdd: Image = {
+      //     questionId: id,
+      //     path: response.uri,
+      //     filename: response.fileName,
+      //     width: response.width,
+      //     height: response.height,
+      //     size: response.fileSize,
+      //     mime: response.fileName.split('.').pop(),
+      //   };
+      //   const originalLength = images.length;
+      //   const updatedImages = addImagesToState([imageToAdd]);
+      //   uploadImage(imageToAdd, originalLength, updatedImages);
+      // });
+      const images = await ImagePicker.openPicker({
+        multiple: true,
+        mediaType: 'photo',
+        width: 800,
+        height: 800,
+        includeBase64: false,
+        compressImageQuality: 0.5,
+        compressImageMaxHeight: 800,
+        compressImageMaxWidth: 800,
+      });
+
+      asyncForEach(images, async (image) => {
         const imageToAdd: Image = {
+          ...image,
           questionId: id,
-          path: response.uri,
-          filename: response.fileName,
-          width: response.width,
-          height: response.height,
-          size: response.fileSize,
-          mime: response.fileName.split('.').pop(),
-        };
+        }
+
         const originalLength = images.length;
         const updatedImages = addImagesToState([imageToAdd]);
-        uploadImage(imageToAdd, originalLength, updatedImages);
-      });
+        await uploadImage(imageToAdd, originalLength, updatedImages);
+      })
+      
+      console.log("images", images)
+
+
     } catch (error) {
       console.error(error);
     }

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TouchableOpacity } from 'react-native';
 import ImagePicker, { Options } from 'react-native-image-crop-picker';
-// import {launchImageLibrary, ImageLibraryOptions} from 'react-native-image-picker';
 import styled from 'styled-components/native';
 import { Text, Button, Icon, Label } from '../../atoms';
 import { Modal, useModal } from '../Modal';
@@ -118,31 +117,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
   };
 
   const addImagesFromLibrary = async () => {
-    // const libraryOptions: ImageLibraryOptions = {
-    //   mediaType: 'photo',
-    //   includeBase64: false,
-    //   maxWidth: 800,
-    //   maxHeight: 800,
-    //   quality: 0.5
-    // };
-
     try {
-      // launchImageLibrary(libraryOptions, (response) => {
-      //   if (response?.didCancel) return;
-
-      //   const imageToAdd: Image = {
-      //     questionId: id,
-      //     path: response.uri,
-      //     filename: response.fileName,
-      //     width: response.width,
-      //     height: response.height,
-      //     size: response.fileSize,
-      //     mime: response.fileName.split('.').pop(),
-      //   };
-      //   const originalLength = images.length;
-      //   const updatedImages = addImagesToState([imageToAdd]);
-      //   uploadImage(imageToAdd, originalLength, updatedImages);
-      // });
       const pickedImages = await ImagePicker.openPicker({
         multiple: true,
         mediaType: 'photo',
@@ -158,16 +133,15 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
 
       const originalLength = images.length;
 
-      asyncForEach(pickedImages, async (image) => {
+      let addedImages = []
+
+      await asyncForEach(pickedImages, async (image) => {
         const imageToAdd: Image = {...image, questionId: id};
 
-        console.log("imageToAdd", imageToAdd)
+        addedImages.push(imageToAdd)
 
         const originalLength = images.length;
         const updatedImages = addImagesToState([imageToAdd]);
-
-        console.log("updatedImages", updatedImages)
-
         try {
           await uploadImage(imageToAdd, originalLength, updatedImages);
         } catch (e) {
@@ -175,8 +149,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
         }
       })
 
-      console.log("pickedImages", pickedImages)
-
+      addImagesToState(addedImages)
 
     } catch (error) {
       console.error(error);

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -94,7 +94,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
   };
 
   const uploadImage = async (image: Image, index: number, updatedImages: Image[]) => {
-    const imageFileType = (image.path as string).split('.').pop();
+    const imageFileType = (image.path as string).split('.').pop().toLowerCase();
     if (!['jpg', 'jpeg', 'png'].includes(imageFileType)) {
       console.error(`Trying to upload a forbidden type of image, ${imageFileType}, allowed file types are [jpg, jpeg, png].`);
       return;
@@ -143,7 +143,7 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
       //   const updatedImages = addImagesToState([imageToAdd]);
       //   uploadImage(imageToAdd, originalLength, updatedImages);
       // });
-      const images = await ImagePicker.openPicker({
+      const pickedImages = await ImagePicker.openPicker({
         multiple: true,
         mediaType: 'photo',
         width: 800,
@@ -152,20 +152,30 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
         compressImageQuality: 0.5,
         compressImageMaxHeight: 800,
         compressImageMaxWidth: 800,
+        writeTempFile: true,
+        cropping: true,
       });
 
-      asyncForEach(images, async (image) => {
-        const imageToAdd: Image = {
-          ...image,
-          questionId: id,
-        }
+      const originalLength = images.length;
+
+      asyncForEach(pickedImages, async (image) => {
+        const imageToAdd: Image = {...image, questionId: id};
+
+        console.log("imageToAdd", imageToAdd)
 
         const originalLength = images.length;
         const updatedImages = addImagesToState([imageToAdd]);
-        await uploadImage(imageToAdd, originalLength, updatedImages);
+
+        console.log("updatedImages", updatedImages)
+
+        try {
+          await uploadImage(imageToAdd, originalLength, updatedImages);
+        } catch (e) {
+          console.error(e)
+        }
       })
-      
-      console.log("images", images)
+
+      console.log("pickedImages", pickedImages)
 
 
     } catch (error) {


### PR DESCRIPTION
## Explain the changes you’ve made

I added support for uploading multiple images from the gallery at once, as well as making both the gallery picker and camera picker use the same library.

More info is available at #gt5z86

## Explain why these changes are made

This change is a quality-of-life feature, and lets users select all images they need at once.

I've also added a `.toLowerCase()` call where we're getting the imageFileType, and it didn't let us upload files with any capitals in the file extension.

## Explain your solution

By moving the gallery selection to the same library as the camera, `[react-native-image-crop-picker](https://github.com/ivpusic/react-native-image-crop-picker)`, I was able to use it's feature of multiple image selection, which our previous library, `[react-native-image-picker](https://github.com/react-native-image-picker/react-native-image-picker)` doesn't support.



## How to test the changes?

Concrete example:
1. Checkout this branch
2. Start the simulator using `yarn ios`
2. Create a Stickprov from the developer tools
3. Upload images from the gallery
4. Select multiple images

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Anything else? (optional)

I'm unsure whether the `.toLowerCase()` call was the best approach to the file extension issue, and I'd like some additional comments and feedback on that.
