### PR TITLE
🐛 Fix bug where last stage summary list was editable

### DIFF
--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -42,7 +42,7 @@ const GroupedList: React.FC<Props> = ({
   categories,
   colorSchema,
   showEditButton,
-  startEditable,
+  startEditable = false,
   help,
   children,
 }) => {


### PR DESCRIPTION
## Explain the changes you’ve made

In order to fix bug #CU-k3bfwy, I've defaulted the `startEditable` property of the `GroupedList`  component to false.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Finish a case
3. On the last step with summary, try editing without pressing the "Ändra" button.


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

