### PR TITLE
feat(description-label): added label to summary list items

### DIFF
--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -40,7 +40,7 @@ const SumContainer = styled.View<{ colorSchema: string }>`
 export interface SummaryListItem {
   title: string;
   id: string;
-  type: 'number' | 'text' | 'date' | 'checkbox' | 'arrayNumber' | 'arrayText' | 'arrayDate' 
+  type: 'number' | 'text' | 'date' | 'checkbox' | 'arrayNumber' | 'arrayText' | 'arrayDate'
    | 'editableListText' | 'editableListNumber' | 'editableListDate' ;
   category?: string;
   inputId?: string;
@@ -135,7 +135,7 @@ const SummaryList: React.FC<Props> = ({
       const oldAnswer: Record<string, string | number>[] = answers[item.id];
       oldAnswer.splice(index, 1);
       onChange(oldAnswer, item.id);
-    } else if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId) { 
+    } else if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId) {
       const oldAnswer: Record<string, string | number> = answers[item.id];
       oldAnswer[item.inputId] = undefined;
       onChange(oldAnswer, item.id);
@@ -163,7 +163,7 @@ const SummaryList: React.FC<Props> = ({
     return typeof answer !== 'undefined';
   });
   itemsWithAnswers
-    .forEach((item) => {
+    .forEach(( item) => {
       if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {
         const values: Record<string, string | number>[] = answers[item.id];
         if (!Array.isArray(values) && values !== undefined) {
@@ -183,6 +183,7 @@ const SummaryList: React.FC<Props> = ({
               <SummaryListItemComponent
                 item={item}
                 index={index ? index + 1 : undefined}
+                userDescriptionLabel={v.text}
                 key={`${item.id}-${index}`}
                 value={v[item?.inputId]}
                 changeFromInput={changeFromInput(item, index)}
@@ -198,10 +199,10 @@ const SummaryList: React.FC<Props> = ({
               addToSum(numericValue);
             }
           });
-        } 
-      } 
-      if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId 
-      && answers?.[item.id]?.[item.inputId]) { 
+        }
+      }
+      if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId
+      && answers?.[item.id]?.[item.inputId]) {
         listItems.push(
           <SummaryListItemComponent
               item={item}
@@ -219,7 +220,7 @@ const SummaryList: React.FC<Props> = ({
           const numericValue: number = answers[item.id][item.inputId];
           addToSum(numericValue);
         }
-      } 
+      }
       if (['text', 'number', 'date', 'checkbox'].includes(item.type)) {
         listItems.push(
           <SummaryListItemComponent
@@ -295,8 +296,8 @@ SummaryList.propTypes = {
    * The form state answers
    */
   answers: PropTypes.object,
-  /** 
-   * Object containing all validation errors for the entire form 
+  /**
+   * Object containing all validation errors for the entire form
    */
   validationErrors: PropTypes.object,
   /**

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -163,7 +163,7 @@ const SummaryList: React.FC<Props> = ({
     return typeof answer !== 'undefined';
   });
   itemsWithAnswers
-    .forEach(( item) => {
+    .forEach((item) => {
       if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {
         const values: Record<string, string | number>[] = answers[item.id];
         if (!Array.isArray(values) && values !== undefined) {

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -180,6 +180,7 @@ const InputComponent = React.forwardRef(({ input, editable, value, onInputBlur, 
 interface Props {
   item: SummaryListItemType;
   value: string | number | boolean;
+  userDescriptionLabel?: string;
   index?: number;
   editable?: boolean;
   changeFromInput: (value: string | number | boolean) => void;
@@ -192,6 +193,7 @@ interface Props {
 const SummaryListItem: React.FC<Props> = ({
   item,
   value,
+  userDescriptionLabel ,
   index,
   changeFromInput,
   onBlur,
@@ -221,8 +223,7 @@ const SummaryListItem: React.FC<Props> = ({
         >
           <LabelWrapper>
             <SmallText editable={editable}>
-              {`${item.title}`}
-              {index ? ` ${index}` : null}
+              {userDescriptionLabel || item.title}
             </SmallText>
           </LabelWrapper>
           <InputWrapper editable={editable}>

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -193,7 +193,7 @@ interface Props {
 const SummaryListItem: React.FC<Props> = ({
   item,
   value,
-  userDescriptionLabel ,
+  userDescriptionLabel,
   index,
   changeFromInput,
   onBlur,


### PR DESCRIPTION
## Explain the changes you’ve made
Setting user description as label for multiple summary list of type"Övriga kostnader".

## Explain why these changes are made
Creating clarity for the user, as several expenses with same label creates confusion.

## Explain your solution
Setting summary list item description as label, if the user added any description. Fallback to label "Övriga kostnader" if only amount inputted by the user.

## How to test the changes?
Add expenses "Övriga kostnader" with and  without description. Description shall be displayed (if inputted) as label in the expense summary.

![Screenshot 2021-04-23 at 14 30 22](https://user-images.githubusercontent.com/186287/115871145-71db6d00-a440-11eb-90f7-f1564bfb5453.png)


## Was this feature tested in the following environments?
- [ ] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.


## Anyhting else? (optional)

Task https://app.clickup.com/t/gq7700 will be broken up in several PR:s. Will iterate through the sub tasks and make incremental releases. Hope that's file.