### PR TITLE
feat: add coverage report on jest unittests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -45,8 +45,6 @@ jobs:
         run: |
           file_list=$(git diff --name-only --diff-filter=d origin/$GIT_BASE_REF HEAD | egrep -i '\.([jt]sx?)$')
 
-          echo "FOUND FILES: $file_list"
-
           if [[ -n $file_list ]]
           then
               yarn eslint $file_list
@@ -64,8 +62,6 @@ jobs:
             | egrep -i '\.([jt]sx?|json|md|ya?ml|s?css)$' \
             | egrep -v "^package.json$"
           )
-
-          echo "FOUND FILES IN STYLES: $file_list"
 
           if [[ -n $file_list ]]
           then

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -43,7 +43,9 @@ jobs:
         env:
           GIT_BASE_REF: ${{ github.base_ref }}
         run: |
-          file_list=$(git diff --name-only --diff-filter=d origin/$GIT_BASE_REF HEAD | egrep -i '\.([j|t]sx?)$')
+          file_list=$(git diff --name-only --diff-filter=d origin/$GIT_BASE_REF HEAD | egrep -i '\.([jt]sx?)$')
+
+          echo "FOUND FILES: $file_list"
 
           if [[ -n $file_list ]]
           then
@@ -63,6 +65,8 @@ jobs:
             | egrep -v "^package.json$"
           )
 
+          echo "FOUND FILES IN STYLES: $file_list"
+
           if [[ -n $file_list ]]
           then
               yarn prettier --check $file_list
@@ -72,4 +76,4 @@ jobs:
 
       # run tests
       - name: run tests
-        run: yarn test -- --coverage
+        run: yarn test --coverage

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -72,4 +72,4 @@ jobs:
 
       # run tests
       - name: run tests
-        run: yarn test
+        run: yarn test -- --coverage

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GIT_BASE_REF: ${{ github.base_ref }}
         run: |
-          file_list=$(git diff --name-only --diff-filter=d origin/$GIT_BASE_REF HEAD | egrep -i '\.([jt]sx?)$')
+          file_list=$(git diff --name-only --diff-filter=d origin/$GIT_BASE_REF HEAD | egrep -i '\.([j|t]sx?)$')
 
           if [[ -n $file_list ]]
           then


### PR DESCRIPTION
## Explain the changes you’ve made
Add printing of jest test coverage after tests has been run

## Explain why these changes are made
These changes are made to have a better overview of what is tested and how much testing coverage we have in our files.

## Explain your solution
Added -- --coverage flag when running jest

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Create PR
3. let the smoke test run and see the result of the testing

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/81250970/134898469-e57bc55d-001d-4a34-a4e9-925663c80979.png)
