### PR TITLE
Bug/field focus

### DIFF
--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -75,6 +75,10 @@ const Select: React.FC<Props> = React.forwardRef(({
     }
   }
 
+  const handleOpen = () => {
+    if (onOpen) onOpen(undefined, true)
+  }
+
   return (
     <Wrapper style={style}>
       <RNPickerSelect
@@ -86,9 +90,7 @@ const Select: React.FC<Props> = React.forwardRef(({
         items={items}
         ref={ref as React.LegacyRef<RNPickerSelect>}
         doneText="Klar"
-        onOpen={() => {
-          if (onOpen) onOpen(undefined, true);
-        }}
+        onOpen={handleOpen}
       />
       {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
     </Wrapper>

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -42,6 +42,7 @@ interface Props {
   editable?: boolean;
   style?: ViewStyle;
   onBlur: (value: string) => void;
+  onOpen: () => void;
   showErrorMessage?: boolean;
   error?: { isValid: boolean; message: string };
 }
@@ -50,6 +51,7 @@ const Select: React.FC<Props> = React.forwardRef(({
   items,
   onValueChange,
   onBlur,
+  onOpen,
   placeholder,
   value,
   editable = true,
@@ -57,7 +59,7 @@ const Select: React.FC<Props> = React.forwardRef(({
   error,
   style,
 }, ref) => {
-
+  
   const currentItem = items.find(item => item.value === value);
   const handleValueChange = (itemValue: string | number | boolean) => {
     if (onValueChange && typeof onValueChange === 'function') {
@@ -84,6 +86,9 @@ const Select: React.FC<Props> = React.forwardRef(({
         items={items}
         ref={ref as React.LegacyRef<RNPickerSelect>}
         doneText="Klar"
+        onOpen={() => {
+          if (onOpen) onOpen();
+        }}
       />
       {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}
     </Wrapper>

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -42,7 +42,7 @@ interface Props {
   editable?: boolean;
   style?: ViewStyle;
   onBlur: (value: string) => void;
-  onOpen: () => void;
+  onOpen: (event: undefined, isSelect: true) => void;
   showErrorMessage?: boolean;
   error?: { isValid: boolean; message: string };
 }
@@ -59,7 +59,7 @@ const Select: React.FC<Props> = React.forwardRef(({
   error,
   style,
 }, ref) => {
-  
+
   const currentItem = items.find(item => item.value === value);
   const handleValueChange = (itemValue: string | number | boolean) => {
     if (onValueChange && typeof onValueChange === 'function') {
@@ -87,7 +87,7 @@ const Select: React.FC<Props> = React.forwardRef(({
         ref={ref as React.LegacyRef<RNPickerSelect>}
         doneText="Klar"
         onOpen={() => {
-          if (onOpen) onOpen();
+          if (onOpen) onOpen(undefined, true);
         }}
       />
       {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -220,10 +220,10 @@ function EditableList({
     if (onBlur) onBlur(state);
   };
 
-  const onInputFocus = (e, index) => {
+  const onInputFocus = (e, index, isSelect = false) => {
     if (onFocus) {
       const target = inputRefs.current[index].inputRef;
-      onFocus(e || { target });
+      onFocus(e || { target }, isSelect);
     }
   };
 
@@ -270,7 +270,7 @@ function EditableList({
                 ref={(el) => {
                   inputRefs.current[index] = el;
                 }}
-                onInputFocus={(e) => onInputFocus(e, index)}
+                onInputFocus={(e, isSelect) => onInputFocus(e, index, isSelect)}
               />
             </EditableListItemInputWrapper>
           </EditableListItem>,

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -130,7 +130,7 @@ const InputComponent = React.forwardRef(
         return (
           <EditableListItemSelect
             onBlur={onInputBlur}
-            onFocus={onInputFocus}
+            onOpen={onInputFocus}
             onValueChange={(value) => onChange(input.key, value)}
             value={value && value !== '' ? value[input.key] : state[input.key]}
             editable={editable}
@@ -220,9 +220,10 @@ function EditableList({
     if (onBlur) onBlur(state);
   };
 
-  const onInputFocus = (e) => {
+  const onInputFocus = (e, index) => {
     if (onFocus) {
-      onFocus(e);
+      const target = inputRefs.current[index].inputRef;
+      onFocus(e || { target });
     }
   };
 
@@ -264,11 +265,12 @@ function EditableList({
             </EditableListItemLabelWrapper>
             <EditableListItemInputWrapper>
               <InputComponent
-                {...{ input, colorSchema, onChange, onInputBlur, onInputFocus, value, state }}
+                {...{ input, colorSchema, onChange, onInputBlur, value, state }}
                 editable={editable && !input.disabled}
                 ref={(el) => {
                   inputRefs.current[index] = el;
                 }}
+                onInputFocus={(e) => onInputFocus(e, index)}
               />
             </EditableListItemInputWrapper>
           </EditableListItem>,

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -98,7 +98,7 @@ const StyledErrorText = styled(Text)`
 
 /** Switch between different input types */
 const InputComponent = React.forwardRef(
-  ({ input, colorSchema, editable, onChange, onInputBlur, value, state }, ref) => {
+  ({ input, colorSchema, editable, onChange, onInputBlur, onInputFocus, value, state }, ref) => {
     switch (input.type) {
       case 'number':
         return (
@@ -107,6 +107,7 @@ const InputComponent = React.forwardRef(
             editable={editable}
             onChangeText={(text) => onChange(input.key, text)}
             onBlur={onInputBlur}
+            onFocus={onInputFocus}
             value={value && value !== '' ? value[input.key] : state[input.key]}
             keyboardType="numeric"
             transparent
@@ -120,6 +121,7 @@ const InputComponent = React.forwardRef(
             value={value && value !== '' ? value[input.key] : state[input.key]}
             onSelect={(date) => onChange(input.key, date)}
             onBlur={onInputBlur}
+            onFocus={onInputFocus}
             editable={editable}
             transparent
           />
@@ -128,6 +130,7 @@ const InputComponent = React.forwardRef(
         return (
           <EditableListItemSelect
             onBlur={onInputBlur}
+            onFocus={onInputFocus}
             onValueChange={(value) => onChange(input.key, value)}
             value={value && value !== '' ? value[input.key] : state[input.key]}
             editable={editable}
@@ -142,6 +145,7 @@ const InputComponent = React.forwardRef(
             editable={editable}
             onChangeText={(text) => onChange(input.key, text)}
             onBlur={onInputBlur}
+            onFocus={onInputFocus}
             value={value && value !== '' ? value[input.key] : state[input.key]}
             transparent
             inputType={input.inputSelectValue}
@@ -183,6 +187,7 @@ function EditableList({
   startEditable,
   help,
   error,
+  onFocus,
 }) {
   const [editable, setEditable] = useState(startEditable);
   const [state, setState] = useState(getInitialState(inputs, value));
@@ -213,6 +218,12 @@ function EditableList({
   };
   const onInputBlur = () => {
     if (onBlur) onBlur(state);
+  };
+
+  const onInputFocus = (e) => {
+    if (onFocus) {
+      onFocus(e);
+    }
   };
 
   const handleListItemPress = (index) => {
@@ -253,7 +264,7 @@ function EditableList({
             </EditableListItemLabelWrapper>
             <EditableListItemInputWrapper>
               <InputComponent
-                {...{ input, colorSchema, onChange, onInputBlur, value, state }}
+                {...{ input, colorSchema, onChange, onInputBlur, onInputFocus, value, state }}
                 editable={editable && !input.disabled}
                 ref={(el) => {
                   inputRefs.current[index] = el;
@@ -300,6 +311,7 @@ EditableList.propTypes = {
    * The color schema/theme of the component, default is blue.
    */
   colorSchema: PropTypes.oneOf(['blue', 'green', 'red', 'purple']),
+  onFocus: PropTypes.func,
 };
 
 EditableList.defaultProps = {

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Dimensions } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import styled from 'styled-components/native';
@@ -134,7 +134,7 @@ function Step({
       };
 
   const [returnScrollY, setReturnScrollY] = useState(0);
-  const scrollRef = React.useRef();
+  const scrollRef = useRef();
 
   const handleFocus = (e, isSelect = false) => {
     const scrollResponder = scrollRef.current.getScrollResponder();
@@ -146,11 +146,15 @@ function Step({
         keyboardHeight = scrollResponder.keyboardWillOpenTo.startCoordinates.height;
       }
 
-      setReturnScrollY(pageY + height);
+      const newReturnScrollY = pageY + height;
 
-      const scrollToY = pageY + height + keyboardHeight;
+      setReturnScrollY(newReturnScrollY);
 
-      if (isSelect) scrollResponder.props.scrollToPosition(0, scrollToY);
+      if (isSelect) {
+        const scrollToY = newReturnScrollY + keyboardHeight;
+
+        scrollResponder.props.scrollToPosition(0, scrollToY);
+      }
     });
   };
 
@@ -158,7 +162,7 @@ function Step({
     <StepContainer>
       <KeyboardAwareScrollView
         keyboardShouldPersistTaps="always"
-        resetScrollToCoords={(() => ({ x: 0, y: returnScrollY }))()}
+        resetScrollToCoords={{ x: 0, y: returnScrollY }}
         innerRef={(r) => (scrollRef.current = r)}
         enableAutomaticScroll
       >

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -133,11 +133,24 @@ function Step({
         formNavigation.back();
       };
 
-  const [returnScrollCoords, setReturnScrollCoords] = useState({ x: 0, y: 0 });
+  const [returnScrollY, setReturnScrollY] = useState(0);
+  const scrollRef = React.useRef();
 
   const handleFocus = (e) => {
-    e.target.measureInWindow((x, y) => {
-      setReturnScrollCoords({ x, y });
+    const scrollResponder = scrollRef.current.getScrollResponder();
+
+    e.target.measure((x, y, width, height, pageX, pageY) => {
+      let keyboardHeight = 0;
+
+      if (scrollResponder.keyboardWillOpenTo) {
+        keyboardHeight = scrollResponder.keyboardWillOpenTo.startCoordinates.height;
+      }
+
+      setReturnScrollY(pageY);
+
+      const scrollToY = pageY + height + keyboardHeight;
+
+      scrollResponder.props.scrollToPosition(0, scrollToY);
     });
   };
 
@@ -145,7 +158,9 @@ function Step({
     <StepContainer>
       <KeyboardAwareScrollView
         keyboardShouldPersistTaps="always"
-        resetScrollToCoords={(() => returnScrollCoords)()}
+        resetScrollToCoords={(() => ({ x: 0, y: returnScrollY }))()}
+        innerRef={(r) => (scrollRef.current = r)}
+        enableAutomaticScroll={false}
       >
         <FormDialog
           visible={dialogIsVisible}

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -85,6 +85,7 @@ function Step({
 
   const [dialogIsVisible, setDialogIsVisible] = useState(false);
   const [dialogTemplate, setDialogTemplate] = useState('mainStep');
+
   const dialogButtonProps = {
     mainStep: [
       {
@@ -132,9 +133,20 @@ function Step({
         formNavigation.back();
       };
 
+  const [returnScrollCoords, setReturnScrollCoords] = useState({ x: 0, y: 0 });
+
+  const handleFocus = (e) => {
+    e.target.measureInWindow((x, y) => {
+      setReturnScrollCoords({ x, y });
+    });
+  };
+
   return (
     <StepContainer>
-      <KeyboardAwareScrollView keyboardShouldPersistTaps="always">
+      <KeyboardAwareScrollView
+        keyboardShouldPersistTaps="always"
+        resetScrollToCoords={(() => returnScrollCoords)()}
+      >
         <FormDialog
           visible={dialogIsVisible}
           template={dialogTemplate}
@@ -177,6 +189,7 @@ function Step({
                       id={field.id}
                       formNavigation={formNavigation}
                       editable={!field.disabled}
+                      onFocus={handleFocus}
                       {...field}
                     />
                   ))}

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -136,7 +136,7 @@ function Step({
   const [returnScrollY, setReturnScrollY] = useState(0);
   const scrollRef = React.useRef();
 
-  const handleFocus = (e) => {
+  const handleFocus = (e, isSelect = false) => {
     const scrollResponder = scrollRef.current.getScrollResponder();
 
     e.target.measure((x, y, width, height, pageX, pageY) => {
@@ -146,11 +146,11 @@ function Step({
         keyboardHeight = scrollResponder.keyboardWillOpenTo.startCoordinates.height;
       }
 
-      setReturnScrollY(pageY);
+      setReturnScrollY(pageY + height);
 
       const scrollToY = pageY + height + keyboardHeight;
 
-      scrollResponder.props.scrollToPosition(0, scrollToY);
+      if (isSelect) scrollResponder.props.scrollToPosition(0, scrollToY);
     });
   };
 
@@ -160,7 +160,7 @@ function Step({
         keyboardShouldPersistTaps="always"
         resetScrollToCoords={(() => ({ x: 0, y: returnScrollY }))()}
         innerRef={(r) => (scrollRef.current = r)}
-        enableAutomaticScroll={false}
+        enableAutomaticScroll
       >
         <FormDialog
           visible={dialogIsVisible}

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, createRef, useRef } from 'react';
 import { InteractionManager, StatusBar } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Modal, useModal } from '../../components/molecules/Modal';
@@ -12,7 +12,7 @@ import { User } from '../../types/UserTypes';
 import useForm, { FormPosition, FormReducerState } from './hooks/useForm';
 import AuthContext from '../../store/AuthContext';
 import { useNotification } from '../../store/NotificationContext';
-import FormUploader from '../../containers/Form/FormUploader';
+import FormUploader from './FormUploader';
 import { AuthLoading } from '../../components/molecules';
 import { Image } from '../../components/molecules/ImageDisplay/ImageDisplay';
 
@@ -40,8 +40,7 @@ export const defaultInitialPosition: FormPosition = {
   currentMainStepIndex: 0,
 };
 
-export const defaultInitialStatus =
-{
+export const defaultInitialStatus = {
   type: 'notStarted',
   name: 'Ej påbörjad',
   description: 'Ansökan är ej påbörjad.',
@@ -63,7 +62,6 @@ const Form: React.FC<Props> = ({
   status,
   updateCaseInContext,
 }) => {
-
   const initialState: FormReducerState = {
     submitted: false,
     currentPosition: initialPosition || defaultInitialPosition,
@@ -109,7 +107,10 @@ const Form: React.FC<Props> = ({
 
   const [hasSigned, setHasSigned] = useState(status.type.includes('signed'));
 
-  const [hasUploaded, setHasUploaded] = useState(attachments?.length && attachments.filter(({ uploadedFileName }) => uploadedFileName).length == attachments.length);
+  const [hasUploaded, setHasUploaded] = useState(
+    attachments?.length &&
+      attachments.filter(({ uploadedFileName }) => uploadedFileName).length == attachments.length
+  );
 
   const showNotification = useNotification();
 
@@ -117,7 +118,7 @@ const Form: React.FC<Props> = ({
     const signature = { success: true };
     formNavigation.next();
     updateCaseInContext(answers, signature, formState.currentPosition);
-  }
+  };
 
   /**
    * Effect for signing a case.
@@ -166,13 +167,22 @@ const Form: React.FC<Props> = ({
     onClose();
   };
 
+  
+
   const stepComponents = formState.steps.map(
     ({ id, banner, title, group, description, questions, actions, colorSchema }) => {
-      const questionsToShow = questions ? questions.filter(question => {
-        const condition = question.conditionalOn;
-        if (!condition || condition.trim() === '') return true;
-        return evaluateConditionalExpression(condition, formState.formAnswers, formState.allQuestions);
-      }) : [];
+      const questionsToShow = questions
+        ? questions.filter((question) => {
+            const condition = question.conditionalOn;
+            if (!condition || condition.trim() === '') return true;
+            return evaluateConditionalExpression(
+              condition,
+              formState.formAnswers,
+              formState.allQuestions
+            );
+          })
+        : [];
+
 
       return (
         <Step
@@ -206,8 +216,10 @@ const Form: React.FC<Props> = ({
             formState.currentPosition.currentMainStep < formState.numberOfMainSteps
           }
           attachments={attachments}
-        />);
-    });
+        />
+      );
+    }
+  );
 
   const mainStep = formState.currentPosition.currentMainStepIndex;
   const [visible, toggleModal] = useModal();
@@ -228,7 +240,7 @@ const Form: React.FC<Props> = ({
           setRef((ref as unknown) as ScrollView);
         }}
       >
-        <StatusBar hidden={true} />
+        <StatusBar hidden />
         {stepComponents[formState.currentPosition.currentMainStepIndex]}
       </ScreenWrapper>
       <Modal visible={formState.currentPosition.level > 0} hide={toggleModal}>
@@ -250,7 +262,7 @@ const Form: React.FC<Props> = ({
 
       {(isLoading || isResolved) && (
         <AuthLoading
-          colorSchema={'neutral'}
+          colorSchema="neutral"
           isLoading={isLoading}
           isResolved={isResolved}
           cancelSignIn={() => handleCancelOrder()}

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState, useContext, createRef, useRef } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { InteractionManager, StatusBar } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Modal, useModal } from '../../components/molecules/Modal';

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -35,6 +35,7 @@ const inputTypes = {
     component: Input,
     changeEvent: 'onChangeText',
     blurEvent: 'onBlur',
+    focusEvent: 'onFocus',
     props: {
       showErrorMessage: true,
     },
@@ -43,6 +44,7 @@ const inputTypes = {
     component: Input,
     blurEvent: 'onBlur',
     changeEvent: 'onChangeText',
+    focusEvent: 'onFocus',
     props: {
       showErrorMessage: true,
       keyboardType: 'numeric',
@@ -59,6 +61,7 @@ const inputTypes = {
   date: {
     component: CalendarPicker,
     changeEvent: 'onSelect',
+    focusEvent: 'onFocus',
     initialValue: undefined,
     props: {
       showErrorMessage: true,
@@ -68,6 +71,7 @@ const inputTypes = {
   checkbox: {
     component: CheckboxField,
     changeEvent: 'onChange',
+    focusEvent: 'onFocus',
     blurEvent: 'onBlur',
     helpInComponent: true,
     helpProp: 'help',
@@ -77,6 +81,7 @@ const inputTypes = {
   editableList: {
     component: EditableList,
     changeEvent: 'onInputChange',
+    focusEvent: 'onFocus',
     blurEvent: 'onBlur',
     helpInComponent: true,
     helpProp: 'help',
@@ -94,6 +99,7 @@ const inputTypes = {
   select: {
     component: Select,
     changeEvent: 'onValueChange',
+    focusEvent: 'onFocus',
     blurEvent: 'onBlur',
     props: {},
   },
@@ -111,6 +117,7 @@ const inputTypes = {
   summaryList: {
     component: SummaryList,
     changeEvent: 'onChange',
+    focusEvent: 'onFocus',
     blurEvent: 'onBlur',
     helpInComponent: true,
     helpProp: 'help',
@@ -118,6 +125,7 @@ const inputTypes = {
   },
   repeaterField: {
     component: RepeaterField,
+    focusEvent: 'onFocus',
     blurEvent: 'onBlur',
     changeEvent: 'onChange',
     props: {},
@@ -155,6 +163,7 @@ const FormField = ({
   id,
   onChange,
   onBlur,
+  onFocus,
   value,
   answers,
   validationErrors,
@@ -170,8 +179,15 @@ const FormField = ({
   const saveInput = (value, fieldId = id) => {
     if (onChange) onChange({ [fieldId]: value }, fieldId);
   };
+
   const onInputBlur = (value, fieldId = id) => {
     if (onBlur) onBlur({ [fieldId]: value }, fieldId);
+  };
+
+  const onInputFocus = (e) => {
+    if (onFocus) {
+      onFocus(e);
+    }
   };
 
   const inputProps = input && input.props ? input.props : {};
@@ -192,6 +208,7 @@ const FormField = ({
   if (input?.props?.validation) inputCompProps.validationErrors = validationErrors;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;
   if (input && input.blurEvent) inputCompProps[input.blurEvent] = onInputBlur;
+  if (input && input.focusEvent) inputCompProps[input.focusEvent] = onInputFocus;
   if (input && input.helpInComponent) inputCompProps[input.helpProp || 'help'] = help;
 
   const inputComponent =
@@ -253,6 +270,7 @@ FormField.propTypes = {
   onChange: PropTypes.func,
   /** What happens when an input field looses focus.  */
   onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
   /**
    * sets the value, since the input field component should be managed.
    */

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -204,6 +204,7 @@ const FormField = ({
     id,
     ...other,
   };
+
   if (input?.props?.answers) inputCompProps.answers = answers;
   if (input?.props?.validation) inputCompProps.validationErrors = validationErrors;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -184,9 +184,9 @@ const FormField = ({
     if (onBlur) onBlur({ [fieldId]: value }, fieldId);
   };
 
-  const onInputFocus = (e) => {
+  const onInputFocus = (e, isSelect = false) => {
     if (onFocus) {
-      onFocus(e);
+      onFocus(e, isSelect);
     }
   };
 


### PR DESCRIPTION
## Explain the changes you’ve made

I've fixed a bug where the form screens would jump to the top of the page when the "Klar" button was pressed on an input.

More information at #CU-nxchvm


## Explain why these changes are made

When the screen jumps around it's detrimental to the user experience.

## Explain your solution

In order for this to work, I've had to add a way of knowing when our inputs become focused.
As the select component isn't a standard textfield and the `[KeyboardAwareScrollView](https://github.com/APSL/react-native-keyboard-aware-scroll-view)` component only recognises the TextInput component, I've had to add a special case for these.

## How to test the changes?

Concrete example:
1. Checkout dev branch
2. Open a case, focus any field
3. Press "Klar"
4. Notice that the screen jumps back to the top of the page
5. Checkout this branch
6. Repeat steps 2 and 3
7. Notice that it doesn't jump to the top of the page anymore

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.


