### PR TITLE
fix: 🐛 display reduction correct

### DIFF
--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -479,18 +479,28 @@ const CaseSummary = (props) => {
                         )}
 
                         <Card.DetailsTitle type="h5">Reducering</Card.DetailsTitle>
-
                         {calculation?.reductions?.reduction ? (
                           <>
-                            <Card.CalculationRow>
-                              <Card.CalculationRowCell>
-                                <Text>{calculation.reductions.reduction}</Text>
-                              </Card.CalculationRowCell>
-                              <Card.CalculationRowCell />
-                              <Card.CalculationRowCell>
-                                <Text>{formatAmount(calculation.reductions.reduction.amount)}</Text>
-                              </Card.CalculationRowCell>
-                            </Card.CalculationRow>
+                            {convertDataToArray(calculation?.reductions?.reduction).map(
+                              (reduction, index) => (
+                                <Card.CalculationRow key={`${index}-${reduction.type}`}>
+                                  <Card.CalculationRowCell>
+                                    <Text>{reduction?.type}</Text>
+                                  </Card.CalculationRowCell>
+                                  <Card.CalculationRowCell>
+                                    <Text>
+                                      {reduction?.days} {reduction?.days > 1 ? 'dagar' : 'dag'}
+                                    </Text>
+                                  </Card.CalculationRowCell>
+                                  <Card.CalculationRowCell>
+                                    <Text>{reduction?.note}</Text>
+                                  </Card.CalculationRowCell>
+                                  <Card.CalculationRowCell>
+                                    <Text>{formatAmount(reduction.amount)}</Text>
+                                  </Card.CalculationRowCell>
+                                </Card.CalculationRow>
+                              )
+                            )}
                           </>
                         ) : (
                           <Card.Text italic>Det finns inga registrerade reduceringar.</Card.Text>


### PR DESCRIPTION
Reductions can be one or more.
Added all attributes on the reduction object

Read more in Clickup

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.