### PR TITLE
feat: added collapsible section component

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-native-background-timer": "^2.4.1",
     "react-native-calendar-picker": "^7.0.5",
     "react-native-calendars": "^1.1266.0",
+    "react-native-collapsible": "^1.6.0",
     "react-native-config": "1.4.0",
     "react-native-document-picker": "^5.0.0",
     "react-native-elements": "^3.0.0-alpha.1",

--- a/source/components/molecules/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/source/components/molecules/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { storiesOf } from "@storybook/react-native";
+import styled from "styled-components/native";
+
+import StoryWrapper from "../StoryWrapper";
+import Text from "../../atoms/Text";
+
+import CollapsibleSection from "./CollapsibleSection";
+
+const FlexContainer = styled.ScrollView`
+  background-color: #fff;
+  flex: 1;
+`;
+
+const Children = () => (
+  <Text style={{ margin: 0, padding: 0, height: 300, backgroundColor: "red" }}>
+    This is my awesome children text
+  </Text>
+);
+
+const OverviewExamples = () => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const handleIconClick = () => {
+    setIsCollapsed((oldValue) => !oldValue);
+  };
+
+  return (
+    <FlexContainer>
+      <Text type="h5">Default design</Text>
+      <CollapsibleSection
+        title="Section title"
+        collapsed={isCollapsed}
+        onPress={handleIconClick}
+      >
+        <Children />
+      </CollapsibleSection>
+    </FlexContainer>
+  );
+};
+
+storiesOf("Collapsible section", module).add(
+  "Overview examples",
+  ({ style, kind, name, children }) => (
+    <StoryWrapper style={style} kind={kind} name={name}>
+      {children}
+      <OverviewExamples />
+    </StoryWrapper>
+  )
+);

--- a/source/components/molecules/CollapsibleSection/CollapsibleSection.tsx
+++ b/source/components/molecules/CollapsibleSection/CollapsibleSection.tsx
@@ -1,0 +1,52 @@
+import React, { useContext } from "react";
+import { Platform } from "react-native";
+import Collapsible from "react-native-collapsible";
+import { ThemeContext } from "styled-components/native";
+
+import Icon from "../../atoms/Icon";
+import Text from "../../atoms/Text";
+
+import { Section, TitleBar } from "./styled";
+
+const ICON = {
+  android: {
+    COLLAPSED: "unfold-less",
+    NOT_COLLAPSED: "unfold-more",
+  },
+  ios: {
+    COLLAPSED: "expand-less",
+    NOT_COLLAPSED: "expand-more",
+  },
+};
+
+interface CollapsibleSectionProps {
+  title: string;
+  collapsed: boolean;
+  children: React.ReactChild | React.ReactChildren;
+  onPress: () => void;
+}
+const CollapsibleSection = (props: CollapsibleSectionProps): JSX.Element => {
+  const { title, collapsed, children, onPress } = props;
+  const theme = useContext(ThemeContext);
+
+  const underlayColor = theme.colors.neutrals[5];
+  const sectionColor = theme.colors.neutrals[6];
+
+  const iconName = collapsed
+    ? ICON[Platform.OS].COLLAPSED
+    : ICON[Platform.OS].NOT_COLLAPSED;
+
+  return (
+    <Section color={sectionColor}>
+      <TitleBar onPress={onPress} underlayColor={underlayColor}>
+        <>
+          <Text type="h5">{title}</Text>
+          <Icon name={iconName} />
+        </>
+      </TitleBar>
+      <Collapsible collapsed={collapsed}>{children}</Collapsible>
+    </Section>
+  );
+};
+
+export default CollapsibleSection;

--- a/source/components/molecules/CollapsibleSection/index.ts
+++ b/source/components/molecules/CollapsibleSection/index.ts
@@ -1,0 +1,3 @@
+import CollapsibleSection from "./CollapsibleSection";
+
+export default CollapsibleSection;

--- a/source/components/molecules/CollapsibleSection/styled.ts
+++ b/source/components/molecules/CollapsibleSection/styled.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components/native";
+
+interface SectionProps {
+  color: string;
+}
+const Section = styled.View<SectionProps>`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background: ${({ color }) => color};
+`;
+
+const TitleBar = styled.TouchableHighlight`
+  display: flex;
+  height: 40px;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  align-items: center;
+  padding: 0px 30px 0px 24px;
+`;
+
+export { Section, TitleBar };

--- a/source/components/molecules/CollapsibleSection/test/CollapsibleSection.test.tsx
+++ b/source/components/molecules/CollapsibleSection/test/CollapsibleSection.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Text } from "react-native";
+import { fireEvent } from "@testing-library/react-native";
+
+import { render } from "../../../../../test-utils";
+
+import CollapsibleSection from "..";
+
+const mockText = "mockText";
+const mockSectionTitle = "mockTitle";
+
+const ChildComponent = () => <Text>{mockText}</Text>;
+
+it("renders the provided props (including children)", () => {
+  const { queryByText } = render(
+    <CollapsibleSection
+      title={mockSectionTitle}
+      collapsed={false}
+      onPress={jest.fn()}
+    >
+      <ChildComponent />
+    </CollapsibleSection>
+  );
+
+  const titleElement = queryByText(mockSectionTitle);
+  const childTextElement = queryByText(mockText);
+
+  expect(titleElement).not.toBeNull();
+  expect(childTextElement).not.toBeNull();
+});
+
+it("calls the onPress when section is clicked", () => {
+  const mockCallback = jest.fn();
+
+  const { queryByText } = render(
+    <CollapsibleSection
+      title={mockSectionTitle}
+      collapsed={false}
+      onPress={mockCallback}
+    >
+      <ChildComponent />
+    </CollapsibleSection>
+  );
+
+  const titleElement = queryByText(mockSectionTitle);
+  fireEvent.press(titleElement);
+
+  expect(mockCallback).toHaveBeenCalledTimes(1);
+});

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -23,6 +23,7 @@ function loadStories() {
   require("../source/components/molecules/CaseCard/CaseCard.stories");
   require("../source/components/molecules/CharacterCard/CharacterCard.stories");
   require("../source/components/molecules/CheckboxField/CheckboxField.stories");
+  require("../source/components/molecules/CollapsibleSection/CollapsibleSection.stories");
   require("../source/components/molecules/DateTimePicker/DateTimePickerForm.stories");
   require("../source/components/molecules/DayPicker/DayPicker.stories");
   require("../source/components/molecules/EditableList/EditableList.stories");
@@ -72,6 +73,7 @@ const stories = [
   "../source/components/molecules/CaseCard/CaseCard.stories",
   "../source/components/molecules/CharacterCard/CharacterCard.stories",
   "../source/components/molecules/CheckboxField/CheckboxField.stories",
+  "../source/components/molecules/CollapsibleSection/CollapsibleSection.stories",
   "../source/components/molecules/DateTimePicker/DateTimePickerForm.stories",
   "../source/components/molecules/DayPicker/DayPicker.stories",
   "../source/components/molecules/EditableList/EditableList.stories",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7797,6 +7797,11 @@ react-native-codegen@^0.0.6:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
+react-native-collapsible@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-collapsible/-/react-native-collapsible-1.6.0.tgz#ca261ffff16914f872059bb0972e3a78c4b37f9c"
+  integrity sha512-beZjdgbT9Y/Pg591Xy5XkKG20HffJiVad4n9bfcUF/f783A+tvOVXnqvbS58Lkaym93mi4jcDPMuW9Vc1t6rqg==
+
 react-native-config@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.4.0.tgz#76e6ba1194a4c23d2e687a0630458238692eec4b"


### PR DESCRIPTION
## Explain the changes you’ve made
Added a new component (CollapsibleSection) which hides its children until it is expanded. Will be used with the booking flow in the application.

## Explain why these changes are made
The component is needed to be able to hide its children when used in a list. In order to make the list not too long, the components are initially hidden. 

## Explain your solution
Added a new npm module (react-native-collapsible) which makes the collapsible logic a lot easier instead of creating the animation ourselves. Also used standard react-native components and device specific icons to building it.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command`yarn ios` or `yarn android`

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.

## Screenshots (optional)
# IOS
closed:
![image](https://user-images.githubusercontent.com/81250970/136023854-c5a8dbe2-fccc-41a3-9778-52e1fa07634a.png)
open:
![image](https://user-images.githubusercontent.com/81250970/136023894-c69f353d-0714-4922-a74f-f940ad0b29a8.png)

# Android
closed:
![image](https://user-images.githubusercontent.com/81250970/136024033-04ccff0b-7d58-4a4d-b484-b521c59d1b30.png)
open:
![image](https://user-images.githubusercontent.com/81250970/136024067-fde3c3ae-f503-4379-832b-4a0dcc375537.png)
