### PR TITLE
fix(case-overview): setting timeout before fetching cases from api

### DIFF
--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -186,7 +186,13 @@ function CaseOverview(props) {
 
   useFocusEffect(
     useCallback(() => {
-      fetchCases();
+      console.log('Refreshing Cases');
+      // Sometimes new cases is not created in an instant, therefore we have to give the api some buffert time before we fetch cases.
+      const milliseconds = 2000;
+      wait(milliseconds).then(() => {
+        console.log('Start Fetching Cases');
+        fetchCases();
+      });
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
   );

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -186,11 +186,11 @@ function CaseOverview(props) {
 
   useFocusEffect(
     useCallback(() => {
-      console.log('Refreshing Cases');
-      // Sometimes new cases is not created in an instant, therefore we have to give the api some buffert time before we fetch cases.
+      // Sometimes new cases is not created in an instant.
+      // Due to this we have to give the api some time before we try to fetch cases,
+      // since we cannot react to changes as of now.
       const milliseconds = 2000;
       wait(milliseconds).then(() => {
-        console.log('Start Fetching Cases');
         fetchCases();
       });
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Due to varying creation time for a case in the api new active cases was not always shown in the
list. The case list had to be refreshed in order to update. To fix this a delay have been added
before starting the fetch request, so that the api have time to process everything it has to do on
case creation.

## Explain the changes you’ve made

Added Delay (setTimeout) of 2 seconds before fetching cases in the CaseOverview component.

## Explain why these changes are made

Due to varying creation time for a case in the api new active cases was not always shown in the
list. The case list had to be refreshed in order to update. 

## Explain your solution

The solution as of know is to give the api a time window of 2 seconds to create a new active case if there are any, before we try to get all user cases and render them into the screen.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Setup person with an active case (Vera Toth, currently has an open active period open)
3. Make sure you can login with the person/user thorugh bankid.
3. Make sure the person does not have any open active cases for the current application window/period (This is needed in order for the api to create a new case on login)
4. Login with the person through bankid.
5. Check to see if there is an active case available in the case list. (If not the bugg is not fully solved)

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots (optional)
The active section in the overview screen should be populated.
![Screenshot 2021-08-30 at 13 42 18](https://user-images.githubusercontent.com/11438902/131333896-1e7b9db9-a28f-49b2-bd99-43d5c763466b.png)

## Anything else? (optional)

Let's consider polling cases on a scheduled time interval of when the screen is active or in the background. This due to that we currently can't react to changes that are happening in the api and therefore data is out of sync in several instances. 
There are other scenarios where updates to cases are made in the api but not reflected in the app without user actively navigating within the app.

Another solution to this would be to adopt web-hooks in the future, but that's a more complex implementation than polling.