### PR TITLE
handle disabled input fields in editable list component

### DIFF
--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -158,6 +158,7 @@ InputComponent.propTypes = {
     type: PropTypes.string.isRequired,
     items: PropTypes.array,
     inputSelectValue: PropTypes.string,
+    disabled: PropTypes.bool,
   }),
   colorSchema: PropTypes.oneOf(['red', 'blue', 'green', 'purple', 'neutral']),
   editable: PropTypes.bool,
@@ -241,7 +242,7 @@ function EditableList({
         {inputs.map((input, index) => [
           <EditableListItem
             colorSchema={colorSchema}
-            editable={editable}
+            editable={editable && !input.disabled}
             key={`${input.key}-${index}`}
             error={error ? error[input.key] : undefined}
             activeOpacity={1.0}
@@ -252,7 +253,8 @@ function EditableList({
             </EditableListItemLabelWrapper>
             <EditableListItemInputWrapper>
               <InputComponent
-                {...{ input, colorSchema, editable, onChange, onInputBlur, value, state }}
+                {...{ input, colorSchema, onChange, onInputBlur, value, state }}
+                editable={editable && !input.disabled}
                 ref={(el) => {
                   inputRefs.current[index] = el;
                 }}


### PR DESCRIPTION
## Explain the changes you’ve made

Fix to handle disabled inputs in editable list component. 

## How to test the changes?

Run storybook and navigate to Editable list component.
Add "disabled: true" prop to any input field in the story (EditableList.stories.js).
The input field should now be disabled. 

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

<img width="384" alt="Screenshot 2021-06-28 at 09 05 57" src="https://user-images.githubusercontent.com/21363149/123594557-25216300-d7f0-11eb-9c13-edb2dd8b0066.png">

<img width="381" alt="Screenshot 2021-06-28 at 09 06 05" src="https://user-images.githubusercontent.com/21363149/123594568-294d8080-d7f0-11eb-9859-cdb9e56033b2.png">
