### PR TITLE
Bug/keyboard button label

### DIFF
--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -57,7 +57,7 @@ const StyledAccessoryViewChild = styled(View)`
   justifyContent: flex-end;
   alignItems: center;
   backgroundColor: #F8F8F8;
-  paddingHorizontal: 8px; 
+  paddingHorizontal: 8px;
 `;
 
 const _replaceSpace = str => (str?.replace ? str.replace(/\u0020/, '\u00a0') : str);

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextInputProps, Keyboard, TextInput, KeyboardTypeOptions } from 'react-native';
+import { TextInputProps, Keyboard, TextInput, KeyboardTypeOptions, InputAccessoryView, View, Button, Dimensions, Platform } from 'react-native';
 import styled, { useTheme } from 'styled-components/native';
 import Text from '../Text';
 import { InputFieldType } from '../../../types/FormTypes';
@@ -50,6 +50,16 @@ const StyledErrorText = styled(Text)`
   padding-top: 8px;
 `;
 
+const StyledAccessoryViewChild = styled(View)`
+  width: ${Dimensions.get('window').width}px;
+  height: 48px;
+  flexDirection: row;
+  justifyContent: flex-end;
+  alignItems: center;
+  backgroundColor: #F8F8F8;
+  paddingHorizontal: 8px; 
+`;
+
 const _replaceSpace = str => (str?.replace ? str.replace(/\u0020/, '\u00a0') : str);
 
 const Input: React.FC<InputProps> = React.forwardRef(
@@ -68,16 +78,30 @@ const Input: React.FC<InputProps> = React.forwardRef(
           onBlur={handleBlur}
           placeholderTextColor={theme.colors.neutrals[1]}
           returnKeyType="done"
+          returnKeyLabel="Klar" // Only works on Android  
           blurOnSubmit
           onSubmitEditing={() => {
             Keyboard.dismiss();
           }}
+          inputAccessoryViewID="klar-accessory"
           keyboardType={smartKeyboardType}
           ref={ref as React.Ref<TextInput>}
           {...props}
         />
         {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
+      
+        {Platform.OS === 'ios' ? (
+          <InputAccessoryView nativeID="klar-accessory">
+            <StyledAccessoryViewChild>
+              <Button
+                title="Klar"
+                onPress={() => Keyboard.dismiss()}
+              />
+            </StyledAccessoryViewChild>
+          </InputAccessoryView>
+        ) : null}
       </>
+      
     );
   }
 );

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -90,7 +90,7 @@ const Input: React.FC<InputProps> = React.forwardRef(
         />
         {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
       
-        {Platform.OS === 'ios' ? (
+        {Platform.OS === 'ios' && inputType !== 'email' && inputType !== 'text' ? (
           <InputAccessoryView nativeID="klar-accessory">
             <StyledAccessoryViewChild>
               <Button

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -83,6 +83,7 @@ const Select: React.FC<Props> = React.forwardRef(({
         onValueChange={handleValueChange}
         items={items}
         ref={ref as React.LegacyRef<RNPickerSelect>}
+        doneText="Klar"
       />
       {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
     </Wrapper>


### PR DESCRIPTION
## Explain the changes you’ve made

I've changed the label of the "Done" button for input and select fields in iOS to read "Klar" instead.

For more information, see #CU-fz6c9n

## Explain why these changes are made

These changes are made as the rest of the app is in Swedish.

## Explain your solution

As I'm unable to change the label natively for the text and number input fields, I needed to implement it using a [`InputAccessoryView`](https://reactnative.dev/docs/inputaccessoryview) with a custom button.

For the select component, I was able to set the `doneText` property from the [`react-native-picker-select`](https://www.npmjs.com/package/react-native-picker-select) library.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Run the app using `yarn ios`
3. Enable the iOS simulator keyboard using `⇧+⌘+K`
4. Create a new EKB case from the developer options
5. Focus on a text field, a number input and the selects.


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots (optional)

### Number input before: 

![Simulator Screen Shot - iPhone 11 - 2021-04-12 at 09 10 32](https://user-images.githubusercontent.com/10225982/114355173-6f8b3000-9b6f-11eb-9ce6-ce3f819e50cc.png)

### Number input after

![Simulator Screen Shot - iPhone 11 - 2021-04-12 at 09 12 05](https://user-images.githubusercontent.com/10225982/114355218-7f0a7900-9b6f-11eb-9aaa-8f3bee09a8d7.png)
