### PR TITLE
Fix/ios12 image picker

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '14.2'
+platform :ios, '12.4'
 
 target 'MittHelsingborg' do
   config = use_native_modules!
@@ -28,7 +28,7 @@ target 'MittHelsingborg' do
         t.remove_from_project
       else
         t.build_configurations.each do |config|
-          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.2'
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.4'
         end
       end
     end

--- a/jestSetupFile.js
+++ b/jestSetupFile.js
@@ -42,15 +42,6 @@ jest.mock('react-native-reanimated', () => {
 jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');
 
 /**
- * Mock react-native-image-picker
- */
-NativeModules.ImagePickerManager = {
-  showImagePicker: jest.fn(),
-  launchCamera: jest.fn(),
-  launchImageLibrary: jest.fn(),
-};
-
-/**
  * Mock react-native datetimepicker
  */
 NativeModules.RNDateTimePickerManager = {};

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-native-gesture-handler": "^1.9.0",
     "react-native-image-crop-picker": "^0.35.2",
     "react-native-image-pan-zoom": "^2.1.12",
-    "react-native-image-picker": "^3.2.1",
     "react-native-keyboard-aware-scroll-view": "^0.9.3",
     "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-modal": "^11.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10713,11 +10713,6 @@ react-native-image-pan-zoom@^2.1.12:
   resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
   integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
 
-react-native-image-picker@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-3.2.1.tgz#97119ffef0ac2de2862f61ac38c2f5af99e9de18"
-  integrity sha512-nOBZzYGmE5qZ8JBCvhWHQA+umYnQ8Jd3HGmgxBnmi0/82mU2nwCCnrzHsb29Q+DD7YasYr64rm8uWBBow8L5Fw==
-
 react-native-iphone-x-helper@^1.0.3, react-native-iphone-x-helper@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
@@ -10812,9 +10807,9 @@ react-native-safe-area-context@^3.1.9:
   integrity sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==
 
 react-native-screens@^2.16.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.17.1.tgz#c3c0ac750af48741c5b1635511e6af2a27b74309"
-  integrity sha512-B4gD5e4csvlVwlhf+RNqjQZ9mHTwe/iL3rXondgZxnKz4oW0QAmtLnLRKOrYVxoaJaF9Fy7jhjo//24/472APQ==
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.18.1.tgz#47b9991c6f762d00d0ed3233e5283d523e859885"
+  integrity sha512-r5WZLpmx2hHjC1RgMdPq5YpSU9tEhBpUaZ5M1SUtNIONyiLqQVxabhRCINdebIk4depJiIl7yw2Q85zJyeX6fw==
 
 react-native-size-matters@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
## Explain the changes you’ve made

Removed unused image library and changed deployment target from 14.2 to 12.4 in pod build settings.

## Explain why these changes are made

Library react-native-image-crop-picker could not be built for iOS 12 (minimum requirement for project).

## Explain your solution

Updated pod script file with build target 12.

## How to test the changes?

Test in simulator with iOS 12.4, 13 and 14.
Application should behave as before, changes shall not effect behavior or functionality!

Set iOS in xCode by setting active schema. 
Ex iPhone 8 with iOS 12.4:
![sh](https://user-images.githubusercontent.com/186287/117299367-c20ef200-ae78-11eb-9ce9-eef131db3c40.png)


## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.

