### PR TITLE
Fix/store bankid login method

### DIFF
--- a/source/components/molecules/AuthLoading.js
+++ b/source/components/molecules/AuthLoading.js
@@ -66,7 +66,7 @@ const SuccessIcon = styled(Icon)`
 `;
 
 const AuthLoading = (props) => {
-  const { isBankidInstalled, cancelSignIn, colorSchema, isLoading, isResolved } = props;
+  const { authenticateOnExternalDevice, cancelSignIn, colorSchema, isLoading, isResolved } = props;
   const fadeAnimation = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -96,7 +96,7 @@ const AuthLoading = (props) => {
         <Container>
           <Box>
             <AuthActivityIndicator size="large" color={theme.colors.primary[colorSchema][1]} />
-            {!isBankidInstalled ? (
+            {authenticateOnExternalDevice ? (
               <InfoText>Väntar på att BankID ska startas på en annan enhet</InfoText>
             ) : (
               <InfoText>Väntar på mobilt BankID</InfoText>
@@ -117,7 +117,7 @@ const AuthLoading = (props) => {
 };
 
 AuthLoading.propTypes = {
-  isBankidInstalled: PropTypes.bool.isRequired,
+  authenticateOnExternalDevice: PropTypes.bool.isRequired,
   cancelSignIn: PropTypes.func.isRequired,
   isResolved: PropTypes.bool,
   isLoading: PropTypes.bool,

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -65,7 +65,7 @@ const StepFooter: React.FC<Props> = ({
   children,
   validateStepAnswers,
 }) => {
-  const { user, handleSign, isLoading } = useContext(AuthContext);
+  const { user, handleSign, isLoading, authenticateOnExternalDevice } = useContext(AuthContext);
   const showNotification = useNotification();
 
   const actionMap = (action: Action) => {
@@ -103,7 +103,8 @@ const StepFooter: React.FC<Props> = ({
             if (action.type === 'sign') {
               await handleSign(
                 user.personalNumber,
-                action?.signMessage || 'Signering Mitt Helsingborg.'
+                action?.signMessage || 'Signering Mitt Helsingborg.',
+                authenticateOnExternalDevice
               );
 
               return;

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -269,7 +269,7 @@ const Form: React.FC<Props> = ({
           isLoading={isLoading}
           isResolved={isResolved}
           cancelSignIn={() => handleCancelOrder()}
-          isBankidInstalled={!authenticateOnExternalDevice}
+          authenticateOnExternalDevice={authenticateOnExternalDevice}
         />
       )}
     </>

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -86,7 +86,7 @@ const Form: React.FC<Props> = ({
     handleBlur,
     validateStepAnswers,
   } = useForm(initialState);
-  
+
   const {
     status: authStatus,
     isLoading,
@@ -94,9 +94,9 @@ const Form: React.FC<Props> = ({
     isRejected,
     error,
     handleCancelOrder,
-    isBankidInstalled,
     handleSetStatus,
     handleSetError,
+    authenticateOnExternalDevice
   } = useContext(AuthContext);
 
   const answers: Record<string, Image | any> = formState.formAnswers;
@@ -112,7 +112,7 @@ const Form: React.FC<Props> = ({
 
   const [hasUploaded, setHasUploaded] = useState(
     attachments?.length &&
-      attachments.filter(({ uploadedFileName }) => uploadedFileName).length == attachments.length
+    attachments.filter(({ uploadedFileName }) => uploadedFileName).length == attachments.length
   );
 
   const showNotification = useNotification();
@@ -170,20 +170,20 @@ const Form: React.FC<Props> = ({
     onClose();
   };
 
-  
+
 
   const stepComponents = formState.steps.map(
     ({ id, banner, title, group, description, questions, actions, colorSchema }) => {
       const questionsToShow = questions
         ? questions.filter((question) => {
-            const condition = question.conditionalOn;
-            if (!condition || condition.trim() === '') return true;
-            return evaluateConditionalExpression(
-              condition,
-              formState.formAnswers,
-              formState.allQuestions
-            );
-          })
+          const condition = question.conditionalOn;
+          if (!condition || condition.trim() === '') return true;
+          return evaluateConditionalExpression(
+            condition,
+            formState.formAnswers,
+            formState.allQuestions
+          );
+        })
         : [];
 
 
@@ -269,7 +269,7 @@ const Form: React.FC<Props> = ({
           isLoading={isLoading}
           isResolved={isResolved}
           cancelSignIn={() => handleCancelOrder()}
-          isBankidInstalled={isBankidInstalled}
+          isBankidInstalled={!authenticateOnExternalDevice}
         />
       )}
     </>

--- a/source/screens/LoginScreen.js
+++ b/source/screens/LoginScreen.js
@@ -227,9 +227,9 @@ function LoginScreen(props) {
   /**
    * Handles the submission of the login form.
    */
-  const handleLogin = async (authOnExternalDevice = false) => {
+  const handleLogin = async (authenticateOnExternalDevice = false) => {
     // Validate personal number if authentication is chosen to be triggered on an external device
-    if (authOnExternalDevice) {
+    if (authenticateOnExternalDevice) {
       if (personalNumber.length <= 0) {
         return;
       }
@@ -239,11 +239,11 @@ function LoginScreen(props) {
         return;
       }
 
-      await handleAuth(personalNumber, false);
+      await handleAuth(personalNumber, true);
       return;
     }
     // Send empty personal number to use the personal number from users BankID app
-    await handleAuth(undefined, true);
+    await handleAuth(undefined, false);
   };
 
   return (

--- a/source/screens/LoginScreen.js
+++ b/source/screens/LoginScreen.js
@@ -266,7 +266,7 @@ function LoginScreen(props) {
                 isLoading={isLoading}
                 isResolved={isResolved}
                 cancelSignIn={handleCancelOrder}
-                isBankidInstalled
+                authenticateOnExternalDevice={false}
               />
             </Form>
           )}
@@ -331,7 +331,7 @@ function LoginScreen(props) {
                   isLoading={isLoading}
                   isResolved={isResolved}
                   cancelSignIn={handleCancelOrder}
-                  isBankidInstalled={false}
+                  authenticateOnExternalDevice
                 />
               </Form>
             )}

--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -5,7 +5,7 @@ import icons from 'source/helpers/Icons';
 import styled from 'styled-components/native';
 import { useFocusEffect } from '@react-navigation/native';
 import { Text } from '../../components/atoms';
-import { AuthLoading, Card, CaseCard, Header, ScreenWrapper } from '../../components/molecules';
+import { Card, CaseCard, Header, ScreenWrapper } from '../../components/molecules';
 import { getSwedishMonthNameByTimeStamp } from '../../helpers/DateHelpers';
 import { CaseState, caseTypes } from '../../store/CaseContext';
 import FormContext from '../../store/FormContext';
@@ -309,15 +309,6 @@ function CaseOverview(props) {
           </Animated.View>
         )}
       </Container>
-      {authContext.isLoading && (
-        <AuthLoading
-          colorSchema="neutral"
-          isLoading={authContext.isLoading}
-          isResolved={authContext.isResolved}
-          cancelSignIn={authContext.handleCancelOrder}
-          isBankidInstalled={authContext.isBankidInstalled}
-        />
-      )}
     </ScreenWrapper>
   );
 }

--- a/source/screens/caseScreens/CaseSummary.js
+++ b/source/screens/caseScreens/CaseSummary.js
@@ -15,7 +15,6 @@ import BackNavigation from '../../components/molecules/BackNavigation';
 import Button from '../../components/atoms/Button';
 import { formatAmount, convertDataToArray, calculateSum } from '../../helpers/FormatVivaData';
 import AuthContext from '../../store/AuthContext';
-import AuthLoading from '../../components/molecules/AuthLoading';
 import { put } from '../../helpers/ApiRequest';
 
 const Container = styled.ScrollView`
@@ -609,15 +608,6 @@ const CaseSummary = (props) => {
           </ModalFooter>
         </ScrollView>
       </Modal>
-      {authContext.isLoading && (
-        <AuthLoading
-          colorSchema="neutral"
-          isLoading={authContext.isLoading}
-          isResolved={authContext.isResolved}
-          cancelSignIn={authContext.handleCancelOrder}
-          isBankidInstalled={authContext.isBankidInstalled}
-        />
-      )}
     </ScreenWrapper>
   );
 };

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -46,7 +46,7 @@ function AuthProvider({ children, initialState }) {
   /**
    * This function starts up the authorization process.
    * @param {string} personalNumber Personal identity number
-   * @param {bool} authenticateOnExternalDevice Will automatically launch BankID app if set to true
+   * @param {bool} authenticateOnExternalDevice Will automatically launch BankID app if set to false
    */
   async function handleAuth(personalNumber, authenticateOnExternalDevice) {
     // Dynamically sets app in dev mode
@@ -69,6 +69,7 @@ function AuthProvider({ children, initialState }) {
    * This function starts up the sign process.
    * @param {string} personalNumber Personal Identity Number
    * @param {string} userVisibleData Message to be shown when signing order
+   * @param {bool} authenticateOnExternalDevice Will automatically launch BankID app if set to false
    */
   async function handleSign(personalNumber, userVisibleData, authenticateOnExternalDevice) {
     if (env.USE_BANKID === 'false') {

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -17,7 +17,6 @@ import {
   mockedAuth,
   startSign,
   setStatus,
-  checkIsBankidInstalled,
   setError,
   setAuthenticateOnExternalDevice,
 } from './actions/AuthActions';
@@ -43,17 +42,6 @@ function AuthProvider({ children, initialState }) {
     handleCheckOrderStatus();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.status, state.orderRef, state.autoStartToken]);
-
-  /**
-   * Check if Bankid App is installed on clients machine
-   */
-  useEffect(() => {
-    const handleCheckIsBankidInstalled = async () => {
-      dispatch(await checkIsBankidInstalled());
-    };
-
-    handleCheckIsBankidInstalled();
-  }, []);
 
   /**
    * This function starts up the authorization process.

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -19,6 +19,7 @@ import {
   setStatus,
   checkIsBankidInstalled,
   setError,
+  setAuthenticateOnExternalDevice,
 } from './actions/AuthActions';
 
 const AuthContext = React.createContext();
@@ -56,12 +57,12 @@ function AuthProvider({ children, initialState }) {
 
   /**
    * This function starts up the authorization process.
-   * @param {string} ssn Swedish Social Security Number (SSN)
-   * @param {bool} launchBankidApp Will automatically launch BankID app if set to true
+   * @param {string} personalNumber Personal identity number
+   * @param {bool} authenticateOnExternalDevice Will automatically launch BankID app if set to true
    */
-  async function handleAuth(ssn, launchBankidApp = true) {
+  async function handleAuth(personalNumber, authenticateOnExternalDevice) {
     // Dynamically sets app in dev mode
-    if (ssn && env.TEST_PERSONAL_NUMBER === ssn) {
+    if (personalNumber && env.TEST_PERSONAL_NUMBER === personalNumber) {
       handleSetMode('development');
     }
 
@@ -71,8 +72,9 @@ function AuthProvider({ children, initialState }) {
       return;
     }
 
+    dispatch(setAuthenticateOnExternalDevice(authenticateOnExternalDevice));
     dispatch(setStatus('pending'));
-    dispatch(await startAuth(ssn, launchBankidApp));
+    dispatch(await startAuth(personalNumber, authenticateOnExternalDevice));
   }
 
   /**
@@ -80,14 +82,14 @@ function AuthProvider({ children, initialState }) {
    * @param {string} personalNumber Personal Identity Number
    * @param {string} userVisibleData Message to be shown when signing order
    */
-  async function handleSign(personalNumber, userVisibleData, launchBankidApp = true) {
+  async function handleSign(personalNumber, userVisibleData, authenticateOnExternalDevice) {
     if (env.USE_BANKID === 'false') {
       dispatch(setStatus('signResolved'));
       return;
     }
 
     dispatch(setStatus('pending'));
-    dispatch(await startSign(personalNumber, userVisibleData, launchBankidApp));
+    dispatch(await startSign(personalNumber, userVisibleData, authenticateOnExternalDevice));
   }
 
   /**

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -19,7 +19,6 @@ export const actionTypes = {
   setStatus: 'SET_STATUS',
   setError: 'SET_ERROR',
   signSuccess: 'SIGN_SUCCESS',
-  setIsBankidInstalled: 'SET_INSTALLED',
   setAuthenticateOnExternalDevice: 'SET_AUTH_ON_EXTERNAL_DEVICE',
 };
 
@@ -223,14 +222,6 @@ export async function cancelOrder(orderRef) {
       type: actionTypes.cancelOrder,
     };
   }
-}
-
-export async function checkIsBankidInstalled() {
-  const isInstalled = await canOpenUrl('bankid:///');
-  return {
-    type: actionTypes.setIsBankidInstalled,
-    isBankidInstalled: isInstalled,
-  };
 }
 
 export function setAuthenticateOnExternalDevice(value) {

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -1,7 +1,6 @@
 import env from 'react-native-config';
 import bankid from '../../services/BankidService';
 import * as authService from '../../services/AuthService';
-import StorageService, { ACCESS_TOKEN_KEY } from '../../services/StorageService';
 import { UrlHelper } from '../../helpers';
 
 const { canOpenUrl } = UrlHelper;
@@ -21,6 +20,7 @@ export const actionTypes = {
   setError: 'SET_ERROR',
   signSuccess: 'SIGN_SUCCESS',
   setIsBankidInstalled: 'SET_INSTALLED',
+  setAuthenticateOnExternalDevice: 'SET_AUTH_ON_EXTERNAL_DEVICE',
 };
 
 export async function mockedAuth() {
@@ -116,16 +116,16 @@ export async function refreshSession() {
   };
 }
 
-export async function startAuth(ssn, launchBankidApp) {
+export async function startAuth(personalNumber, authenticateOnExternalDevice) {
   try {
-    const response = await bankid.auth(ssn);
+    const response = await bankid.auth(personalNumber);
     if (response.success === false) {
       throw new Error(response.data);
     }
     const { orderRef, autoStartToken } = response.data;
 
-    if (launchBankidApp) {
-      // Tries to start the bankId app on the device for user authorization.
+    if (!authenticateOnExternalDevice) {
+      // Start the bankId app on the device for user authorization.
       await bankid.launchApp(autoStartToken);
     }
 
@@ -146,7 +146,7 @@ export async function startAuth(ssn, launchBankidApp) {
   }
 }
 
-export async function startSign(personalNumber, userVisibleData, launchBankidApp) {
+export async function startSign(personalNumber, userVisibleData, authenticateOnExternalDevice) {
   try {
     const response = await bankid.sign(personalNumber, userVisibleData);
 
@@ -156,8 +156,8 @@ export async function startSign(personalNumber, userVisibleData, launchBankidApp
 
     const { orderRef, autoStartToken } = response.data;
 
-    if (launchBankidApp) {
-      // Tries to start the bankId app on the device for user authorization.
+    if (!authenticateOnExternalDevice) {
+      // Start the bankId app on the device for user authorization.
       await bankid.launchApp(autoStartToken);
     }
 
@@ -230,5 +230,12 @@ export async function checkIsBankidInstalled() {
   return {
     type: actionTypes.setIsBankidInstalled,
     isBankidInstalled: isInstalled,
+  };
+}
+
+export function setAuthenticateOnExternalDevice(value) {
+  return {
+    type: actionTypes.setAuthenticateOnExternalDevice,
+    authenticateOnExternalDevice: value,
   };
 }

--- a/source/store/reducers/AuthReducer.js
+++ b/source/store/reducers/AuthReducer.js
@@ -6,7 +6,6 @@ export const initialState = {
   user: null,
   error: null,
   status: 'idle',
-  isBankidInstalled: false,
   authenticateOnExternalDevice: false,
 };
 
@@ -108,12 +107,6 @@ export default function AuthReducer(state, action) {
       return {
         ...state,
         status: action.status,
-      };
-
-    case actionTypes.setIsBankidInstalled:
-      return {
-        ...state,
-        isBankidInstalled: action.isBankidInstalled,
       };
 
     case actionTypes.setError:

--- a/source/store/reducers/AuthReducer.js
+++ b/source/store/reducers/AuthReducer.js
@@ -7,6 +7,7 @@ export const initialState = {
   error: null,
   status: 'idle',
   isBankidInstalled: false,
+  authenticateOnExternalDevice: false,
 };
 
 export default function AuthReducer(state, action) {
@@ -119,6 +120,12 @@ export default function AuthReducer(state, action) {
       return {
         ...state,
         ...payload,
+      };
+
+    case actionTypes.setAuthenticateOnExternalDevice:
+      return {
+        ...state,
+        authenticateOnExternalDevice: action.authenticateOnExternalDevice,
       };
 
     default:


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed bug when a user is signing a case and Bankid app is always triggered, even if the user authenticated with Bankid from another device. 

## Explain your solution

Added a new state to save if user logged in on same device or external bankid app.
This state is then used to check if Bankid app should be triggered or not when sign action is called. 

## How to test the changes?
Log in with a user and enter personal number manually, to trigger Bankid on external app.
Then step through a form and click on Sign button. 
Now the Bankid app should only be triggered externaly and not open bankid on users phone.

After that do the same process but click the button "Logga in med Mobilt Bankid" and log in with your user stored in mobile bankid app. 
The bankid app should be automatically opened for both login and sign actions. 
 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [ ] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.