### PR TITLE
feat: show env vars on dev features screen

### DIFF
--- a/source/screens/DevFeaturesScreen.js
+++ b/source/screens/DevFeaturesScreen.js
@@ -4,6 +4,7 @@ import { CaseDispatch } from 'app/store/CaseContext';
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import styled from 'styled-components/native';
+import env from 'react-native-config';
 import { Button, Text } from '../components/atoms';
 import Header from '../components/molecules/Header';
 import ScreenWrapper from '../components/molecules/ScreenWrapper';
@@ -71,6 +72,19 @@ const DeveloperScreen = (props) => {
           >
             <Text>Tillbaka</Text>
           </Button>
+        </FieldWrapper>
+
+        <FieldWrapper>
+          {Object.keys(env)
+            .filter((key) => typeof env[key] !== typeof Object)
+            .map((key) => (
+              <FieldWrapper key={key}>
+                <Text>
+                  {key} ({typeof env[key]})
+                </Text>
+                <Text>{JSON.stringify(env[key])}</Text>
+              </FieldWrapper>
+            ))}
         </FieldWrapper>
       </Container>
     </ScreenWrapper>


### PR DESCRIPTION
## Explain the changes you’ve made

Added fields showing all current environment variables and values from `.env` to the developer features screen.


## Explain why these changes are made

It can be difficult to debug which environment is actually in use for a build. This helps to debug the environment and environment-related issues.

## Explain your solution

In `DevFeaturesScreen`, added a loop of the `env` object (from `react-native-config`) keys to print each key and it's value (stringified). Excludes Object-type values (should only show primitives).


## How to test the changes?

1. Checkout this branch
2. Go to the developer features screen
3. Scroll down and the current environment variables should be listed


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.


## Screenshots (optional)

![dev_env_vars](https://user-images.githubusercontent.com/81566071/116264152-59d65700-a77a-11eb-8a0f-d8a8e3713a61.png)

