### PR TITLE
fix(case-overview): extended timeout for fetching cases on refresh

### DIFF
--- a/source/screens/caseScreens/CaseOverview.js
+++ b/source/screens/caseScreens/CaseOverview.js
@@ -189,7 +189,7 @@ function CaseOverview(props) {
       // Sometimes new cases is not created in an instant.
       // Due to this we have to give the api some time before we try to fetch cases,
       // since we cannot react to changes as of now.
-      const milliseconds = 2000;
+      const milliseconds = 4000;
       wait(milliseconds).then(() => {
         fetchCases();
       });


### PR DESCRIPTION
## Explain the changes you’ve made

I've added support for authentication to implement Key Result 2 of OKR1. It includes 
model, table, controller and test. For more background, see #CLICKUP-ID.
Include 

## Explain why these changes are made

These changes have been made due to that cases in the overview list is not up to date with the case data stored in AWS.

## Explain your solution

A Good example:
Extended the timeout time from 2s to 4s when case refresh is made when user lands on the case overview screen.

## Anyhting else? (optional)

Let's consider polling cases on an set interval to keep the cases up to date with the data that is stored in AWS. 