### PR TITLE
fix: don't blank hidden field value on mount

### DIFF
--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -85,6 +85,7 @@ const Form: React.FC<Props> = ({
     formState,
     formNavigation,
     handleInputChange,
+    handleInputMount,
     handleSubmit,
     handleBlur,
     handleAddAnswer,
@@ -217,7 +218,7 @@ const Form: React.FC<Props> = ({
           onFieldBlur={handleBlur}
           onAddAnswer={handleAddAnswer}
           updateCaseInContext={updateCaseInContext}
-          onFieldMount={handleInputChange}
+          onFieldMount={handleInputMount}
           currentPosition={formState.currentPosition}
           totalStepNumber={formState.numberOfMainSteps || 0}
           isBackBtnVisible={

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -161,6 +161,11 @@ function useForm(initialState: FormReducerState) {
     dispatch({ type: 'UPDATE_ANSWER', payload: answer });
     dispatch({ type: 'VALIDATE_ANSWER', payload: { answer, id: questionId, checkIfDirty: true } });
   };
+
+  const handleInputMount = (answer: Record<string, any>, questionId: string) => {
+    console.log("handleInputMount", questionId, answer);
+    dispatch({ type: "VALIDATE_ANSWER", payload: { answer, id: questionId, checkIfDirty: true } });
+  };
   
   const handleAddAnswer = (answer: Record<string, any>, questionId: string) => {
     dispatch({ type: 'DIRTY_FIELD', payload: { answer, id: questionId } });
@@ -186,6 +191,7 @@ function useForm(initialState: FormReducerState) {
     formState,
     formNavigation,
     handleInputChange,
+    handleInputMount,
     handleBlur,
     handleSubmit,
     handleAddAnswer,


### PR DESCRIPTION
## Explain the changes you’ve made

Fixed hidden field values not being correctly pre-populated.

## Explain why these changes are made

This fixes the bug where dynamic co-applicant form did not work as intended.

## Explain your solution

In order to mark hidden fields as dirty (so that their value gets picked up and sent with the application) they are marked as "changed" when initially mounted, however this process also updates the field value to the supplied answer (which on mount is blank - pre-population happens after mount).

The fix is to create a custom form action which only marks the field as dirty, not changed, and use that for the field mount event.

## How to test the changes?

Concrete example:

Two things to check:

1) Hidden descriptions (such as hyra för inneboende) is correctly applied and sent to VIVA (instead of "övrig inkomst")
2) Form correctly displays co-applicant fields for when a main applicant views the form 

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- []X Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots (optional)

You can easily tell if it's the co-applicant variant of the form if there's an "OM #PARTNERNAME" on the second page:
![image](https://user-images.githubusercontent.com/2890987/137439039-585eee3e-d13b-49b9-9db9-23cd308744a1.png)
