### PR TITLE
Fix/upload file error handling

### DIFF
--- a/source/containers/Form/FormUploader.tsx
+++ b/source/containers/Form/FormUploader.tsx
@@ -119,7 +119,7 @@ const FormUploader: React.FunctionComponent<Props> = ({
             Säkerställ att du har internet uppkoppling och försök igen. Om problemet kvarstår,
             kontakta din handläggare.
           </Text>
-          <DialogButton block value="Förösk igen" onClick={retry} />
+          <DialogButton block value="Försök igen" onClick={retry} />
         </>
       )}
     </Dialog>

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -57,19 +57,17 @@ export const uploadFile = async ({
     const fileUploadAttributes = signedUrlResponse.data.data.attributes;
     const { uploadUrl } = fileUploadAttributes;
 
-    await axios({
-      url: uploadUrl,
+    const putResponse = await fetch(uploadUrl, {
       method: 'PUT',
-      data,
+      body: data,
       headers: {
         'Content-Type': MIMEs[fileType],
         'Content-Encoding': 'base64',
         'x-amz-acl': 'public-read',
       },
     });
-
     // return the url and filename on server to the uploaded file.
-    return { url: uploadUrl, uploadedFileName: fileUploadAttributes.fileName };
+    return { url: putResponse.url, uploadedFileName: fileUploadAttributes.fileName };
   } catch (error) {
     console.error('Axios error while uploading file:', error);
     return { error: true, message: error.message, ...error.response };

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -57,17 +57,19 @@ export const uploadFile = async ({
     const fileUploadAttributes = signedUrlResponse.data.data.attributes;
     const { uploadUrl } = fileUploadAttributes;
 
-    const putResponse = await fetch(uploadUrl, {
+    await axios({
+      url: uploadUrl,
       method: 'PUT',
-      body: data,
+      data,
       headers: {
         'Content-Type': MIMEs[fileType],
         'Content-Encoding': 'base64',
         'x-amz-acl': 'public-read',
       },
     });
+
     // return the url and filename on server to the uploaded file.
-    return { url: putResponse.url, uploadedFileName: fileUploadAttributes.fileName };
+    return { url: uploadUrl, uploadedFileName: fileUploadAttributes.fileName };
   } catch (error) {
     console.error('Axios error while uploading file:', error);
     return { error: true, message: error.message, ...error.response };

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -66,10 +66,15 @@ export const uploadFile = async ({
         'x-amz-acl': 'public-read',
       },
     });
+
+    if (!putResponse.ok) {
+      throw new Error(`${putResponse.status} ${putResponse.statusText}`);
+    }
+
     // return the url and filename on server to the uploaded file.
     return { url: putResponse.url, uploadedFileName: fileUploadAttributes.fileName };
   } catch (error) {
-    console.error('Axios error while uploading file:', error);
+    console.error('Error while uploading file:', error);
     return { error: true, message: error.message, ...error.response };
   }
 };


### PR DESCRIPTION
## Explain the changes you’ve made

Handle http errors for uploading files.


## Explain why these changes are made

Errors during part of the file upload were not handling, which could cause the "upload" to be marked as successful without any files being uploaded.

## Explain your solution

Check the `putResponse.ok` value and throw an error if it's not ok.

## How to test the changes?

1. Checkout this branch
2. Perform any action that requires uploading a file (like stickprovskontroll)
3. File should be uploaded successfully
4. On failure, a "retry" dialog should pop-up (see screenshot).
    * suggestion: test failure by manually changing the url to something invalid, like `uploadUrl + "a"`


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.


## Screenshots

![sim_error_dialog](https://user-images.githubusercontent.com/81566071/116261052-90f73900-a777-11eb-9f94-32b238c36d50.png)

