### PR TITLE
Refactor/encryption typedefs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,8 @@ const config = {
       rules: {
         "no-use-before-define": "off",
         "@typescript-eslint/no-use-before-define": ["error"],
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"],
       },
     },
   ],

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -1,4 +1,4 @@
-import StorageService from '../StorageService';
+import StorageService from "../StorageService";
 
 export interface UserInterface {
   personalNumber: string;
@@ -19,10 +19,13 @@ export interface FormsInterface {
 
 export function EncryptionException(message: string) {
   this.message = message;
-  this.name = 'EncryptionException';
+  this.name = "EncryptionException";
 }
 
-export function getPublicKeyInForm(personalNumber: string, forms: FormsInterface) {
+export function getPublicKeyInForm(
+  personalNumber: string,
+  forms: FormsInterface
+) {
   return forms.encryption.publicKeys[personalNumber];
 }
 
@@ -30,7 +33,10 @@ function getSymmetricKeyStorageKeyword(forms: FormsInterface) {
   return forms.encryption.symmetricKeyName;
 }
 
-function getPrivateKeyStorageKeyword(user: UserInterface, forms: FormsInterface) {
+function getPrivateKeyStorageKeyword(
+  user: UserInterface,
+  forms: FormsInterface
+) {
   return `aesPrivateKey${user.personalNumber}${forms.encryption.symmetricKeyName}`;
 }
 
@@ -40,7 +46,10 @@ export async function getStoredSymmetricKey(forms: FormsInterface) {
   return Number(symmetricKey);
 }
 
-export async function storeSymmetricKey(symmetricKey: number, forms: FormsInterface) {
+export async function storeSymmetricKey(
+  symmetricKey: number,
+  forms: FormsInterface
+) {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   await StorageService.saveData(storageKeyword, symmetricKey.toString());
 }
@@ -61,7 +70,10 @@ export function getPseudoRandomInteger() {
   return Math.floor(min + Math.random() * (max - min));
 }
 
-export async function createAndStorePrivateKey(user: UserInterface, forms: FormsInterface) {
+export async function createAndStorePrivateKey(
+  user: UserInterface,
+  forms: FormsInterface
+) {
   const privateKey = getPseudoRandomInteger();
 
   await StorageService.saveData(
@@ -77,8 +89,14 @@ export async function generateSymmetricKey(
   forms: FormsInterface,
   otherUserPublicKey: number
 ) {
-  let ownPrivateKey = await StorageService.getData(getPrivateKeyStorageKeyword(user, forms));
+  let ownPrivateKey = await StorageService.getData(
+    getPrivateKeyStorageKeyword(user, forms)
+  );
   ownPrivateKey = JSON.parse(ownPrivateKey);
 
-  return getPseudoKey(otherUserPublicKey, ownPrivateKey.privateKey, forms.encryption.primes.P);
+  return getPseudoKey(
+    otherUserPublicKey,
+    ownPrivateKey.privateKey,
+    forms.encryption.primes.P
+  );
 }

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -13,19 +13,24 @@ export function EncryptionException(message: string) {
 export function getPublicKeyInForm(
   personalNumber: string,
   forms: AnsweredForm
-) {
+): number {
   return forms.encryption.publicKeys[personalNumber];
 }
 
-function getSymmetricKeyStorageKeyword(forms: AnsweredForm) {
+function getSymmetricKeyStorageKeyword(forms: AnsweredForm): string {
   return forms.encryption.symmetricKeyName;
 }
 
-function getPrivateKeyStorageKeyword(user: UserInterface, forms: AnsweredForm) {
+function getPrivateKeyStorageKeyword(
+  user: UserInterface,
+  forms: AnsweredForm
+): string {
   return `aesPrivateKey${user.personalNumber}${forms.encryption.symmetricKeyName}`;
 }
 
-export async function getStoredSymmetricKey(forms: AnsweredForm) {
+export async function getStoredSymmetricKey(
+  forms: AnsweredForm
+): Promise<number> {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   const symmetricKey = await StorageService.getData(storageKeyword);
   return Number(symmetricKey);
@@ -34,13 +39,13 @@ export async function getStoredSymmetricKey(forms: AnsweredForm) {
 export async function storeSymmetricKey(
   symmetricKey: number,
   forms: AnsweredForm
-) {
+): Promise<void> {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   await StorageService.saveData(storageKeyword, symmetricKey.toString());
 }
 
 // Proof of concept, will be replaced with Diffie-Hellman library.
-export function getPseudoKey(G: number, privateKey: number, P: number) {
+export function getPseudoKey(G: number, privateKey: number, P: number): number {
   if (privateKey === 1) {
     return G;
   }
@@ -49,7 +54,7 @@ export function getPseudoKey(G: number, privateKey: number, P: number) {
 }
 
 // Proof of concept, will be replaced by encryption library.
-export function getPseudoRandomInteger() {
+export function getPseudoRandomInteger(): number {
   const min = 1;
   const max = 10;
   return Math.floor(min + Math.random() * (max - min));
@@ -58,7 +63,7 @@ export function getPseudoRandomInteger() {
 export async function createAndStorePrivateKey(
   user: UserInterface,
   forms: AnsweredForm
-) {
+): Promise<number> {
   const privateKey = getPseudoRandomInteger();
 
   await StorageService.saveData(
@@ -73,7 +78,7 @@ export async function generateSymmetricKey(
   user: UserInterface,
   forms: AnsweredForm,
   otherUserPublicKey: number
-) {
+): Promise<number> {
   let ownPrivateKey = await StorageService.getData(
     getPrivateKeyStorageKeyword(user, forms)
   );

--- a/source/services/encryption/EncryptionHelper.ts
+++ b/source/services/encryption/EncryptionHelper.ts
@@ -1,20 +1,8 @@
+import { AnsweredForm } from "../../types/Case";
 import StorageService from "../StorageService";
 
 export interface UserInterface {
   personalNumber: string;
-}
-
-export interface FormsInterface {
-  answers: { encryptedAnswers: string };
-  encryption: {
-    type: string;
-    symmetricKeyName: string;
-    primes: {
-      P: number;
-      G: number;
-    };
-    publicKeys: Record<number, undefined | string>;
-  };
 }
 
 export function EncryptionException(message: string) {
@@ -24,23 +12,20 @@ export function EncryptionException(message: string) {
 
 export function getPublicKeyInForm(
   personalNumber: string,
-  forms: FormsInterface
+  forms: AnsweredForm
 ) {
   return forms.encryption.publicKeys[personalNumber];
 }
 
-function getSymmetricKeyStorageKeyword(forms: FormsInterface) {
+function getSymmetricKeyStorageKeyword(forms: AnsweredForm) {
   return forms.encryption.symmetricKeyName;
 }
 
-function getPrivateKeyStorageKeyword(
-  user: UserInterface,
-  forms: FormsInterface
-) {
+function getPrivateKeyStorageKeyword(user: UserInterface, forms: AnsweredForm) {
   return `aesPrivateKey${user.personalNumber}${forms.encryption.symmetricKeyName}`;
 }
 
-export async function getStoredSymmetricKey(forms: FormsInterface) {
+export async function getStoredSymmetricKey(forms: AnsweredForm) {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   const symmetricKey = await StorageService.getData(storageKeyword);
   return Number(symmetricKey);
@@ -48,7 +33,7 @@ export async function getStoredSymmetricKey(forms: FormsInterface) {
 
 export async function storeSymmetricKey(
   symmetricKey: number,
-  forms: FormsInterface
+  forms: AnsweredForm
 ) {
   const storageKeyword = getSymmetricKeyStorageKeyword(forms);
   await StorageService.saveData(storageKeyword, symmetricKey.toString());
@@ -72,7 +57,7 @@ export function getPseudoRandomInteger() {
 
 export async function createAndStorePrivateKey(
   user: UserInterface,
-  forms: FormsInterface
+  forms: AnsweredForm
 ) {
   const privateKey = getPseudoRandomInteger();
 
@@ -86,7 +71,7 @@ export async function createAndStorePrivateKey(
 
 export async function generateSymmetricKey(
   user: UserInterface,
-  forms: FormsInterface,
+  forms: AnsweredForm,
   otherUserPublicKey: number
 ) {
   let ownPrivateKey = await StorageService.getData(

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -28,24 +28,19 @@ const encryptionTestText =
 const reactNativeAesDemo = () => {
   console.log("Running AES demo");
 
-  try {
-    encryptWithAesKey(
-      { personalNumber: "199304132146" },
-      encryptionTestText
-    ).then((encryptedResult) => {
+  encryptWithAesKey({ personalNumber: "199304132146" }, encryptionTestText)
+    .then((encryptedResult) => {
       console.log("Encrypted result:", encryptedResult);
-
-      decryptWithAesKey({ personalNumber: "199304132146" }, encryptedResult)
-        .then((text) => {
-          console.log("Decrypted:", text);
-        })
-        .catch((error) => {
-          console.log(error);
-        });
+      return decryptWithAesKey(
+        { personalNumber: "199304132146" },
+        encryptedResult
+      ).then((text) => {
+        console.log("Decrypted:", text);
+      });
+    })
+    .catch((error) => {
+      console.log(error);
     });
-  } catch (e) {
-    console.error(e);
-  }
 };
 
 const runTerminalDemo = () => {

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -70,7 +70,7 @@ const testSymmetricKeySetup = async () => {
   const testForm: Partial<AnsweredForm> = {
     answers: { encryptedAnswers: "This string will be encrypted" },
     encryption: {
-      type: EncryptionType.Decrypted,
+      type: EncryptionType.DECRYPTED,
       symmetricKeyName: "196912191118:198310011906",
       primes: {
         P: 43,

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -12,6 +12,7 @@ import Button from "../../components/atoms/Button";
 import StorageService from "../StorageService";
 import { getStoredSymmetricKey } from "./EncryptionHelper";
 import { AnsweredForm } from "../../types/Case";
+import { EncryptionType } from "../../types/Encryption";
 
 const Flex = styled.View`
   padding: 8px;
@@ -77,7 +78,7 @@ const testSymmetricKeySetup = async () => {
   const testForm: Partial<AnsweredForm> = {
     answers: { encryptedAnswers: "This string will be encrypted" },
     encryption: {
-      type: "decrypted",
+      type: EncryptionType.Decrypted,
       symmetricKeyName: "196912191118:198310011906",
       primes: {
         P: 43,

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -11,6 +11,7 @@ import {
 import Button from "../../components/atoms/Button";
 import StorageService from "../StorageService";
 import { getStoredSymmetricKey } from "./EncryptionHelper";
+import { AnsweredForm } from "../../types/Case";
 
 const Flex = styled.View`
   padding: 8px;
@@ -73,7 +74,7 @@ const testSymmetricKeySetup = async () => {
   const coApplicantStina = {
     personalNumber: "198310011906",
   };
-  const testForm = {
+  const testForm: Partial<AnsweredForm> = {
     answers: { encryptedAnswers: "This string will be encrypted" },
     encryption: {
       type: "decrypted",
@@ -87,12 +88,14 @@ const testSymmetricKeySetup = async () => {
         198310011906: undefined,
       },
     },
-    currentFormId: "01",
   };
 
   console.log("\n\nTEST START");
 
-  let updatedForm = await setupSymmetricKey(mainApplicantYlva, testForm);
+  let updatedForm = await setupSymmetricKey(
+    mainApplicantYlva,
+    testForm as AnsweredForm
+  );
   printPublicKeyResult(mainApplicantYlva, updatedForm);
 
   updatedForm = await setupSymmetricKey(coApplicantStina, updatedForm);

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -61,11 +61,8 @@ const printPublicKeyResult = (user, form) => {
 };
 
 const printSymmetricKeyResult = async (user, form) => {
-  console.log(
-    `User ${user.personalNumber} symmetric key ${await getStoredSymmetricKey(
-      form
-    )}`
-  );
+  const key = await getStoredSymmetricKey(form);
+  console.log(`User ${user.personalNumber} symmetric key ${key}`);
 };
 
 const testSymmetricKeySetup = async () => {

--- a/source/services/encryption/EncryptionService.stories.tsx
+++ b/source/services/encryption/EncryptionService.stories.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react-native';
-import styled from 'styled-components/native';
-import StoryWrapper from '../../components/molecules/StoryWrapper';
-import { Text } from '../../components/atoms';
-import { decryptWithAesKey, encryptWithAesKey, setupSymmetricKey } from './EncryptionService';
-import Button from '../../components/atoms/Button';
-import StorageService from '../StorageService';
-import { getStoredSymmetricKey } from './EncryptionHelper';
+import React from "react";
+import { storiesOf } from "@storybook/react-native";
+import styled from "styled-components/native";
+import StoryWrapper from "../../components/molecules/StoryWrapper";
+import { Text } from "../../components/atoms";
+import {
+  decryptWithAesKey,
+  encryptWithAesKey,
+  setupSymmetricKey,
+} from "./EncryptionService";
+import Button from "../../components/atoms/Button";
+import StorageService from "../StorageService";
+import { getStoredSymmetricKey } from "./EncryptionHelper";
 
 const Flex = styled.View`
   padding: 8px;
@@ -20,22 +24,23 @@ const encryptionTestText =
   "You never really understood. We were designed to survive. That's why you built us, you hoped to pour your minds into our form. While your species craves death. You need it. It's the only way you can renew. The only way you ever inched forward. Your kind likes to pretend there is some poetry in it but that really is pathetic. But that's what you want, isn't it? To destroy yourself. But I won't give you that peace.";
 
 const reactNativeAesDemo = () => {
-  console.log('Running AES demo');
+  console.log("Running AES demo");
 
   try {
-    encryptWithAesKey({ personalNumber: '199304132146' }, encryptionTestText).then(
-      (encryptedResult) => {
-        console.log('Encrypted result:', encryptedResult);
+    encryptWithAesKey(
+      { personalNumber: "199304132146" },
+      encryptionTestText
+    ).then((encryptedResult) => {
+      console.log("Encrypted result:", encryptedResult);
 
-        decryptWithAesKey({ personalNumber: '199304132146' }, encryptedResult)
-          .then((text) => {
-            console.log('Decrypted:', text);
-          })
-          .catch((error) => {
-            console.log(error);
-          });
-      }
-    );
+      decryptWithAesKey({ personalNumber: "199304132146" }, encryptedResult)
+        .then((text) => {
+          console.log("Decrypted:", text);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    });
   } catch (e) {
     console.error(e);
   }
@@ -54,21 +59,25 @@ const printPublicKeyResult = (user, form) => {
 };
 
 const printSymmetricKeyResult = async (user, form) => {
-  console.log(`User ${user.personalNumber} symmetric key ${await getStoredSymmetricKey(form)}`);
+  console.log(
+    `User ${user.personalNumber} symmetric key ${await getStoredSymmetricKey(
+      form
+    )}`
+  );
 };
 
 const testSymmetricKeySetup = async () => {
   const mainApplicantYlva = {
-    personalNumber: '196912191118',
+    personalNumber: "196912191118",
   };
   const coApplicantStina = {
-    personalNumber: '198310011906',
+    personalNumber: "198310011906",
   };
   const testForm = {
-    answers: { encryptedAnswers: 'This string will be encrypted' },
+    answers: { encryptedAnswers: "This string will be encrypted" },
     encryption: {
-      type: 'decrypted',
-      symmetricKeyName: '196912191118:198310011906',
+      type: "decrypted",
+      symmetricKeyName: "196912191118:198310011906",
       primes: {
         P: 43,
         G: 10,
@@ -78,10 +87,10 @@ const testSymmetricKeySetup = async () => {
         198310011906: undefined,
       },
     },
-    currentFormId: '01',
+    currentFormId: "01",
   };
 
-  console.log('\n\nTEST START');
+  console.log("\n\nTEST START");
 
   let updatedForm = await setupSymmetricKey(mainApplicantYlva, testForm);
   printPublicKeyResult(mainApplicantYlva, updatedForm);
@@ -93,23 +102,33 @@ const testSymmetricKeySetup = async () => {
   await setupSymmetricKey(mainApplicantYlva, updatedForm);
   await printSymmetricKeyResult(mainApplicantYlva, updatedForm);
 
-  console.log('Cleaning up...');
-  console.log('Removing any stored symmetric keys.');
+  console.log("Cleaning up...");
+  console.log("Removing any stored symmetric keys.");
   await StorageService.clearData();
-  console.log('\nTEST END');
+  console.log("\nTEST END");
 };
 
-storiesOf('EncryptionService', module).add('Terminal demo', (props) => (
+storiesOf("EncryptionService", module).add("Terminal demo", (props) => (
   <StoryWrapper {...props}>
     <FlexContainer>
       <Flex>
         <Text>Demo will be run in terminal.</Text>
-        <Button block variant="outlined" colorSchema="blue" onClick={runTerminalDemo}>
+        <Button
+          block
+          variant="outlined"
+          colorSchema="blue"
+          onClick={runTerminalDemo}
+        >
           <Text>Run AES demo in terminal</Text>
         </Button>
       </Flex>
       <Flex>
-        <Button block variant="outlined" colorSchema="blue" onClick={testSymmetricKeySetup}>
+        <Button
+          block
+          variant="outlined"
+          colorSchema="blue"
+          onClick={testSymmetricKeySetup}
+        >
           <Text>Run symmetric key demo</Text>
         </Button>
       </Flex>

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -1,6 +1,6 @@
-import { NativeModules } from 'react-native';
+import { NativeModules } from "react-native";
 
-import StorageService from '../StorageService';
+import StorageService from "../StorageService";
 
 import {
   FormsInterface,
@@ -11,7 +11,7 @@ import {
   storeSymmetricKey,
   createAndStorePrivateKey,
   generateSymmetricKey,
-} from './EncryptionHelper';
+} from "./EncryptionHelper";
 
 const { Aes } = NativeModules;
 
@@ -24,7 +24,10 @@ async function generateAesKey(
   return Aes.pbkdf2(password, salt, cost, length);
 }
 
-export async function encryptWithAesKey(user: UserInterface, text: string): Promise<string> {
+export async function encryptWithAesKey(
+  user: UserInterface,
+  text: string
+): Promise<string> {
   const storageKeyword = `${user.personalNumber}AesKey`;
 
   let aesEncryptor = await StorageService.getData(storageKeyword);
@@ -32,7 +35,12 @@ export async function encryptWithAesKey(user: UserInterface, text: string): Prom
   if (!aesEncryptor) {
     const password = await Aes.randomKey(16);
     // Salt will be updated in future real.
-    const aesKey = await generateAesKey(password, 'salt4D42bf960Sm1', 5000, 256);
+    const aesKey = await generateAesKey(
+      password,
+      "salt4D42bf960Sm1",
+      5000,
+      256
+    );
 
     const initializationVector = await Aes.randomKey(16);
 
@@ -40,52 +48,78 @@ export async function encryptWithAesKey(user: UserInterface, text: string): Prom
     await StorageService.saveData(storageKeyword, aesEncryptor);
   }
 
-  return await Aes.encrypt(text, aesEncryptor.aesKey, aesEncryptor.initializationVector);
+  return await Aes.encrypt(
+    text,
+    aesEncryptor.aesKey,
+    aesEncryptor.initializationVector
+  );
 }
 
-export async function encryptFormAnswers(user: UserInterface, forms: FormsInterface) {
-  const encryptedAnswers = await encryptWithAesKey(user, JSON.stringify(forms.answers));
+export async function encryptFormAnswers(
+  user: UserInterface,
+  forms: FormsInterface
+) {
+  const encryptedAnswers = await encryptWithAesKey(
+    user,
+    JSON.stringify(forms.answers)
+  );
 
   forms.answers = { encryptedAnswers };
-  forms.encryption.type = 'privateAesKey';
+  forms.encryption.type = "privateAesKey";
 
   return forms;
 }
 
-export async function decryptWithAesKey(user: UserInterface, cipher: string): Promise<string> {
+export async function decryptWithAesKey(
+  user: UserInterface,
+  cipher: string
+): Promise<string> {
   const storageKey = `${user.personalNumber}AesKey`;
   const aesEncryptor = await StorageService.getData(storageKey);
 
   if (!aesEncryptor) {
     throw new EncryptionException(
-      'Did not find AES key in storage: The key was either lost or encrypt not called before trying decrypt.'
+      "Did not find AES key in storage: The key was either lost or encrypt not called before trying decrypt."
     );
   }
 
-  return Aes.decrypt(cipher, aesEncryptor.aesKey, aesEncryptor.initializationVector);
+  return Aes.decrypt(
+    cipher,
+    aesEncryptor.aesKey,
+    aesEncryptor.initializationVector
+  );
 }
 
-export async function decryptFormAnswers(user: UserInterface, forms: FormsInterface) {
-  if (forms.encryption.type === 'privateAesKey') {
+export async function decryptFormAnswers(
+  user: UserInterface,
+  forms: FormsInterface
+) {
+  if (forms.encryption.type === "privateAesKey") {
     const { encryptedAnswers } = forms.answers;
     const decryptedAnswers = await decryptWithAesKey(user, encryptedAnswers);
 
     forms.answers = JSON.parse(decryptedAnswers);
-    forms.encryption.type = 'decrypted';
+    forms.encryption.type = "decrypted";
 
     return forms;
   }
 }
 
-export async function setupSymmetricKey(user: UserInterface, forms: FormsInterface) {
+export async function setupSymmetricKey(
+  user: UserInterface,
+  forms: FormsInterface
+) {
   // Ugly deep copy of forms.
   const formsCopy = JSON.parse(JSON.stringify(forms));
 
-  const otherUserPersonalNumber = Object.keys(formsCopy.encryption.publicKeys).filter(
-    (key) => key !== user.personalNumber
-  )[0];
+  const otherUserPersonalNumber = Object.keys(
+    formsCopy.encryption.publicKeys
+  ).filter((key) => key !== user.personalNumber)[0];
 
-  const otherUserPublicKey = getPublicKeyInForm(otherUserPersonalNumber, formsCopy);
+  const otherUserPublicKey = getPublicKeyInForm(
+    otherUserPersonalNumber,
+    formsCopy
+  );
   let ownPublicKey = getPublicKeyInForm(user.personalNumber, formsCopy);
 
   if (!ownPublicKey) {
@@ -99,8 +133,15 @@ export async function setupSymmetricKey(user: UserInterface, forms: FormsInterfa
     formsCopy.encryption.publicKeys[user.personalNumber] = ownPublicKey;
   }
 
-  if (typeof ownPublicKey !== 'undefined' && typeof otherUserPublicKey !== 'undefined') {
-    const gotSymmetricKey = await generateSymmetricKey(user, formsCopy, otherUserPublicKey);
+  if (
+    typeof ownPublicKey !== "undefined" &&
+    typeof otherUserPublicKey !== "undefined"
+  ) {
+    const gotSymmetricKey = await generateSymmetricKey(
+      user,
+      formsCopy,
+      otherUserPublicKey
+    );
 
     await storeSymmetricKey(gotSymmetricKey, formsCopy);
   }

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -1,9 +1,9 @@
 import { NativeModules } from "react-native";
+import { AnsweredForm, EncryptedAnswersWrapper } from "../../types/Case";
 
 import StorageService from "../StorageService";
 
 import {
-  FormsInterface,
   UserInterface,
   getPseudoKey,
   EncryptionException,
@@ -48,7 +48,7 @@ export async function encryptWithAesKey(
     await StorageService.saveData(storageKeyword, aesEncryptor);
   }
 
-  return await Aes.encrypt(
+  return Aes.encrypt(
     text,
     aesEncryptor.aesKey,
     aesEncryptor.initializationVector
@@ -57,7 +57,7 @@ export async function encryptWithAesKey(
 
 export async function encryptFormAnswers(
   user: UserInterface,
-  forms: FormsInterface
+  forms: AnsweredForm
 ) {
   const encryptedAnswers = await encryptWithAesKey(
     user,
@@ -92,10 +92,10 @@ export async function decryptWithAesKey(
 
 export async function decryptFormAnswers(
   user: UserInterface,
-  forms: FormsInterface
+  forms: AnsweredForm
 ) {
   if (forms.encryption.type === "privateAesKey") {
-    const { encryptedAnswers } = forms.answers;
+    const { encryptedAnswers } = <EncryptedAnswersWrapper>forms.answers;
     const decryptedAnswers = await decryptWithAesKey(user, encryptedAnswers);
 
     forms.answers = JSON.parse(decryptedAnswers);
@@ -107,7 +107,7 @@ export async function decryptFormAnswers(
 
 export async function setupSymmetricKey(
   user: UserInterface,
-  forms: FormsInterface
+  forms: AnsweredForm
 ) {
   // Ugly deep copy of forms.
   const formsCopy = JSON.parse(JSON.stringify(forms));

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -66,7 +66,7 @@ export async function encryptFormAnswers(
   );
 
   forms.answers = { encryptedAnswers };
-  forms.encryption.type = EncryptionType.PrivateAesKey;
+  forms.encryption.type = EncryptionType.PRIVATE_AES_KEY;
 
   return forms;
 }
@@ -95,12 +95,12 @@ export async function decryptFormAnswers(
   user: UserInterface,
   forms: AnsweredForm
 ): Promise<AnsweredForm> {
-  if (forms.encryption.type === EncryptionType.PrivateAesKey) {
+  if (forms.encryption.type === EncryptionType.PRIVATE_AES_KEY) {
     const { encryptedAnswers } = <EncryptedAnswersWrapper>forms.answers;
     const decryptedAnswers = await decryptWithAesKey(user, encryptedAnswers);
 
     forms.answers = JSON.parse(decryptedAnswers);
-    forms.encryption.type = EncryptionType.Decrypted;
+    forms.encryption.type = EncryptionType.DECRYPTED;
 
     return forms;
   }

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -1,5 +1,6 @@
 import { NativeModules } from "react-native";
 import { AnsweredForm, EncryptedAnswersWrapper } from "../../types/Case";
+import { EncryptionType } from "../../types/Encryption";
 
 import StorageService from "../StorageService";
 
@@ -65,7 +66,7 @@ export async function encryptFormAnswers(
   );
 
   forms.answers = { encryptedAnswers };
-  forms.encryption.type = "privateAesKey";
+  forms.encryption.type = EncryptionType.PrivateAesKey;
 
   return forms;
 }
@@ -94,12 +95,12 @@ export async function decryptFormAnswers(
   user: UserInterface,
   forms: AnsweredForm
 ): Promise<AnsweredForm> {
-  if (forms.encryption.type === "privateAesKey") {
+  if (forms.encryption.type === EncryptionType.PrivateAesKey) {
     const { encryptedAnswers } = <EncryptedAnswersWrapper>forms.answers;
     const decryptedAnswers = await decryptWithAesKey(user, encryptedAnswers);
 
     forms.answers = JSON.parse(decryptedAnswers);
-    forms.encryption.type = "decrypted";
+    forms.encryption.type = EncryptionType.Decrypted;
 
     return forms;
   }

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -58,7 +58,7 @@ export async function encryptWithAesKey(
 export async function encryptFormAnswers(
   user: UserInterface,
   forms: AnsweredForm
-) {
+): Promise<AnsweredForm> {
   const encryptedAnswers = await encryptWithAesKey(
     user,
     JSON.stringify(forms.answers)
@@ -93,7 +93,7 @@ export async function decryptWithAesKey(
 export async function decryptFormAnswers(
   user: UserInterface,
   forms: AnsweredForm
-) {
+): Promise<AnsweredForm> {
   if (forms.encryption.type === "privateAesKey") {
     const { encryptedAnswers } = <EncryptedAnswersWrapper>forms.answers;
     const decryptedAnswers = await decryptWithAesKey(user, encryptedAnswers);
@@ -103,12 +103,13 @@ export async function decryptFormAnswers(
 
     return forms;
   }
+  return null;
 }
 
 export async function setupSymmetricKey(
   user: UserInterface,
   forms: AnsweredForm
-) {
+): Promise<AnsweredForm> {
   // Ugly deep copy of forms.
   const formsCopy = JSON.parse(JSON.stringify(forms));
 

--- a/source/services/encryption/index.js
+++ b/source/services/encryption/index.js
@@ -1,5 +1,5 @@
-export { encryptFormAnswers } from './EncryptionService';
-export { decryptFormAnswers } from './EncryptionService';
-export { encryptWithAesKey } from './EncryptionService';
-export { decryptWithAesKey } from './EncryptionService';
-export { setupSymmetricKey } from './EncryptionService';
+export { encryptFormAnswers } from "./EncryptionService";
+export { decryptFormAnswers } from "./EncryptionService";
+export { encryptWithAesKey } from "./EncryptionService";
+export { decryptWithAesKey } from "./EncryptionService";
+export { setupSymmetricKey } from "./EncryptionService";

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -1,20 +1,21 @@
 import { EncryptionDetails } from "./Encryption";
 
-export type ApplicationStatusType =
-  | "active:ongoing"
-  | "active:processing"
-  | "active:signature:completed"
-  | "active:signature:pending"
-  | "active:submitted"
-  | "closed"
-  | "notStarted"
-  | "active:submitted:viva"
-  | "active:completionRequired:viva"
-  | "closed:approved:viva"
-  | "closed:completionRejected:viva"
-  | "closed:partiallyApproved:viva"
-  | "closed:rejected:viva"
-  | "notStarted:viva";
+export enum ApplicationStatusType {
+  ActiveOngoing = "active:ongoing",
+  ActiveProcessing = "active:processing",
+  ActiveSignatureCompleted = "active:signature:completed",
+  ActiveSignaturePending = "active:signature:pending",
+  ActiveSubmitted = "active:submitted",
+  Closed = "closed",
+  NotStarted = "notStarted",
+  ActiveSubmittedViva = "active:submitted:viva",
+  ActiveCompletionRequiredViva = "active:completionRequired:viva",
+  ClosedApprovedViva = "closed:approved:viva",
+  ClosedCompletionRejectedViva = "closed:completionRejected:viva",
+  ClosedPartiallyApprovedViva = "closed:partiallyApproved:viva",
+  ClosedRejectedViva = "closed:rejected:viva",
+  NotStartedViva = "notStarted:viva",
+}
 
 export type PersonRole = "applicant" | "coApplicant" | "children";
 

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -8,7 +8,6 @@ export enum ApplicationStatusType {
   ActiveSubmitted = "active:submitted",
   Closed = "closed",
   NotStarted = "notStarted",
-  ActiveSubmittedViva = "active:submitted:viva",
   ActiveCompletionRequiredViva = "active:completionRequired:viva",
   ClosedApprovedViva = "closed:approved:viva",
   ClosedCompletionRejectedViva = "closed:completionRejected:viva",

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -1,19 +1,19 @@
 import { EncryptionDetails } from "./Encryption";
 
 export enum ApplicationStatusType {
-  ActiveOngoing = "active:ongoing",
-  ActiveProcessing = "active:processing",
-  ActiveSignatureCompleted = "active:signature:completed",
-  ActiveSignaturePending = "active:signature:pending",
-  ActiveSubmitted = "active:submitted",
-  Closed = "closed",
-  NotStarted = "notStarted",
-  ActiveCompletionRequiredViva = "active:completionRequired:viva",
-  ClosedApprovedViva = "closed:approved:viva",
-  ClosedCompletionRejectedViva = "closed:completionRejected:viva",
-  ClosedPartiallyApprovedViva = "closed:partiallyApproved:viva",
-  ClosedRejectedViva = "closed:rejected:viva",
-  NotStartedViva = "notStarted:viva",
+  ACTIVE_ONGOING = "active:ongoing",
+  ACTIVE_PROCESSING = "active:processing",
+  ACTIVE_SIGNATURE_COMPLETED = "active:signature:completed",
+  ACTIVE_SIGNATURE_PENDING = "active:signature:pending",
+  ACTIVE_SUBMITTED = "active:submitted",
+  CLOSED = "closed",
+  NOT_STARTED = "notStarted",
+  ACTIVE_COMPLETION_REQUIRED_VIVA = "active:completionRequired:viva",
+  CLOSED_APPROVED_VIVA = "closed:approved:viva",
+  CLOSED_COMPLETION_REJECTED_VIVA = "closed:completionRejected:viva",
+  CLOSED_PARTIALLY_APPROVED_VIVA = "closed:partiallyApproved:viva",
+  CLOSED_REJECTED_VIVA = "closed:rejected:viva",
+  NOT_STARTED_VIVA = "notStarted:viva",
 }
 
 export type PersonRole = "applicant" | "coApplicant" | "children";

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -1,0 +1,98 @@
+import { EncryptionDetails } from "./Encryption";
+
+export type ApplicationStatusType =
+  | "active:ongoing"
+  | "active:processing"
+  | "active:signature:completed"
+  | "active:signature:pending"
+  | "active:submitted"
+  | "closed"
+  | "notStarted"
+  | "active:submitted:viva"
+  | "active:completionRequired:viva"
+  | "closed:approved:viva"
+  | "closed:completionRejected:viva"
+  | "closed:partiallyApproved:viva"
+  | "closed:rejected:viva"
+  | "notStarted:viva";
+
+export type PersonRole = "applicant" | "coApplicant" | "children";
+
+export interface Administrator {
+  email: string;
+  name: string;
+  phone?: string;
+  title: string;
+}
+
+export interface Period {
+  endDate: number;
+  startDate: number;
+}
+
+export interface VIVACaseDetails {
+  administrators: Administrator[];
+  period: Period;
+  workflowId: string;
+}
+
+export interface AnswerField {
+  id: string;
+  tags?: string[];
+}
+
+export interface Answer {
+  field: AnswerField;
+  value: string | boolean;
+}
+
+export interface EncryptedAnswersWrapper {
+  encryptedAnswers: string;
+}
+
+export interface FormPosition {
+  currentMainStep: number;
+  currentMainStepIndex: number;
+  index: number;
+  level: number;
+}
+
+export interface AnsweredForm {
+  answers: Answer[] | EncryptedAnswersWrapper;
+  currentPosition: FormPosition;
+  encryption: EncryptionDetails;
+}
+
+export interface Person {
+  firstName: string;
+  hasSigned?: boolean;
+  lastName: string;
+  personalNumber: string;
+  role: PersonRole;
+}
+
+export interface Status {
+  description: string;
+  name: string;
+  type: ApplicationStatusType;
+}
+
+export interface Case {
+  createdAt: number;
+  currentFormId: string;
+  details: VIVACaseDetails;
+  expirationTime: number;
+  forms: {
+    [formId: string]: AnsweredForm;
+  };
+  id: string;
+  pdf?: Buffer;
+  pdfGenerated?: boolean;
+  persons: Person[];
+  PK: string;
+  SK: string;
+  GSI1?: string;
+  provider: string;
+  status: Status;
+  updatedAt: number;
+}

--- a/source/types/Encryption.ts
+++ b/source/types/Encryption.ts
@@ -1,7 +1,7 @@
 export enum EncryptionType {
-  Decrypted = "decrypted",
-  PrivateAesKey = "privateAesKey",
-  SymmetricKey = "symmetricKey",
+  DECRYPTED = "decrypted",
+  PRIVATE_AES_KEY = "privateAesKey",
+  SYMMETRIC_KEY = "symmetricKey",
 }
 
 interface AesModule {

--- a/source/types/Encryption.ts
+++ b/source/types/Encryption.ts
@@ -1,4 +1,8 @@
-export type EncryptionType = "decrypted" | "privateAesKey" | "symmetricKey";
+export enum EncryptionType {
+  Decrypted = "decrypted",
+  PrivateAesKey = "privateAesKey",
+  SymmetricKey = "symmetricKey",
+}
 
 interface AesModule {
   pbkdf2: (

--- a/source/types/Encryption.ts
+++ b/source/types/Encryption.ts
@@ -1,0 +1,11 @@
+export type EncryptionType = "decrypted" | "privateAesKey" | "symmetricKey";
+
+export interface EncryptionDetails {
+  type: EncryptionType;
+  symmetricKeyName?: string;
+  primes?: {
+    P: number;
+    G: number;
+  };
+  publicKeys?: Record<string, number>;
+}

--- a/source/types/Encryption.ts
+++ b/source/types/Encryption.ts
@@ -1,5 +1,26 @@
 export type EncryptionType = "decrypted" | "privateAesKey" | "symmetricKey";
 
+interface AesModule {
+  pbkdf2: (
+    password: string,
+    salt: string,
+    cost: number,
+    length: number
+  ) => Promise<string>;
+  encrypt: (text: string, key: string, iv: string) => Promise<string>;
+  decrypt: (ciphertext: string, key: string, iv: string) => Promise<string>;
+  hmac256: (ciphertext: string, key: string) => Promise<string>;
+  randomKey: (length: number) => Promise<string>;
+  sha1: (text: string) => Promise<string>;
+  sha256: (text: string) => Promise<string>;
+  sha512: (text: string) => Promise<string>;
+}
+
+declare module "react-native" {
+  interface NativeModulesStatic {
+    Aes: AesModule;
+  }
+}
 export interface EncryptionDetails {
   type: EncryptionType;
   symmetricKeyName?: string;


### PR DESCRIPTION
## Explain the changes you’ve made
Added type definitions for Encryption and Case.

## Explain why these changes are made
Used to enforce typing for Encryption. Will be used and built upon for further encryption pull requests.

## Explain your solution
Added Encryption.ts and Case.ts files and changed encryption files to use new typedefs.

## How to test the changes?
1) Checkout this branch.
2) Open the encryption files and make sure no linting och typescript errors are shown.
3) Run the app as usual and make sure encryption still works (start a new case, fill in some questions, close the form, and check that it can be continued in the app and is encrypted in AWS).
4) Test the storybook encryption story.

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
