### PR TITLE
Fix/login and boundary error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-native-config": "1.4.0",
     "react-native-document-picker": "^5.0.0",
     "react-native-elements": "^3.0.0-alpha.1",
-    "react-native-exception-handler": "^2.10.9",
+    "react-native-exception-handler": "^2.10.10",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.9.0",
     "react-native-image-crop-picker": "^0.35.2",

--- a/source/helpers/error-handler/ErrorHandler.tsx
+++ b/source/helpers/error-handler/ErrorHandler.tsx
@@ -37,8 +37,6 @@ const boundaryErrorHandler = (error: undefined | string | Error, isFatal: boolea
     // non-fatal errors go here
     // they are probably already logged to console so no need to log them again
   }
-
-  // TODO: send error to analytics
 };
 
 export default boundaryErrorHandler;

--- a/source/helpers/error-handler/ErrorHandler.tsx
+++ b/source/helpers/error-handler/ErrorHandler.tsx
@@ -9,21 +9,36 @@ import { string } from 'prop-types';
  * (run-xxx --configuration Release).
  * Set .env flag "ENABLE_DEV_ERROR_BOUNDARY=true" to enable boundary errors in dev mode (non release builds of app).
  *
- * @param error Object with error message
+ * Non-fatal errors are triggered by `console.error` calls.
+ * Fatal errors are triggered by unhandled exceptions, and can also be triggered manually with `ErrorUtils.reportFatalError`.
+ *
+ * @param error Error object or error message string
+ * @param isFatal True if error is deemed fatal and cannot be recovered from
  */
-const boundaryErrorHandler = (error = { message: string }) => {
-  if (Config.IS_STORYBOOK === 'true') {
-    Alert.alert('Something went wrong in storybook', `${error.message}`, [{ text: 'OK' }]);
-  } else {
-    Alert.alert('Something went wrong in Mitt Helsingborg', `${error.message}`, [
-      {
-        text: 'Restart',
-        onPress: () => {
-          RNRestart.Restart();
+const boundaryErrorHandler = (error: undefined | string | Error, isFatal: boolean) => {
+  const errorMessage = typeof error === 'string' ? error : error?.message || 'unknown error';
+
+  if (error && isFatal) {
+    console.log('boundary error', typeof error, error);
+
+    if (Config.IS_STORYBOOK === 'true') {
+      Alert.alert('Something went wrong in storybook', `${errorMessage}`, [{ text: 'OK' }]);
+    } else {
+      Alert.alert('Something went wrong in Mitt Helsingborg', `${errorMessage}`, [
+        {
+          text: 'Restart',
+          onPress: () => {
+            RNRestart.Restart();
+          },
         },
-      },
-    ]);
+      ]);
+    }
+  } else {
+    // non-fatal errors go here
+    // they are probably already logged to console so no need to log them again
   }
+
+  // TODO: send error to analytics
 };
 
 export default boundaryErrorHandler;

--- a/source/services/BankidService.js
+++ b/source/services/BankidService.js
@@ -57,6 +57,9 @@ async function auth(ssn) {
     if (response.status === 400) {
       return await auth(ssn);
     }
+    if (response.status !== 200) {
+      throw new Error(response.message);
+    }
     return { success: true, data: response.data.data.attributes };
   } catch (error) {
     console.error(`BankID Auth Error: ${error}`);

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -140,7 +140,7 @@ export async function startAuth(ssn, launchBankidApp) {
     return {
       type: actionTypes.authError,
       payload: {
-        error: error.data,
+        error,
       },
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10672,10 +10672,10 @@ react-native-elements@^3.0.0-alpha.1:
     react-native-safe-area-context "^3.1.9"
     react-native-size-matters "^0.3.1"
 
-react-native-exception-handler@^2.10.9:
-  version "2.10.9"
-  resolved "https://registry.yarnpkg.com/react-native-exception-handler/-/react-native-exception-handler-2.10.9.tgz#4935a9e106b02ebecc729bfaac8ac8e6b0340781"
-  integrity sha512-V1SJWHzhGUnFWTQKK5dk9yz+Ybkl1wSFWgY6saPkZomYiB9120FdeejJ5NdAio1sH75+op9RpC1w9KbHg+1zFA==
+react-native-exception-handler@^2.10.10:
+  version "2.10.10"
+  resolved "https://registry.yarnpkg.com/react-native-exception-handler/-/react-native-exception-handler-2.10.10.tgz#b6bfe2b7e6ea4a4deb1f518f48ce2ee1d4843497"
+  integrity sha512-otAXGoZDl1689OoUJWN/rXxVbdoZ3xcmyF1uq/CsizdLwwyZqVGd6d+p/vbYvnF996FfEyAEBnHrdFxulTn51w==
 
 react-native-fit-image@^1.5.5:
   version "1.5.5"


### PR DESCRIPTION
## Explain the changes you’ve made
* Upgraded react-native-exception-handler to 2.10.10 (one patch level bump)
* Set bankid auth to throw on non-200 statuses
* Fix incorrect property used as state error payload data for auth action
* Fixed incorrect typescript syntax on boundary error handler
* Changed boundary error handler to only show alerts (and prompt restart) on fatal errors

## Explain why these changes are made
* Upgrading react-native-exception-handler changes so it does not silence `console.error` messages, and correctly pipes the message to the handler.
* Throwing on non-200 statuses for auth correctly bubbles up an error to the UI layer instead of cryptically failing later on due to `undefined` being accessed.
* Previously incorrect error payload evaluated to `undefined`, causing the ui state to see no error (since `undefined` means no error).
* Previous boundary error handler function signature specified the parameter to _default_ to the value, not use it as the type structure (`=` vs `:`), meaning for calls where `error` is undefined (which it was for `console.error` in the previous `react-native-exception-handler` version), it would default to (`{ message: string }`), thus accessing `error.message` would result in garbage such as printing the inner function of the PropTypes validator (see screenshots). Oddly, this was not caught by RN/intellisense, as using types as value is not valid.
* Previously all non-fatal errors (e.g. `console.error` calls) would result in an alert box prompting to restart the app. This is now changed to only show for fatal errors (e.g. uncaught exceptions), since in many placed we call `console.error` only for developers to see, and then handle the error internally (such as logging and handling login errors).

## Explain your solution
* `react-native-exception-handler` was updated with `yarn add react-native-exception-handler`.
* Rewritten `boundaryErrorHandler` in [ErrorHandler.tsx](source/helpers/error-handler/ErrorHandler.tsx) to fix new syntax error and switch alert on nonFatal errors.
* The rest is fairly minimal code changes and additions to [BankidService.js](source/services/BankidService.js) and [AuthActions](source/store/actions/AuthActions.js).

## How to test the changes?
1. Checkout this branch.
2. Do `yarn install`.
3. Build and run.
4. Simulate server error (for example by using an invalid API key to get 403 server errors).
5. Attempt to login.
6. Verify the app does not prompt to restart but instead shows a general error message and allows you to retry.
7. Simulate a fatal error (for example by adding `global.ErrorUtils.reportFatalError(new Error('Fatal test'));` as the first line of `handleLogin` in [LoginScreen.js](source/screens/LoginScreen.js) and attempt to login).
8. Verify that an alert shows with the error message and prompts you to restart.
9. Verify restart works.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
How it looked previously (the actual error was a 500 status from the release API endpoint and had nothing to do with PropTypes):
![image](https://user-images.githubusercontent.com/81566071/118492811-b0530780-b720-11eb-8dc2-8f175b7651da.png)

How it looks after the changes (the bottom error message is only in dev mode):
![image](https://user-images.githubusercontent.com/81566071/118492705-91547580-b720-11eb-9ce7-41d60c5a8eb8.png)
