### PR TITLE
🐛 Fix bug where image wasn't readable in viva (#CU-1e6mzqy)

### DIFF
--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -134,8 +134,6 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
         height: 800,
         includeBase64: false,
         compressImageQuality: 0.8,
-        compressImageMaxHeight: 1200,
-        compressImageMaxWidth: 1200,
         writeTempFile: true,
         cropping: false,
         includeExif: false,
@@ -156,8 +154,6 @@ const ImageUploader: React.FC<Props> = ({ buttonText, value: images, answers, on
       const rawImage = await ImagePicker.openCamera({
         includeBase64: false,
         compressImageQuality: 0.8,
-        compressImageMaxHeight: 1200,
-        compressImageMaxWidth: 1200,
         cropping: false,
         includeExif: false,
       });


### PR DESCRIPTION
## Explain the changes you’ve made

I've removed the maximum dimensions for the image picker as the cropping causes the images to become unreadable. More info available at #CU-1e6mzqy

## Explain why these changes are made

To facilitate readability of images

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Start a stickprov
3. Upload an image
4. Open the image in S3
5. See that it's readable.

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Anything else? (optional)

I'm unsure if this is the best way to go about this issue, as it does increase the file size on S3.