### PR TITLE
Feat/automatiskt utfra tester vid pull requests cu h18xra

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,41 @@
+# Workflow for running smoke tests for pull requests etc.
+
+name: Smoke tests
+
+on:
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  smoke-tests:
+    name: Smoke Tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # yarn / node modules
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: cache yarn
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          # note: uses a separate (dev) cache, different from the build workflow
+          key: ${{ runner.os }}-yarn-dev-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-dev-
+
+      # install yarn (will use cache if possible)
+      - name: yarn install
+        run: yarn install
+
+      # run tests
+      - name: run tests
+        run: yarn test

--- a/__tests__/App-test.js
+++ b/__tests__/App-test.js
@@ -1,14 +1,13 @@
-/**
- * @format
- */
+// import React from 'react';
+// import { View } from 'react-native';
+//
+// // Note: test renderer must be required after react-native.
+// import renderer from 'react-test-renderer';
+//
+// import App from '../source/App';
+//
+// it('renders correctly', () => {
+//   renderer.create(<App />);
+// });
 
-import 'react-native';
-import React from 'react';
-import App from '../App';
-
-// Note: test renderer must be required after react-native.
-import renderer from 'react-test-renderer';
-
-it('renders correctly', () => {
-  renderer.create(<App />);
-});
+it('PLACEHOLDER', () => {});


### PR DESCRIPTION
## Explain the changes you’ve made

Added a GitHub actions workflow that will run on pull requests and perform `yarn test` to check for any test-related issues.

Note: this PR does not add any tests. It only adds the CI setup to run tests automatically. Currently, the default `App-test.js` has been stubbed and will always pass.


## Explain why these changes are made

Running tests on pull requests ensures developers do not accidentally add breaking changes or introduces new bugs that would otherwise not been caught.


## Explain your solution

A workflow file has been added to `.github/workflows/smoke-tests.yml` which on pull requests sets up an Ubuntu instance in GitHub Actions and runs `yarn test`. The workflow will also attempt to cache `yarn install` artifacts to speed up the process. 

The results will automatically be reported back into the pull request's comment flow.


## How to test the changes?

The check should automatically be running as soon as I create this pull request (for this pull request only). After accepting this pull request (and rebasing into `develop`), the workflow will be run for all pull requests and can also be manually run from the Actions tab in GitHub.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.


## Anything else? (optional)

The first time a new workflow is added (such as this `smoke-tests.yml`) the file has to exist on the default branch (in this case `develop`) before it is available in the Actions tab. After it has been added to the default branch, other branches can freely modify and run branch-local changes on it without having to commit the changes to the default branch until ready.
