### PR TITLE
🐛 Fix bug with periods not showing

### DIFF
--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -9,7 +9,7 @@ import { evaluateConditionalExpression } from '../../helpers/conditionParser';
 import { CaseStatus } from '../../types/CaseType';
 import { Step as StepType, StepperActions } from '../../types/FormTypes';
 import { User } from '../../types/UserTypes';
-import useForm, { FormPosition, FormReducerState } from './hooks/useForm';
+import useForm, { FormPeriod, FormPosition, FormReducerState } from './hooks/useForm';
 import AuthContext from '../../store/AuthContext';
 import { useNotification } from '../../store/NotificationContext';
 import FormUploader from '../../containers/Form/FormUploader';
@@ -31,6 +31,7 @@ interface Props {
     signature: { success: boolean },
     currentPosition: FormPosition
   ) => void;
+  period?: FormPeriod;
 }
 
 export const defaultInitialPosition: FormPosition = {
@@ -57,6 +58,7 @@ const Form: React.FC<Props> = ({
   steps,
   connectivityMatrix,
   user,
+  period,
   onClose,
   onSubmit,
   initialAnswers,
@@ -75,6 +77,7 @@ const Form: React.FC<Props> = ({
     dirtyFields: {},
     connectivityMatrix,
     allQuestions: [],
+    period,
   };
 
   const {
@@ -85,7 +88,7 @@ const Form: React.FC<Props> = ({
     handleBlur,
     validateStepAnswers,
   } = useForm(initialState);
-
+  
   const {
     status: authStatus,
     isLoading,

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -9,8 +9,9 @@ import { evaluateConditionalExpression } from '../../../helpers/conditionParser'
  * @param {FormReducerState} state the current state of the form
  */
 export function replaceMarkdownText(state: FormReducerState) {
-  const { steps, user } = state;
-  const updatedSteps = replaceMarkdownTextInSteps(steps, user);
+  const { steps, user, period } = state;
+
+  const updatedSteps = replaceMarkdownTextInSteps(steps, user, period);
   return {
     ...state,
     steps: updatedSteps,

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -38,30 +38,30 @@ const swedishMonthTable = [
 ];
 
 const replaceDates = (descriptor: string[], period?: FormPeriod): string => {
-  const today = period ? new Date(period.endDate) : new Date();
+  const activeDate = period ? new Date(period.endDate) : new Date();
 
   if (descriptor[1] === 'nextMonth') {
-    const month = today.getMonth() + 2;
+    const month = activeDate.getMonth() + 2;
     if (descriptor[2] === 'first') {
       return `1/${month}`;
     }
     if (descriptor[2] === 'last') {
-      const days = new Date(today.getFullYear(), month, 0).getDate();
+      const days = new Date(activeDate.getFullYear(), month, 0).getDate();
       return `${days}/${month}`;
     }
   }
 
   if (descriptor[1] === 'currentYear') {
-    const year = new Date(today.getFullYear(), today.getMonth() + 1, 1).getFullYear();
+    const year = new Date(activeDate.getFullYear(), activeDate.getMonth() + 1, 1).getFullYear();
     return `${year}`;
   }
 
   if (descriptor[1] === 'currentDate') {
-    return `${today.getDate()}`;
+    return `${activeDate.getDate()}`;
   }
 
   if (descriptor[1] === 'previousMonth') {
-    const currentMonth = today.getMonth();
+    const currentMonth = activeDate.getMonth();
 
     switch (descriptor[2]) {
       case 'currentMonth':

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -9,6 +9,11 @@ export interface FormPosition {
   currentMainStep: number;
   currentMainStepIndex: number;
 }
+
+export interface FormPeriod {
+  startDate: number;
+  endDate: number;
+}
 export interface FormReducerState {
   submitted: boolean;
   currentPosition: FormPosition;
@@ -21,6 +26,7 @@ export interface FormReducerState {
   validations: Record<string, any>;
   dirtyFields: Record<string, any>;
   numberOfMainSteps?: number;
+  period?: FormPeriod;
 }
 
 function useForm(initialState: FormReducerState) {

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -146,6 +146,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       onSubmit={handleSubmitForm}
       initialAnswers={initialAnswers}
       status={initialCase.status || defaultInitialStatus}
+      period={initialCase.details.period}
       updateCaseInContext={updateCaseContext}
       {...props}
     />


### PR DESCRIPTION
## Explain the changes you’ve made

I've added support for the `textReplacement.ts#replaceDates` function to take an optional period parameter in order to use that as a base for `#month` replacements.

More info is available at #CU-k3bfpw

## Explain your solution

I made the base date start from the period if it's provided.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Create an application
3. See that the period is correct

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

