### PR TITLE
:bug: Fix bug where checkbox would follow along even though it was un…

### DIFF
--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -160,8 +160,13 @@ const SummaryList: React.FC<Props> = ({
 
   const itemsWithAnswers = items.filter(item => {
     const answer = answers[item.id];
-    return typeof answer !== 'undefined';
+
+    if (typeof answer !== 'undefined') {
+      if (item.type === 'checkbox') return answer
+      return true
+    }
   });
+
   itemsWithAnswers
     .forEach((item) => {
       if (['arrayNumber', 'arrayText', 'arrayDate'].includes(item.type)) {


### PR DESCRIPTION
…checked

## Explain the changes you’ve made

I've changed the way the answers filter works in summary lists, to now also check if checkboxes are unchecked.
If they are, they don't follow along.

More info at #CU-k3bfnz


## How to test the changes?

Concrete example:
1. Checkout this branch
2. Start a new case
3. Go to the step for "Inkomster"
4. Add a new income from "Myndigheter"
5. Check and uncheck an option
6. If the option is unchecked, it's not coming along.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
