### PR TITLE
Feat/co applicant case overview cu kq7evx

### DIFF
--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -227,7 +227,7 @@ function CaseOverview(props) {
 
       await Promise.all(updateCaseItemsPromises).then((updatedItems) => {
         const flattenedList = updatedItems.flat();
-        flattenedList.sort((a, b) => b.updatedAt - a.updatedAt);
+        flattenedList.sort((caseA, caseB) => caseB.updatedAt - caseA.updatedAt);
         setCaseItems(flattenedList);
         setIsLoading(false);
       });

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -227,7 +227,7 @@ function CaseOverview(props) {
 
       await Promise.all(updateCaseItemsPromises).then((updatedItems) => {
         const flattenedList = updatedItems.flat();
-        flattenedList.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+        flattenedList.sort((a, b) => b.updatedAt - a.updatedAt);
         setCaseItems(flattenedList);
         setIsLoading(false);
       });

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -100,11 +100,11 @@ const computeCaseCardComponent = (
   navigation,
   toggleModal
 ) => {
-  const { status, details: { period: { endDate } = {} } = {} } = caseData;
   const {
     currentPosition: { currentMainStep: currentStep },
   } = caseData.forms[caseData.currentFormId];
   const {
+    status,
     details: {
       period = {},
       workflow: { decision = {}, payments = {}, application = {} } = {},
@@ -215,7 +215,7 @@ const CaseSummary = (props) => {
   const {
     details: {
       administrators,
-      workflow: { decision = {}, payments = {}, calculations = {}, journals = {} } = {},
+      workflow: { decision = {}, calculations = {}, journals = {} } = {},
     } = {},
   } = caseData;
 
@@ -229,7 +229,6 @@ const CaseSummary = (props) => {
   const decisions = decision?.decisions?.decision
     ? convertDataToArray(decision.decisions.decision)
     : [];
-  const paymentsArray = payments?.payment ? convertDataToArray(payments?.payment) : [];
 
   useEffect(() => {
     const caseData = getCase(caseId);


### PR DESCRIPTION
## Explain the changes you’ve made

Added support for handling cases in overview (and summary) as co-applicant.

## Explain why these changes are made

Co-applicant cases needs to be handled slightly differently (notably co-applicant should currently be unable to edit a case). 

## Explain your solution

Compute `isCoApplicant` based on properties on the case, and use that to conditionally render the CTA button.

In order to know if we're the co-applicant, we pass down the logged-in user's `personalNumber` to `computeCaseCardComponent` to cross-check against the `persons` data on the case.

Very similar changes are made for both `caseOverview.js` and `caseSummary.js`.

## How to test the changes?

1. Checkout this branch
2. Verify that nothing is broken for an existing user/case.
3. Add persons data to a case and login as the co-applicant.
4. Verify that the co-applicant sees the case in the list but there is no CTA button.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

Overview:
![Simulator Screen Shot - iPhone 12 - 2021-06-09 at 15 10 58](https://user-images.githubusercontent.com/81566071/121360895-1a805600-c935-11eb-8f4d-6cb11b57e167.png)

Summary:
![Simulator Screen Shot - iPhone 12 - 2021-06-09 at 15 11 54](https://user-images.githubusercontent.com/81566071/121360951-25d38180-c935-11eb-980d-b52196ceb709.png)

## Anything else

Sample `persons` data on a case:

```json
"persons": [
    {
      "firstName": "Vera",
      "hasSigned": true,
      "lastName": "Toth",
      "personalNumber": "196001198685",
      "role": "applicant"
    },
    {
      "firstName": "Felix",
      "hasSigned": false,
      "lastName": "Persson",
      "personalNumber": "196912191118",
      "role": "coapplicant"
    }
  ],
```
