### PR TITLE
Feat/co applicant summary

### DIFF
--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -60,10 +60,18 @@ function Step({
   totalStepNumber,
   answerSnapshot,
   attachments,
+  isFormEditable,
 }) {
+  const isSubstep = currentPosition.level !== 0;
+  const isLastMainStep =
+    currentPosition.level === 0 && currentPosition.currentMainStep === totalStepNumber;
+  const isDirtySubStep = JSON.stringify(answers) !== JSON.stringify(answerSnapshot) && isSubstep;
+  const [dialogIsVisible, setDialogIsVisible] = useState(false);
+  const [dialogTemplate, setDialogTemplate] = useState('mainStep');
+
   /** TODO: move out of this scope, this logic should be defined on the form component */
   const closeForm = () => {
-    if (!status.type.includes('submitted')) {
+    if (!isLastMainStep && isFormEditable) {
       if (onFieldChange) {
         onFieldChange(answers);
       }
@@ -71,19 +79,11 @@ function Step({
         updateCaseInContext(answers, undefined, currentPosition);
       }
     }
+
     if (formNavigation?.close) {
       formNavigation.close(() => {});
     }
   };
-
-  const isSubstep = currentPosition.level !== 0;
-  const isLastMainStep =
-    currentPosition.level === 0 && currentPosition.currentMainStep === totalStepNumber;
-
-  const isDirtySubStep = JSON.stringify(answers) !== JSON.stringify(answerSnapshot) && isSubstep;
-
-  const [dialogIsVisible, setDialogIsVisible] = useState(false);
-  const [dialogTemplate, setDialogTemplate] = useState('mainStep');
 
   const dialogButtonProps = {
     mainStep: [
@@ -206,7 +206,7 @@ function Step({
                       colorSchema={field.color && field.color !== '' ? field.color : colorSchema}
                       id={field.id}
                       formNavigation={formNavigation}
-                      editable={!field.disabled}
+                      editable={!field.disabled && isFormEditable}
                       onFocus={(e, isSelect) => {
                         if (Platform.OS === 'android') {
                           return;
@@ -238,7 +238,7 @@ function Step({
       </KeyboardAwareScrollView>
 
       <StepBackNavigation
-        showBackButton={isBackBtnVisible}
+        showBackButton={isBackBtnVisible && isFormEditable}
         primary={!isSubstep}
         isSubstep={isSubstep}
         onBack={backButtonBehavior}
@@ -367,6 +367,7 @@ Step.propTypes = {
   /** Total number of steps in the form */
   totalStepNumber: PropTypes.number,
   attachments: PropTypes.array,
+  isFormEditable: PropTypes.bool,
 };
 
 Step.defaultProps = {

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -11,7 +11,7 @@ import { useNotification } from '../../../store/NotificationContext';
 import env from 'react-native-config';
 import { InputType } from '../../atoms/Input/Input';
 
-const SumLabel = styled(Heading)<{ colorSchema: string }>`
+const SumLabel = styled(Heading) <{ colorSchema: string }>`
   margin-top: 5px;
   margin-left: 3px;
   font-weight: ${props => props.theme.fontWeights[1]};
@@ -41,7 +41,7 @@ export interface SummaryListItem {
   title: string;
   id: string;
   type: 'number' | 'text' | 'date' | 'checkbox' | 'arrayNumber' | 'arrayText' | 'arrayDate'
-   | 'editableListText' | 'editableListNumber' | 'editableListDate' ;
+  | 'editableListText' | 'editableListNumber' | 'editableListDate';
   category?: string;
   inputId?: string;
   inputSelectValue?: InputType;
@@ -66,7 +66,8 @@ interface Props {
   >;
   showSum: boolean;
   startEditable?: boolean;
-  help? : Help;
+  help?: Help;
+  editable?: boolean;
 }
 /**
  * Summary list, that is linked and summarizes values from other input components.
@@ -85,6 +86,7 @@ const SummaryList: React.FC<Props> = ({
   showSum,
   startEditable,
   help,
+  editable,
 }) => {
   // For development: show an error popup when something is configured wrong.
   const showNotification = useNotification();
@@ -118,10 +120,10 @@ const SummaryList: React.FC<Props> = ({
       ['arrayNumber', 'arrayText', 'arrayDate', 'editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) &&
       typeof index !== 'undefined' &&
       item.inputId
-    ){
-      if(onBlur) onBlur(answers[item.id], item.id);
+    ) {
+      if (onBlur) onBlur(answers[item.id], item.id);
     } else {
-      if(onBlur) onBlur(value, item.id);
+      if (onBlur) onBlur(value, item.id);
     }
   }
   /**
@@ -197,7 +199,7 @@ const SummaryList: React.FC<Props> = ({
                 colorSchema={colorSchema}
                 validationError={validationError}
                 category={item.category}
-            />
+              />
             );
             if (item.type === 'arrayNumber') {
               const numericValue: string | number = v[item?.inputId || item.id];
@@ -207,19 +209,19 @@ const SummaryList: React.FC<Props> = ({
         }
       }
       if (['editableListText', 'editableListNumber', 'editableListDate'].includes(item.type) && item.inputId
-      && answers?.[item.id]?.[item.inputId]) {
+        && answers?.[item.id]?.[item.inputId]) {
         listItems.push(
           <SummaryListItemComponent
-              item={item}
-              key={`${item.id}`}
-              value={answers[item.id][item.inputId]}
-              changeFromInput={changeFromInput(item)}
-              onBlur={onItemBlur(item)}
-              removeItem={removeListItem(item)}
-              colorSchema={colorSchema}
-              validationError={validationErrors?.[item.id]?.[item.inputId] ? validationErrors?.[item.id]?.[item.inputId] : undefined}
-              category={item.category}
-            />
+            item={item}
+            key={`${item.id}`}
+            value={answers[item.id][item.inputId]}
+            changeFromInput={changeFromInput(item)}
+            onBlur={onItemBlur(item)}
+            removeItem={removeListItem(item)}
+            colorSchema={colorSchema}
+            validationError={validationErrors?.[item.id]?.[item.inputId] ? validationErrors?.[item.id]?.[item.inputId] : undefined}
+            category={item.category}
+          />
         );
         if (item.type === 'editableListNumber') {
           const numericValue: number = answers[item.id][item.inputId];
@@ -229,16 +231,16 @@ const SummaryList: React.FC<Props> = ({
       if (['text', 'number', 'date', 'checkbox'].includes(item.type)) {
         listItems.push(
           <SummaryListItemComponent
-              item={item}
-              key={`${item.id}`}
-              value={answers[item.id]}
-              changeFromInput={changeFromInput(item)}
-              onBlur={onItemBlur(item)}
-              removeItem={removeListItem(item)}
-              colorSchema={colorSchema}
-              validationError={validationErrors ? (validationErrors as Record<string,  { isValid: boolean; message: string }>)[item.id] : undefined}
-              category={item.category}
-            />
+            item={item}
+            key={`${item.id}`}
+            value={answers[item.id]}
+            changeFromInput={changeFromInput(item)}
+            onBlur={onItemBlur(item)}
+            removeItem={removeListItem(item)}
+            colorSchema={colorSchema}
+            validationError={validationErrors ? (validationErrors as Record<string, { isValid: boolean; message: string }>)[item.id] : undefined}
+            category={item.category}
+          />
         );
         if (item.type === 'number') {
           const numericValue: number = answers[item.id];
@@ -255,8 +257,8 @@ const SummaryList: React.FC<Props> = ({
           heading={heading}
           categories={categories}
           colorSchema={validColorSchema}
-          showEditButton
-          startEditable={startEditable}
+          showEditButton={editable}
+          startEditable={startEditable && editable}
           help={help}
         >
           {listItems}
@@ -313,9 +315,9 @@ SummaryList.propTypes = {
    * Whether to start in editable mode or not.
    */
   startEditable: PropTypes.bool,
-    /**
-   * Show a help button
-   */
+  /**
+ * Show a help button
+ */
   help: PropTypes.shape({
     text: PropTypes.string,
     size: PropTypes.number,
@@ -329,6 +331,6 @@ SummaryList.defaultProps = {
   items: [],
   color: 'blue',
   showSum: true,
-  onChange: () => {},
+  onChange: () => { },
 };
 export default SummaryList;

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -32,6 +32,7 @@ interface Props {
     currentPosition: FormPosition
   ) => void;
   period?: FormPeriod;
+  editable: boolean;
 }
 
 export const defaultInitialPosition: FormPosition = {
@@ -63,6 +64,7 @@ const Form: React.FC<Props> = ({
   initialAnswers,
   status,
   updateCaseInContext,
+  editable
 }) => {
   const initialState: FormReducerState = {
     submitted: false,
@@ -76,6 +78,7 @@ const Form: React.FC<Props> = ({
     connectivityMatrix,
     allQuestions: [],
     period,
+    editable
   };
 
   const {
@@ -219,6 +222,7 @@ const Form: React.FC<Props> = ({
             formState.currentPosition.currentMainStep < formState.numberOfMainSteps
           }
           attachments={attachments}
+          isFormEditable={editable}
         />
       );
     }

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -27,6 +27,7 @@ export interface FormReducerState {
   dirtyFields: Record<string, any>;
   numberOfMainSteps?: number;
   period?: FormPeriod;
+  editable?: boolean;
 }
 
 function useForm(initialState: FormReducerState) {

--- a/source/helpers/CaseDataConverter.js
+++ b/source/helpers/CaseDataConverter.js
@@ -45,9 +45,11 @@ export const convertAnswersToArray = (data, formQuestions) => {
 
   Object.entries(data).forEach((answer) => {
     const [fieldId, value] = answer;
-    const { id, type, tags, ...other } = formQuestions.find((element) => element.id === fieldId);
+    const { id, type, tags, disableValueStorage, ...other } = formQuestions.find(
+      (element) => element.id === fieldId
+    );
 
-    if (value === undefined) {
+    if (value === undefined || disableValueStorage) {
       return;
     }
 

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -18,11 +18,15 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
   const [form, setForm] = useState(undefined);
   const [formQuestions, setFormQuestions] = useState(undefined);
   const [initialCase, setInitialCase] = useState(undefined);
-  const { caseData, caseId } = route && route.params ? route.params : {};
+  const { caseData, caseId, signMode } = route && route.params ? route.params : {};
   const { user } = useContext(AuthContext);
   const { getForm } = useContext(FormContext);
   const { getCase } = useContext(CaseState);
   const { updateCase } = useContext(CaseDispatch);
+
+  const initialPosition =
+    initialCase?.forms?.[initialCase.currentFormId]?.currentPosition || defaultInitialPosition;
+  const initialAnswers = initialCase?.forms?.[initialCase.currentFormId]?.answers || {};
 
   useEffect(() => {
     if (caseData?.currentFormId) {
@@ -131,9 +135,6 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       </SpinnerContainer>
     );
   }
-  const initialPosition =
-    initialCase?.forms?.[initialCase.currentFormId]?.currentPosition || defaultInitialPosition;
-  const initialAnswers = initialCase?.forms?.[initialCase.currentFormId]?.answers || {};
 
   return (
     <Form
@@ -148,6 +149,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       status={initialCase.status || defaultInitialStatus}
       period={initialCase.details.period}
       updateCaseInContext={updateCaseContext}
+      editable={!signMode}
       {...props}
     />
   );

--- a/source/screens/FormCaseScreen.js
+++ b/source/screens/FormCaseScreen.js
@@ -18,7 +18,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
   const [form, setForm] = useState(undefined);
   const [formQuestions, setFormQuestions] = useState(undefined);
   const [initialCase, setInitialCase] = useState(undefined);
-  const { caseData, caseId, signMode } = route && route.params ? route.params : {};
+  const { caseData, caseId, isSignMode } = route && route.params ? route.params : {};
   const { user } = useContext(AuthContext);
   const { getForm } = useContext(FormContext);
   const { getCase } = useContext(CaseState);
@@ -149,7 +149,7 @@ const FormCaseScreen = ({ route, navigation, ...props }) => {
       status={initialCase.status || defaultInitialStatus}
       period={initialCase.details.period}
       updateCaseInContext={updateCaseContext}
-      editable={!signMode}
+      editable={!isSignMode}
       {...props}
     />
   );

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -104,7 +104,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext) => {
 
   if (isWaitingForSign && !selfHasSigned) {
     buttonProps.onClick = () =>
-      navigation.navigate('Form', { caseId: caseData.id, signMode: true });
+      navigation.navigate('Form', { caseId: caseData.id, isSignMode: true });
     buttonProps.text = 'Granska och signera';
   }
 

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -233,14 +233,6 @@ function CaseOverview(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cases]);
 
-  const signCase = useCallback(
-    async (caseData) => {
-      setPendingCaseSign(caseData);
-      await authContext.handleSign(authContext.user.personalNumber, 'Signering Mitt Helsingborg.');
-    },
-    [authContext, setPendingCaseSign]
-  );
-
   useEffect(() => {
     if (pendingCaseSign && authContext.status === 'signResolved') {
       (async () => {
@@ -286,7 +278,7 @@ function CaseOverview(props) {
         {activeCases.length > 0 && (
           <Animated.View style={{ opacity: fadeAnimation }}>
             {activeCases.map((caseData) =>
-              computeCaseCardComponent(caseData, navigation, authContext, signCase)
+              computeCaseCardComponent(caseData, navigation, authContext)
             )}
           </Animated.View>
         )}

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -103,7 +103,8 @@ const computeCaseCardComponent = (caseData, navigation, authContext, signCaseFun
   }
 
   if (isWaitingForSign && !selfHasSigned) {
-    buttonProps.onClick = () => signCaseFunc(caseData);
+    buttonProps.onClick = () =>
+      navigation.navigate('Form', { caseId: caseData.id, signMode: true });
     buttonProps.text = 'Granska och signera';
   }
 

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -37,7 +37,7 @@ const colorSchema = 'red';
  * @param {obj} navigation
  * @param {obj} authContext
  */
-const computeCaseCardComponent = (caseData, navigation, authContext, signCaseFunc) => {
+const computeCaseCardComponent = (caseData, navigation, authContext) => {
   const currentStep =
     caseData?.forms?.[caseData.currentFormId]?.currentPosition?.currentMainStep || 0;
   const totalSteps = caseData.form?.stepStructure ? caseData.form.stepStructure.length : 0;

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -168,10 +168,9 @@ const computeCaseCardComponent = (
   }
 
   if (isWaitingForSign && !selfHasSigned) {
-    buttonProps.onClick = async () => {
-      await authContext.handleSign(authContext.user.personalNumber, 'Signering Mitt Helsingborg.');
-    };
-    buttonProps.text = 'Signera med BankID';
+    buttonProps.onClick = () =>
+      navigation.navigate('Form', { caseId: caseData.id, isSignMode: true });
+    buttonProps.text = 'Granska och signera';
   }
 
   const giveDate = payments?.payment?.givedate


### PR DESCRIPTION
## Explain the changes you’ve made

Added functionality for co-applicants to display a summary of the case and sign.

## Explain your solution

Added ability for co-applicants to enter the same form as the applicant. The difference is that co-applicants enters the form in "sign mode". This mode locks a case to where the applicant left of, which is on the sign screen. 
Sign mode also disables ability to edit summary fields and hides the form navigation. 

## How to test the changes?

This PR is depending on that encryption works for both applicants and co-applicants. Until then you have to mock the process.
You have to create a case that has applicant and co-applicant and has status: "active:signature:pending". The case must be non-encrypted for the co-applicant.
After that the co-applicant can enter the case summary and sign. 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

Images of the process:

![Screenshot 2021-08-25 at 13 30 58](https://user-images.githubusercontent.com/21363149/130783408-2b0ca3e4-de70-4ea7-8289-6076698419f6.png)
![Screenshot 2021-08-25 at 13 31 19](https://user-images.githubusercontent.com/21363149/130783415-f674d282-d9c0-494b-aa19-b20303313775.png)
![Screenshot 2021-08-25 at 13 31 45](https://user-images.githubusercontent.com/21363149/130783419-fe7f7ccf-1b4b-4062-b388-655f48f4e70f.png)
![Screenshot 2021-08-25 at 13 31 52](https://user-images.githubusercontent.com/21363149/130783422-fc2c43af-ca2e-4034-95ba-9cced7579538.png)
![Screenshot 2021-08-25 at 13 32 05](https://user-images.githubusercontent.com/21363149/130783424-c8614ae6-89ab-418f-8b8e-f617ec507e6f.png)
![Screenshot 2021-08-25 at 13 32 15](https://user-images.githubusercontent.com/21363149/130783430-c459d887-da7c-40c1-86a2-dfb46d8395af.png)
