### PR TITLE
🐛 Fix bug where hidden fields didn't save

### DIFF
--- a/source/components/organisms/Step/Step.js
+++ b/source/components/organisms/Step/Step.js
@@ -54,6 +54,7 @@ function Step({
   onSubmit,
   onFieldChange,
   onFieldBlur,
+  onFieldMount,
   isBackBtnVisible,
   updateCaseInContext,
   currentPosition,
@@ -199,6 +200,7 @@ function Step({
                       key={`${field.id}`}
                       onChange={!status.type.includes('submitted') ? onFieldChange : null}
                       onBlur={onFieldBlur}
+                      onMount={onFieldMount}
                       inputType={field.type}
                       value={answers[field.id] || ''}
                       answers={answers}
@@ -294,6 +296,9 @@ Step.propTypes = {
   onFieldChange: PropTypes.func,
   /** The function to handle fields losing focus */
   onFieldBlur: PropTypes.func,
+  
+  onFieldMount: PropTypes.func,
+  
   /*
    * A object with form navigation actions
    */

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -215,6 +215,7 @@ const Form: React.FC<Props> = ({
           onFieldChange={handleInputChange}
           onFieldBlur={handleBlur}
           updateCaseInContext={updateCaseInContext}
+          onFieldMount={handleInputChange}
           currentPosition={formState.currentPosition}
           totalStepNumber={formState.numberOfMainSteps || 0}
           isBackBtnVisible={

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -28,6 +28,7 @@ import PdfViewer from '../../components/molecules/PdfViewer/PdfViewer';
  * blurEvent: if the component can be blurred, this is the name of the corresponding prop, typically 'onBlur'
  * helpInComponent: set to true if the component has a help button 'inside', where the help should go instead of in the label.
  * helpProp: the name of the prop where the help object should be sent, typically just 'help'.
+ * onMountEvent: The event that triggers when the input is mounted
  * props: additional props to send into the generated component
  */
 const inputTypes = {
@@ -57,6 +58,7 @@ const inputTypes = {
       showErrorMessage: false,
       hidden: true,
     },
+    onMountEvent: 'onMount'
   },
   date: {
     component: CalendarPicker,
@@ -164,6 +166,7 @@ const FormField = ({
   onChange,
   onBlur,
   onFocus,
+  onMount,
   value,
   answers,
   validationErrors,
@@ -183,6 +186,10 @@ const FormField = ({
   const onInputBlur = (value, fieldId = id) => {
     if (onBlur) onBlur({ [fieldId]: value }, fieldId);
   };
+
+  const onInputMount = (value, fieldId = id) => {
+    if (onMount) onMount({[fieldId]: value}, fieldId);
+  }
 
   const onInputFocus = (e, isSelect = false) => {
     if (onFocus) {
@@ -211,6 +218,7 @@ const FormField = ({
   if (input && input.blurEvent) inputCompProps[input.blurEvent] = onInputBlur;
   if (input && input.focusEvent) inputCompProps[input.focusEvent] = onInputFocus;
   if (input && input.helpInComponent) inputCompProps[input.helpProp || 'help'] = help;
+  if (input && input.onMountEvent) inputCompProps[input.onMountEvent] = onInputMount;
 
   const inputComponent =
     input && input.component ? (
@@ -272,6 +280,8 @@ FormField.propTypes = {
   /** What happens when an input field looses focus.  */
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
+
+  onMount: PropTypes.func,
   /**
    * sets the value, since the input field component should be managed.
    */


### PR DESCRIPTION
## Explain the changes you’ve made

In accordance with #CU-1ej51y0, I've made a fix for hidden fields to save in the submitted data.

## Explain your solution

In order to facilitate this, I've added a listener to the `onMount` event of inputs for hidden fields, which further up in the chain calls the `handleInputChange` function to add the field and its value to the form answers.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Edit a form to have a hidden field
3. Create a case with the edited form
4. Submit the hidden field
5. See that it shows up in the case data

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.


