### PR TITLE
Feat/create symmetric key

### DIFF
--- a/jestSetupFile.js
+++ b/jestSetupFile.js
@@ -39,7 +39,7 @@ jest.mock('react-native-reanimated', () => {
 /**
  * Mock NativeAnimatedHelper
  */
-jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 
 /**
  * Mock react-native datetimepicker

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "typescript": "^4.1.2"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "setupFiles": ["./jestSetupFile.js"]
   }
 }

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -24,7 +24,7 @@ export async function storeSymmetricKey(symmetricKey, forms) {
   await StorageService.saveData(storageKeyword, symmetricKey.toString());
 }
 
-// Prof of concept, will be replaced with elliptic curves.
+// Prof of concept, will be replaced with Diffie-Hellman library.
 export function getPseudoKey(G, privateKey, P) {
   if (privateKey === 1) {
     return G;
@@ -37,4 +37,15 @@ export function getPseudoRandomInteger() {
   const min = 1;
   const max = 10;
   return Math.floor(min + Math.random() * (max - min));
+}
+
+export async function createAndStorePrivateKey(user, forms) {
+  const privateKey = getPseudoRandomInteger();
+
+  await StorageService.saveData(
+    `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`,
+    JSON.stringify({ privateKey })
+  );
+
+  return privateKey;
 }

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -54,6 +54,7 @@ export function getPseudoKey(G: number, privateKey: number, P: number) {
   return G ** privateKey % P;
 }
 
+// Prof of concept, will be replaced by encryption library.
 export function getPseudoRandomInteger() {
   const min = 1;
   const max = 10;

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -45,7 +45,7 @@ export async function storeSymmetricKey(symmetricKey: number, forms: FormsInterf
   await StorageService.saveData(storageKeyword, symmetricKey.toString());
 }
 
-// Prof of concept, will be replaced with Diffie-Hellman library.
+// Proof of concept, will be replaced with Diffie-Hellman library.
 export function getPseudoKey(G: number, privateKey: number, P: number) {
   if (privateKey === 1) {
     return G;
@@ -54,7 +54,7 @@ export function getPseudoKey(G: number, privateKey: number, P: number) {
   return G ** privateKey % P;
 }
 
-// Prof of concept, will be replaced by encryption library.
+// Proof of concept, will be replaced by encryption library.
 export function getPseudoRandomInteger() {
   const min = 1;
   const max = 10;

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -13,3 +13,23 @@ export async function getStoredSymmetricKey(symmetricKeyName) {
   const symmetricKey = await StorageService.getData(symmetricKeyName);
   return Number(symmetricKey);
 }
+
+export async function storeSymmetricKey(symmetricKey, forms) {
+  const storageKeyword = getSymmetricKeyStorageKeyword(forms);
+  await StorageService.saveData(storageKeyword, symmetricKey.toString());
+}
+
+// Prof of concept, will be replaced with elliptic curves.
+export function getPseudoKey(G, privateKey, P) {
+  if (privateKey === 1) {
+    return G;
+  }
+
+  return G ** privateKey % P;
+}
+
+export function getPseudoRandomInteger() {
+  const min = 1;
+  const max = 10;
+  return Math.floor(min + Math.random() * (max - min));
+}

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -1,0 +1,15 @@
+import StorageService from '../StorageService';
+
+export function EncryptionException(message: string) {
+  this.message = message;
+  this.name = 'EncryptionException';
+}
+
+export function getPublicKeyInForm(personalNumber, forms) {
+  return forms.encryption.publicKey.publicKeys[personalNumber];
+}
+
+export async function getStoredSymmetricKey(symmetricKeyName) {
+  const symmetricKey = await StorageService.getData(symmetricKeyName);
+  return Number(symmetricKey);
+}

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -1,31 +1,48 @@
 import StorageService from '../StorageService';
 
+export interface UserInterface {
+  personalNumber: string;
+}
+
+export interface FormsInterface {
+  answers: { encryptedAnswers: string };
+  encryption: {
+    type: string;
+    publicKey: {
+      P: number;
+      G: number;
+      symmetricKeyName: string;
+      publicKeys: Record<number, undefined | string>;
+    };
+  };
+}
+
 export function EncryptionException(message: string) {
   this.message = message;
   this.name = 'EncryptionException';
 }
 
-export function getPublicKeyInForm(personalNumber, forms) {
+export function getPublicKeyInForm(personalNumber: number, forms: FormsInterface) {
   return forms.encryption.publicKey.publicKeys[personalNumber];
 }
 
-function getSymmetricKeyStorageKeyword(forms) {
+function getSymmetricKeyStorageKeyword(forms: FormsInterface) {
   return `${forms.encryption.publicKey.symmetricKeyName}`;
 }
 
-export async function getStoredSymmetricKey(forms) {
+export async function getStoredSymmetricKey(forms: FormsInterface) {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   const symmetricKey = await StorageService.getData(storageKeyword);
   return Number(symmetricKey);
 }
 
-export async function storeSymmetricKey(symmetricKey, forms) {
+export async function storeSymmetricKey(symmetricKey: number, forms: FormsInterface) {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   await StorageService.saveData(storageKeyword, symmetricKey.toString());
 }
 
 // Prof of concept, will be replaced with Diffie-Hellman library.
-export function getPseudoKey(G, privateKey, P) {
+export function getPseudoKey(G: number, privateKey: number, P: number) {
   if (privateKey === 1) {
     return G;
   }
@@ -39,7 +56,7 @@ export function getPseudoRandomInteger() {
   return Math.floor(min + Math.random() * (max - min));
 }
 
-export async function createAndStorePrivateKey(user, forms) {
+export async function createAndStorePrivateKey(user: UserInterface, forms: FormsInterface) {
   const privateKey = getPseudoRandomInteger();
 
   await StorageService.saveData(

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -9,8 +9,13 @@ export function getPublicKeyInForm(personalNumber, forms) {
   return forms.encryption.publicKey.publicKeys[personalNumber];
 }
 
-export async function getStoredSymmetricKey(symmetricKeyName) {
-  const symmetricKey = await StorageService.getData(symmetricKeyName);
+function getSymmetricKeyStorageKeyword(forms) {
+  return `${forms.encryption.publicKey.symmetricKeyName}`;
+}
+
+export async function getStoredSymmetricKey(forms) {
+  const storageKeyword = getSymmetricKeyStorageKeyword(forms);
+  const symmetricKey = await StorageService.getData(storageKeyword);
   return Number(symmetricKey);
 }
 

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -66,3 +66,16 @@ export async function createAndStorePrivateKey(user: UserInterface, forms: Forms
 
   return privateKey;
 }
+
+export async function generateSymmetricKey(
+  user: UserInterface,
+  forms: FormsInterface,
+  otherUserPublicKey
+) {
+  let ownPrivateKey = await StorageService.getData(
+    `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`
+  );
+  ownPrivateKey = JSON.parse(ownPrivateKey);
+
+  return getPseudoKey(otherUserPublicKey, ownPrivateKey.privateKey, forms.encryption.publicKey.P);
+}

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -22,7 +22,7 @@ export function EncryptionException(message: string) {
   this.name = 'EncryptionException';
 }
 
-export function getPublicKeyInForm(personalNumber: number, forms: FormsInterface) {
+export function getPublicKeyInForm(personalNumber: string, forms: FormsInterface) {
   return forms.encryption.publicKey.publicKeys[personalNumber];
 }
 

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -8,12 +8,12 @@ export interface FormsInterface {
   answers: { encryptedAnswers: string };
   encryption: {
     type: string;
-    publicKey: {
+    symmetricKeyName: string;
+    primes: {
       P: number;
       G: number;
-      symmetricKeyName: string;
-      publicKeys: Record<number, undefined | string>;
     };
+    publicKeys: Record<number, undefined | string>;
   };
 }
 
@@ -23,15 +23,15 @@ export function EncryptionException(message: string) {
 }
 
 export function getPublicKeyInForm(personalNumber: string, forms: FormsInterface) {
-  return forms.encryption.publicKey.publicKeys[personalNumber];
+  return forms.encryption.publicKeys[personalNumber];
 }
 
 function getSymmetricKeyStorageKeyword(forms: FormsInterface) {
-  return forms.encryption.publicKey.symmetricKeyName;
+  return forms.encryption.symmetricKeyName;
 }
 
 function getPrivateKeyStorageKeyword(user: UserInterface, forms: FormsInterface) {
-  return `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`;
+  return `aesPrivateKey${user.personalNumber}${forms.encryption.symmetricKeyName}`;
 }
 
 export async function getStoredSymmetricKey(forms: FormsInterface) {
@@ -80,5 +80,5 @@ export async function generateSymmetricKey(
   let ownPrivateKey = await StorageService.getData(getPrivateKeyStorageKeyword(user, forms));
   ownPrivateKey = JSON.parse(ownPrivateKey);
 
-  return getPseudoKey(otherUserPublicKey, ownPrivateKey.privateKey, forms.encryption.publicKey.P);
+  return getPseudoKey(otherUserPublicKey, ownPrivateKey.privateKey, forms.encryption.primes.P);
 }

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -30,6 +30,10 @@ function getSymmetricKeyStorageKeyword(forms: FormsInterface) {
   return forms.encryption.publicKey.symmetricKeyName;
 }
 
+function getPrivateKeyStorageKeyword(user: UserInterface, forms: FormsInterface) {
+  return `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`;
+}
+
 export async function getStoredSymmetricKey(forms: FormsInterface) {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   const symmetricKey = await StorageService.getData(storageKeyword);
@@ -60,7 +64,7 @@ export async function createAndStorePrivateKey(user: UserInterface, forms: Forms
   const privateKey = getPseudoRandomInteger();
 
   await StorageService.saveData(
-    `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`,
+    getPrivateKeyStorageKeyword(user, forms),
     JSON.stringify({ privateKey })
   );
 
@@ -72,9 +76,7 @@ export async function generateSymmetricKey(
   forms: FormsInterface,
   otherUserPublicKey: number
 ) {
-  let ownPrivateKey = await StorageService.getData(
-    `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`
-  );
+  let ownPrivateKey = await StorageService.getData(getPrivateKeyStorageKeyword(user, forms));
   ownPrivateKey = JSON.parse(ownPrivateKey);
 
   return getPseudoKey(otherUserPublicKey, ownPrivateKey.privateKey, forms.encryption.publicKey.P);

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -70,7 +70,7 @@ export async function createAndStorePrivateKey(user: UserInterface, forms: Forms
 export async function generateSymmetricKey(
   user: UserInterface,
   forms: FormsInterface,
-  otherUserPublicKey
+  otherUserPublicKey: number
 ) {
   let ownPrivateKey = await StorageService.getData(
     `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -27,7 +27,7 @@ export function getPublicKeyInForm(personalNumber: string, forms: FormsInterface
 }
 
 function getSymmetricKeyStorageKeyword(forms: FormsInterface) {
-  return `${forms.encryption.publicKey.symmetricKeyName}`;
+  return forms.encryption.publicKey.symmetricKeyName;
 }
 
 export async function getStoredSymmetricKey(forms: FormsInterface) {

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -110,7 +110,7 @@ storiesOf('EncryptionService', module).add('Terminal demo', (props) => (
       </Flex>
       <Flex>
         <Button block variant="outlined" colorSchema="blue" onClick={testSymmetricKeySetup}>
-          <Text>Encrypt and decrypt Form answers</Text>
+          <Text>Run symmetric key demo</Text>
         </Button>
       </Flex>
     </FlexContainer>

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -48,7 +48,7 @@ const runTerminalDemo = () => {
 const printPublicKeyResult = (user, form) => {
   console.log(
     `Updated user ${user.personalNumber} public key: ${
-      form.encryption.publicKey.publicKeys[user.personalNumber]
+      form.encryption.publicKeys[user.personalNumber]
     }`
   );
 };
@@ -68,14 +68,14 @@ const testSymmetricKeySetup = async () => {
     answers: { encryptedAnswers: 'This string will be encrypted' },
     encryption: {
       type: 'decrypted',
-      publicKey: {
+      symmetricKeyName: '196912191118:198310011906',
+      primes: {
         P: 43,
         G: 10,
-        symmetricKeyName: '196912191118:198310011906',
-        publicKeys: {
-          196912191118: undefined,
-          198310011906: undefined,
-        },
+      },
+      publicKeys: {
+        196912191118: undefined,
+        198310011906: undefined,
       },
     },
     currentFormId: '01',

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -10,8 +10,15 @@ interface User {
 
 interface Forms {
   answers: { encryptedAnswers: string };
-  encryption: { type: string };
-  currentFormId: string;
+  encryption: {
+    type: string;
+    publicKey: {
+      P: number;
+      G: number;
+      symmetricKeyName: string;
+      publicKeys: Record<number, undefined | string>;
+    };
+  };
 }
 
 function EncryptionException(message: string) {

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -3,13 +3,14 @@ import { NativeModules } from 'react-native';
 import StorageService from '../StorageService';
 
 import {
+  FormsInterface,
+  UserInterface,
   getPseudoKey,
   EncryptionException,
   getPublicKeyInForm,
   storeSymmetricKey,
   createAndStorePrivateKey,
-  FormsInterface,
-  UserInterface,
+  generateSymmetricKey,
 } from './EncryptionHelper';
 
 const { Aes } = NativeModules;
@@ -96,17 +97,7 @@ export async function setupSymmetricKey(user, forms) {
   }
 
   if (typeof ownPublicKey !== 'undefined' && typeof otherUserPublicKey !== 'undefined') {
-    // Generate symmetric key.
-    let ownPrivateKey = await StorageService.getData(
-      `aesPrivateKey${user.personalNumber}${forms.encryption.publicKey.symmetricKeyName}`
-    );
-    ownPrivateKey = JSON.parse(ownPrivateKey);
-
-    const gotSymmetricKey = getPseudoKey(
-      otherUserPublicKey,
-      ownPrivateKey.privateKey,
-      forms.encryption.publicKey.P
-    );
+    const gotSymmetricKey = await generateSymmetricKey(user, forms, otherUserPublicKey);
 
     await storeSymmetricKey(gotSymmetricKey, forms);
   }

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -2,6 +2,14 @@ import { NativeModules } from 'react-native';
 
 import StorageService from '../StorageService';
 
+import {
+  getPseudoKey,
+  EncryptionException,
+  getPublicKeyInForm,
+  storeSymmetricKey,
+  createAndStorePrivateKey,
+} from './EncryptionHelper';
+
 const { Aes } = NativeModules;
 
 interface User {

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -86,7 +86,7 @@ export async function setupSymmetricKey(user, forms) {
 
   if (!ownPublicKey) {
     const privateKey = await createAndStorePrivateKey(user, forms);
-    ownPublicKey = await getPseudoKey(
+    ownPublicKey = getPseudoKey(
       forms.encryption.publicKey.G,
       privateKey,
       forms.encryption.publicKey.P

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -58,15 +58,12 @@ export async function encryptFormAnswers(user: User, forms: Forms) {
   const encryptedAnswers = await encryptWithAesKey(user, JSON.stringify(forms.answers));
 
   forms.answers = { encryptedAnswers };
-  forms.encryption = {
-    ...forms.encryption,
-    type: 'privateAesKey',
-  };
+  forms.encryption.type = 'privateAesKey';
 
   return forms;
 }
 
-async function decryptWithAesKey(user: User, cipher: string): Promise<string> {
+export async function decryptWithAesKey(user: User, cipher: string): Promise<string> {
   const storageKey = `${user.personalNumber}AesKey`;
   const aesEncryptor = await StorageService.getData(storageKey);
 

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -38,7 +38,7 @@ async function generateAesKey(
   return Aes.pbkdf2(password, salt, cost, length);
 }
 
-async function encryptWithAesKey(user: User, text: string): Promise<string> {
+export async function encryptWithAesKey(user: User, text: string): Promise<string> {
   const storageKeyword = `${user.personalNumber}AesKey`;
 
   let aesEncryptor = await StorageService.getData(storageKeyword);

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -29,11 +29,6 @@ interface Forms {
   };
 }
 
-function EncryptionException(message: string) {
-  this.message = message;
-  this.name = 'EncryptionException';
-}
-
 async function generateAesKey(
   password: string,
   salt: string,

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -81,7 +81,7 @@ export async function setupSymmetricKey(user: UserInterface, forms: FormsInterfa
   // Ugly deep copy of forms.
   const formsCopy = JSON.parse(JSON.stringify(forms));
 
-  const otherUserPersonalNumber = Object.keys(formsCopy.encryption.publicKey.publicKeys).filter(
+  const otherUserPersonalNumber = Object.keys(formsCopy.encryption.publicKeys).filter(
     (key) => key !== user.personalNumber
   )[0];
 
@@ -91,12 +91,12 @@ export async function setupSymmetricKey(user: UserInterface, forms: FormsInterfa
   if (!ownPublicKey) {
     const privateKey = await createAndStorePrivateKey(user, formsCopy);
     ownPublicKey = getPseudoKey(
-      formsCopy.encryption.publicKey.G,
+      formsCopy.encryption.primes.G,
       privateKey,
-      formsCopy.encryption.publicKey.P
+      formsCopy.encryption.primes.P
     );
 
-    formsCopy.encryption.publicKey.publicKeys[user.personalNumber] = ownPublicKey;
+    formsCopy.encryption.publicKeys[user.personalNumber] = ownPublicKey;
   }
 
   if (typeof ownPublicKey !== 'undefined' && typeof otherUserPublicKey !== 'undefined') {

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -58,7 +58,10 @@ export async function encryptFormAnswers(user: User, forms: Forms) {
   const encryptedAnswers = await encryptWithAesKey(user, JSON.stringify(forms.answers));
 
   forms.answers = { encryptedAnswers };
-  forms.encryption = { type: 'privateAesKey' };
+  forms.encryption = {
+    ...forms.encryption,
+    type: 'privateAesKey',
+  };
 
   return forms;
 }

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -77,7 +77,7 @@ export async function decryptFormAnswers(user: UserInterface, forms: FormsInterf
   }
 }
 
-export async function setupSymmetricKey(user, forms) {
+export async function setupSymmetricKey(user: UserInterface, forms: FormsInterface) {
   const otherUserPersonalNumber = Object.keys(forms.encryption.publicKey.publicKeys).filter(
     (key) => key !== user.personalNumber
   )[0];

--- a/source/services/encryption/index.js
+++ b/source/services/encryption/index.js
@@ -1,2 +1,5 @@
 export { encryptFormAnswers } from './EncryptionService';
 export { decryptFormAnswers } from './EncryptionService';
+export { encryptWithAesKey } from './EncryptionService';
+export { decryptWithAesKey } from './EncryptionService';
+export { setupSymmetricKey } from './EncryptionService';


### PR DESCRIPTION
## Explain the changes you’ve made

Added support for setting up a symmetric key. 

## Explain why these changes are made

To securely share case information between clients. See #n5fgkw for more information.

## Explain your solution

Using Diffie-Hellman model to generate a shared public key. The generated public key will be stored in the case.
A public key name shall be generated by API for keeping track of keys for users and cases in the event of multiple shared secrets between different users: User A shares secret X with user B, user A shares secret Y with user C, B and C shall not be able to read secret X and Y.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Swap the application to run storybook
3. Fire up the simulator by running the command "yarn ios"
4. Find story "EncryptionService / Terminal demo"
5. Run demo for symmetric key and follow the terminal logs.

## Was this feature tested in the following environments?
- [x] Storybook on a iOS device/simulator.
- [ ] Building the Application on a iOS device/simulator.
- [ ] Building the Application on a Android device/simulator.

## Anything else? (optional)

This PR is more of a prof of concept that implements necessary steps for setting up a shared key. Some of  the functions in EncryptionHelper.ts will be changed (ex. stronger implementation of a random key).
I'm hoping for a dissolution and imput on the implementation and storing of public keys in case and input on any better logic handling symmetric key name and public that are stored in the case.

