### PR TITLE
💄 Change bannerwrapper height

### DIFF
--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -161,6 +161,7 @@ function Step({
     <StepContainer>
       <KeyboardAwareScrollView
         keyboardShouldPersistTaps="always"
+        contentContainerStyle={{ flexGrow: 1 }}
         resetScrollToCoords={{ x: 0, y: returnScrollY }}
         innerRef={(r) => (scrollRef.current = r)}
         enableAutomaticScroll

--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -12,6 +12,7 @@ import StepDescription from './StepDescription/StepDescription';
 import StepFooter from './StepFooter/StepFooter';
 
 const StepContainer = styled.View`
+  flex: 1;
   background: ${(props) => props.theme.colors.neutrals[7]};
 `;
 
@@ -19,11 +20,9 @@ const StepBackNavigation = styled(BackNavigation)`
   padding: 24px 24px 0px 24px;
 `;
 
-const StepBanner = styled(Banner)`
+const StepContentContainer = styled.View`
   flex: 1;
 `;
-
-const StepContentContainer = styled.View``;
 
 const StepLayout = styled.View`
   flex: 1;
@@ -171,10 +170,9 @@ function Step({
           template={dialogTemplate}
           buttons={dialogButtonProps[dialogTemplate]}
         />
-
         <StepContentContainer>
           {banner && banner.constructor === Object && Object.keys(banner).length > 0 && (
-            <StepBanner {...banner} colorSchema={colorSchema || 'blue'} />
+            <Banner {...banner} colorSchema={colorSchema || 'blue'} />
           )}
           {currentPosition.level === 0 && (
             <Progressbar

--- a/source/components/organisms/Step/StepBanner/StepBanner.tsx
+++ b/source/components/organisms/Step/StepBanner/StepBanner.tsx
@@ -8,7 +8,7 @@ import {PrimaryColor} from '../../../../styles/themeHelpers';
 const BannerWrapper = styled.View<{ colorSchema: PrimaryColor; image?: boolean }>`
   margin: 0;
   padding: 0;
-  min-height: 256px;
+  min-height: 80px;
   background-color: ${props => props.theme.colors.complementary[props.colorSchema][0]};
   position: relative;
   justify-content: flex-end;

--- a/source/components/organisms/Step/StepDescription/StepDescription.js
+++ b/source/components/organisms/Step/StepDescription/StepDescription.js
@@ -6,7 +6,7 @@ import { Text, Heading } from '../../../atoms';
 const StepDescriptionWrapper = styled.View`
   padding-left: 24px;
   padding-right: 24px;
-  margin-top: 80px;
+  margin-top: 50px;
 `;
 
 const StepDescriptionContent = styled.View``;

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -12,7 +12,6 @@ import { evaluateConditionalExpression } from '../../../../helpers/conditionPars
 const ActionContainer = styled.View`
   width: 100%;
   background-color: ${(props) => props.theme.colors.neutrals[5]};
-  flex-grow: 0;
 `;
 
 const Flex = styled.View`


### PR DESCRIPTION
## Explain the changes you’ve made

I've changed the `min-height` property on the `BannerWrapper` component.

## Explain why these changes are made

In order to have the CTA Button show up without the need for scrolling on single-step views. See #CU-k3bftg for more info.

## Explain your solution

I changed the min-height of the `BannerWrapper` component.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Start a new case
3. Go to the third step
4. See that the button is in view

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots (optional)

Before:

![Before](https://user-images.githubusercontent.com/10225982/127819913-21b0c081-4f24-4d3b-b411-bcf73c5f490c.png)

After

![After](https://user-images.githubusercontent.com/10225982/127819943-e7547b6b-231f-48e2-bfb4-8dc0b212a557.png)
