### PR TITLE
Feat/show thanks screen after sign

### DIFF
--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -259,12 +259,17 @@ function CaseOverview(props) {
 
           setPendingCaseSign(null);
           onRefresh();
+
+          // Show last screen of form
+          navigation.navigate('Form', {
+            caseId: pendingCaseSign.id,
+          });
         } catch (error) {
           console.log(`Could not update case with new signature: ${error}`);
         }
       })();
     }
-  }, [pendingCaseSign, authContext.status, setPendingCaseSign, onRefresh]);
+  }, [pendingCaseSign, authContext.status, setPendingCaseSign, onRefresh, navigation]);
 
   return (
     <ScreenWrapper {...props}>

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -272,7 +272,7 @@ const CaseSummary = (props) => {
 
         // Show last screen of form
         navigation.navigate('Form', {
-          caseId: pendingCaseSign.id,
+          caseId: caseItem.id,
         });
         return updateCaseResponse;
       } catch (error) {

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -248,30 +248,39 @@ const CaseSummary = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFocused, cases]);
 
-  const updateCaseSignature = useCallback(async (caseItem, signatureSuccessful) => {
-    const currentForm = caseItem.forms[caseItem.currentFormId];
+  const updateCaseSignature = useCallback(
+    async (caseItem, signatureSuccessful) => {
+      const currentForm = caseItem.forms[caseItem.currentFormId];
 
-    const updateCaseRequestBody = {
-      currentFormId: caseItem.currentFormId,
-      ...currentForm,
-      signature: { success: signatureSuccessful },
-    };
+      const updateCaseRequestBody = {
+        currentFormId: caseItem.currentFormId,
+        ...currentForm,
+        signature: { success: signatureSuccessful },
+      };
 
-    try {
-      const updateCaseResponse = await put(
-        `/cases/${caseItem.id}`,
-        JSON.stringify(updateCaseRequestBody)
-      );
+      try {
+        const updateCaseResponse = await put(
+          `/cases/${caseItem.id}`,
+          JSON.stringify(updateCaseRequestBody)
+        );
 
-      if (updateCaseResponse.status !== 200) {
-        throw new Error(`${updateCaseResponse.status} ${updateCaseResponse?.data?.data?.message}`);
+        if (updateCaseResponse.status !== 200) {
+          throw new Error(
+            `${updateCaseResponse.status} ${updateCaseResponse?.data?.data?.message}`
+          );
+        }
+
+        // Show last screen of form
+        navigation.navigate('Form', {
+          caseId: pendingCaseSign.id,
+        });
+        return updateCaseResponse;
+      } catch (error) {
+        console.log(`Could not update case with new signature: ${error}`);
       }
-
-      return updateCaseResponse;
-    } catch (error) {
-      console.log(`Could not update case with new signature: ${error}`);
-    }
-  }, []);
+    },
+    [navigation]
+  );
 
   useEffect(() => {
     const updateCaseAfterSignature = async () => {

--- a/source/store/actions/CaseActions.js
+++ b/source/store/actions/CaseActions.js
@@ -27,6 +27,7 @@ export async function updateCase(
     answers: convertAnswersToArray(answerObject, formQuestions),
     currentPosition,
     currentFormId: formId,
+    encryption: { type: 'decrypted' },
   };
 
   if (encryptAnswers) {

--- a/source/store/actions/CaseActions.js
+++ b/source/store/actions/CaseActions.js
@@ -110,7 +110,7 @@ export async function fetchCases(user) {
 
       // eslint-disable-next-line no-restricted-syntax
       for await (const c of response.data.data.attributes.cases) {
-        if (c?.status.type === 'active:ongoing') {
+        if (c?.status.type === 'active:ongoing' || c?.status.type === 'active:signature:pending') {
           try {
             c.forms[c.currentFormId] = await decryptFormAnswers(user, c.forms[c.currentFormId]);
             cases[c.id] = c;


### PR DESCRIPTION
## Explain the changes you’ve made

Added code for showing the last screen of the form (the "Thank you" screen) after signing a case as co-applicant.

## Explain why these changes are made

This is part of the big feature of co-applicant support.

## Explain your solution

Navigation to show the form is triggered after BankID sign, both on overview and summary screen. Navigation is performed the same way as when opening the form. This however assumes that `currentPosition` in a case always results in showing the last screen of the form, which is also assumed to be the "Thank You" screen. `currentPosition` _should_ point to the last screen, as that is the last viewed screen for the main applicant as well, however the code makes no checks for this.

## How to test the changes?

Concrete example:
0. Note: since encryption is not fully done, it is recommended to hard-code the Aes key and initialization vector in `EncryptionService.ts` so that the co-applicant can decrypt the case, otherwise it will fail.

For example, in `encryptWithAesKey`:

```javascript
return Aes.encrypt(
    text,
    '44141c4ff6f3b6ae19e3091a4796d7038b88cb55087f5eb1e92f199fe232b318',
    '3ce84f398aede185b28e42dc02567926'
  );
```

and in `decryptWithAesKey`:

```javascript
return Aes.decrypt(
    cipher,
    '44141c4ff6f3b6ae19e3091a4796d7038b88cb55087f5eb1e92f199fe232b318',
    '3ce84f398aede185b28e42dc02567926'
  );
```

1. Checkout this branch
2. As main applicant, go through a case as usual, and sign.
  - Note: recommended to now do a backup of the case in DynamoDB so you can quickly check that both Overview and Summary works without having to go through a case from scratch.
3. Sign in as co-applicant.
4. Press the sign button and sign in Overview.
5. Verify that after a successful sign you are taken to the last screen of the form.
6. Repeat step 4 but in the Summary view.
7. Verify that the same behaviour as step 5 occurs.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Anything else?

This solution is not really ideal. One idea I have is to be able to tag screens in form-builder with unique IDs, the navigate to these exact IDs in code.