### PR TITLE
🐛 Fix bug with email field autocorrecting

### DIFF
--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -28,6 +28,20 @@ const keyboardTypes: Record<InputFieldType, KeyboardTypeOptions> = {
   personalNumber: 'number-pad',
 }
 
+
+const keyboardTypeExtraProp: Record<InputFieldType, Partial<InputProps>> = {
+  text: {},
+  number: {},
+  email: {
+    autoCapitalize: 'none',
+    autoCorrect: false,
+  },
+  postalCode: {},
+  phone: {},
+  date: {},
+  personalNumber: {},
+}
+
 const StyledTextInput = styled.TextInput<InputProps>`
   width: 100%;
   font-weight: ${({ theme }) => theme.fontWeights[0]};
@@ -75,6 +89,7 @@ const Input: React.FC<InputProps> = React.forwardRef(
     };
     const theme = useTheme();
     const smartKeyboardType = inputType ? keyboardTypes[inputType] : keyboardType;
+    const smartKeyboardExtraProps = inputType ? keyboardTypeExtraProp[inputType] : {};
 
 
     useEffect(handleMount, []);
@@ -96,6 +111,8 @@ const Input: React.FC<InputProps> = React.forwardRef(
           inputAccessoryViewID="klar-accessory"
           keyboardType={smartKeyboardType}
           ref={ref as React.Ref<TextInput>}
+          {...smartKeyboardExtraProps}
+          
           {...props}
         />
         {showErrorMessage && error ? <StyledErrorText>{error?.message}</StyledErrorText> : <></>}


### PR DESCRIPTION
## Explain the changes you’ve made

I've added a way to specify input props based on the smart keyboard types.
See #CU-p3eb0e

## Explain why these changes are made

These changes are made in order to disable the autocorrect and auto-capitalization of email fields, while allowing for other field types to do the same.

## Explain your solution

I've added an object containing the extra props.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Start a case
3. Enter email in the field

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
