### PR TITLE
✨ Add support for rendering hidden fields in repeaters

### DIFF
--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -1,26 +1,30 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { LayoutAnimation } from 'react-native';
-import { Button, Icon, Text } from '../../atoms';
-import RepeaterFieldListItem from './RepeaterFieldListItem';
-import Fieldset from '../../atoms/Fieldset/Fieldset';
-import { getValidColorSchema, PrimaryColor } from '../../../styles/themeHelpers';
-import { InputFieldType } from '../../../types/FormTypes';
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { LayoutAnimation } from "react-native";
+import { Button, Icon, Text } from "../../atoms";
+import RepeaterFieldListItem from "./RepeaterFieldListItem";
+import Fieldset from "../../atoms/Fieldset/Fieldset";
+import {
+  getValidColorSchema,
+  PrimaryColor,
+} from "../../../styles/themeHelpers";
+import { InputFieldType } from "../../../types/FormTypes";
 
 const AddButton = styled(Button)`
   margin-top: 30px;
-  background: ${props => props.theme.colors.neutrals[7]};
+  background: ${(props) => props.theme.colors.neutrals[7]};
   border: 0;
-`
+`;
 export interface InputRow {
   id: string;
   title: string;
-  type: 'text' | 'date' | 'number';
+  type: "text" | "date" | "number" | "hidden";
   inputSelectValue: InputFieldType;
+  value?: string;
 }
 
-type Answers = Record<string, any> | string | number
+type Answers = Record<string, any> | string | number;
 
 interface Props {
   heading: string;
@@ -31,33 +35,51 @@ interface Props {
   onBlur?: (answers: Answers, fieldId?: string) => void;
   onAddAnswer?: (answers: Answers, fieldId?: string) => void;
   colorSchema: PrimaryColor;
-  error?: Record<string, {isValid: boolean, validationMessage: string}>[];
+  error?: Record<string, { isValid: boolean; validationMessage: string }>[];
   maxRows?: number;
 }
 const emptyInput: Record<string, string | number>[] = [];
 
-function isRecordArray(value: string | Record<string,string|number>[]): value is Record<string, string | number>[] {
-  return typeof value !== 'string';
+function isRecordArray(
+  value: string | Record<string, string | number>[]
+): value is Record<string, string | number>[] {
+  return typeof value !== "string";
 }
 /**
  * Repeater field component, for adding multiple copies of a particular kind of input.
  * The input-prop specifies the form of each input-group.
  */
-const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChange, onBlur, onAddAnswer, colorSchema, value, error, maxRows }) => {
-  const [localAnswers, setLocalAnswers] = useState( isRecordArray(value) ? value : emptyInput);
+const RepeaterField: React.FC<Props> = ({
+  heading,
+  addButtonText,
+  inputs,
+  onChange,
+  onBlur,
+  onAddAnswer,
+  colorSchema,
+  value,
+  error,
+  maxRows,
+}) => {
+  const [localAnswers, setLocalAnswers] = useState(
+    isRecordArray(value) ? value : emptyInput
+  );
 
-  const changeFromInput = (index: number) => (input: InputRow) => (text: string) => {
-    localAnswers[index][input.id] = text;
-    onChange(localAnswers);
-    setLocalAnswers([...localAnswers]);
-  };
+  const changeFromInput =
+    (index: number) => (input: InputRow) => (text: string) => {
+      console.log("change from input", index, input, text);
+      localAnswers[index][input.id] = text;
+      onChange(localAnswers);
+      setLocalAnswers([...localAnswers]);
+    };
 
   const onInputBlur = () => {
+    console.log("oninput blur", localAnswers);
     if (onBlur) onBlur(localAnswers);
   };
 
   const removeAnswer = (index: number) => () => {
-    setLocalAnswers(prev => {
+    setLocalAnswers((prev) => {
       prev.splice(index, 1);
       onChange(prev);
       if (onBlur) onBlur(prev);
@@ -76,11 +98,11 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
         type: LayoutAnimation.Types.easeInEaseOut,
       },
     });
-    // construct a new answer object from the inputs, where each answer is an empty string to start
+    // construct a new answer object from the inputs, where each answer is either the input value or an empty string to start
     const newAnswers = {};
-    inputs.forEach(input => {
-      newAnswers[input.id] = '';
-    })
+    inputs.forEach((input) => {
+      newAnswers[input.id] = input.value || "";
+    });
     const updatedAnswers = [...localAnswers, newAnswers];
     onChange(updatedAnswers);
     setLocalAnswers(updatedAnswers);
@@ -96,24 +118,34 @@ const RepeaterField: React.FC<Props> = ({ heading, addButtonText, inputs, onChan
     listItems.push(
       <RepeaterFieldListItem
         key={`${index}`}
-        heading={`${heading} ${index+1}`}
+        heading={`${heading} ${index + 1}`}
         inputs={inputs}
         value={answer}
         changeFromInput={changeFromInput(index)}
         onBlur={onInputBlur}
         color={validColorSchema}
         removeItem={removeAnswer(index)}
-        error={error && error[index] ? error[index]: undefined}
+        error={error && error[index] ? error[index] : undefined}
       />
     );
   });
 
   return (
-    <Fieldset legend={heading} colorSchema={validColorSchema} empty={listItems.length === 0}>
-       {listItems}
-      <AddButton onClick={addAnswer} colorSchema="green" block variant="outlined" disabled={maxRows && listItems.length >= maxRows}>
+    <Fieldset
+      legend={heading}
+      colorSchema={validColorSchema}
+      empty={listItems.length === 0}
+    >
+      {listItems}
+      <AddButton
+        onClick={addAnswer}
+        colorSchema="green"
+        block
+        variant="outlined"
+        disabled={maxRows && listItems.length >= maxRows}
+      >
         <Icon name="add" color="green" />
-        <Text>{addButtonText || 'Lägg till'}</Text>
+        <Text>{addButtonText || "Lägg till"}</Text>
       </AddButton>
     </Fieldset>
   );
@@ -144,7 +176,7 @@ RepeaterField.propTypes = {
 
 RepeaterField.defaultProps = {
   inputs: [],
-  color: 'red',
+  color: "red",
   onChange: () => {},
 };
 export default RepeaterField;

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -1,14 +1,18 @@
+/* eslint-disable react/display-name */
 /* eslint-disable no-nested-ternary */
-import React, {useRef} from 'react';
-import styled from 'styled-components/native';
-import PropTypes from 'prop-types';
-import { Text, Input } from '../../atoms';
-import Button from '../../atoms/Button';
-import Label from '../../atoms/Label';
-import { InputRow } from './RepeaterField';
-import CalendarPicker from '../CalendarPicker/CalendarPickerForm';
-import theme from '../../../styles/theme';
-import { getValidColorSchema, PrimaryColor } from '../../../styles/themeHelpers';
+import React, { useRef } from "react";
+import styled from "styled-components/native";
+import PropTypes from "prop-types";
+import { Text, Input } from "../../atoms";
+import Button from "../../atoms/Button";
+import Label from "../../atoms/Label";
+import { InputRow } from "./RepeaterField";
+import CalendarPicker from "../CalendarPicker/CalendarPickerForm";
+import theme from "../../../styles/theme";
+import {
+  getValidColorSchema,
+  PrimaryColor,
+} from "../../../styles/themeHelpers";
 
 const Base = styled.View`
   padding: 0px;
@@ -17,61 +21,69 @@ const Base = styled.View`
   border-radius: 6px;
 `;
 
-const RepeaterItem = styled.TouchableOpacity<{colorSchema: string; error: Record<string, any>}>`
-  font-size: ${props => props.theme.fontSizes[4]}px;
+const RepeaterItem = styled.TouchableOpacity<{
+  colorSchema: string;
+  error: Record<string, any>;
+  hidden?: boolean;
+}>`
+  font-size: ${(props) => props.theme.fontSizes[4]}px;
   flex-direction: row;
   height: auto;
   background-color: transparent;
   border-radius: 4.5px;
   margin-bottom: 10px;
   ${({ theme, error }) =>
-    !(error?.isValid || !error) && `border: solid 1px ${theme.colors.primary.red[0]}`};
-  background-color: ${props => props.theme.repeater[props.colorSchema].inputBackground};
+    !(error?.isValid || !error) &&
+    `border: solid 1px ${theme.colors.primary.red[0]}`};
+  background-color: ${(props) =>
+    props.theme.repeater[props.colorSchema].inputBackground};
   padding: 10px;
+  ${(props) => (props.hidden ? "display: none" : null)}
 `;
 
-const ItemLabel = styled(Label)<{colorSchema: string}>`
+const ItemLabel = styled(Label)<{ colorSchema: string }>`
   margin-top: 20px;
   margin-left: 10px;
   font-size: 12px;
   margin-bottom: 0px;
   padding-bottom: 0px;
-  color: ${props => props.theme.repeater[props.colorSchema].inputText};
-`
+  color: ${(props) => props.theme.repeater[props.colorSchema].inputText};
+`;
 
 const InputLabelWrapper = styled.View`
   flex: 4;
   justify-content: center;
 `;
 
-const InputLabel = styled.Text<{colorSchema: string}>`
+const InputLabel = styled.Text<{ colorSchema: string }>`
   padding: 4px;
-  font-weight: ${props => props.theme.fontWeights[1]};
-  color: ${props => props.theme.repeater[props.colorSchema].inputText};
+  font-weight: ${(props) => props.theme.fontWeights[1]};
+  color: ${(props) => props.theme.repeater[props.colorSchema].inputText};
 `;
 
-const InputWrapper = styled.View<{colorSchema: string}>`
+const InputWrapper = styled.View<{ colorSchema: string; hidden?: boolean }>`
   flex-direction: column;
   align-items: flex-end;
   justify-content: center;
   flex: 5;
+  ${(props) => (props.hidden ? "display: none" : null)};
 `;
 // eslint-disable-next-line prettier/prettier
 const ItemInput = styled(Input)`
   text-align: right;
   min-width: 80%;
   font-weight: 500;
-  color: ${props => props.theme.repeater[props.colorSchema].inputText};
+  color: ${(props) => props.theme.repeater[props.colorSchema].inputText};
   padding: 5px;
 `;
-const DeleteButton = styled(Button)<{color: string}>`
+const DeleteButton = styled(Button)<{ color: string }>`
   margin-top: 10px;
   margin-bottom: 10px;
-  background: ${props => theme.repeater[props.color].deleteButton};
+  background: ${(props) => theme.repeater[props.color].deleteButton};
 `;
 
-const DeleteButtonText = styled(Text)<{color: string}>`
-  color: ${props => theme.repeater[props.color].deleteButtonText};
+const DeleteButtonText = styled(Text)<{ color: string }>`
+  color: ${(props) => theme.repeater[props.color].deleteButtonText};
   text-transform: uppercase;
   font-weight: 900;
   font-size: 12px;
@@ -82,80 +94,106 @@ interface InputComponentProps {
   input: InputRow;
   colorSchema: PrimaryColor;
   value: string | number | boolean;
-  error?: {isValid: boolean, message: string};
+  error?: { isValid: boolean; message: string };
   showErrorMessage?: boolean;
   onChange: (value: string | number) => void;
   onBlur: () => void;
 }
 
-const InputComponent = React.forwardRef(({input, colorSchema, value, onChange, onBlur, error = undefined, showErrorMessage = false }: InputComponentProps, ref) => {
-  switch (input.type) {
-    case 'text':
-      return (
-        <ItemInput
-          textAlign="right"
-          colorSchema={colorSchema}
-          value={value.toString()}
-          onChangeText={onChange}
-          onBlur={onBlur}
-          transparent
-          inputType={input.inputSelectValue}
-          error={error}
-          showErrorMessage={showErrorMessage}
-          ref={ref}
-        />
-      );
-    case 'number':
-      return (
-        <ItemInput
-          textAlign="right"
-          colorSchema={colorSchema}
-          keyboardType="numeric"
-          value={value.toString()}
-          onChangeText={onChange}
-          onBlur={onBlur}
-          transparent
-          inputType={input.inputSelectValue}
-          error={error}
-          showErrorMessage={showErrorMessage}
-          ref={ref}
-        />
-      );
-    case 'date':
-      return (
-        <CalendarPicker
-          colorSchema={colorSchema}
-          value={value as number}
-          onSelect={onChange}
-          editable
-          transparent
-        />
-      );
-    default:
-      return (
-        <ItemInput
-          colorSchema={colorSchema}
-          textAlign="right"
-          value={value.toString()}
-          onChangeText={onChange}
-          onBlur={onBlur}
-          transparent
-          inputType={input.inputSelectValue}
-          error={error}
-          showErrorMessage={showErrorMessage}
-          ref={ref}
-        />
-      );
+const InputComponent = React.forwardRef(
+  (
+    {
+      input,
+      colorSchema,
+      value,
+      onChange,
+      onBlur,
+      error = undefined,
+      showErrorMessage = false,
+    }: InputComponentProps,
+    ref
+  ) => {
+    switch (input.type) {
+      case "text":
+        return (
+          <ItemInput
+            textAlign="right"
+            colorSchema={colorSchema}
+            value={value.toString()}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            transparent
+            inputType={input.inputSelectValue}
+            error={error}
+            showErrorMessage={showErrorMessage}
+            ref={ref}
+          />
+        );
+      case "hidden":
+        return (
+          <ItemInput
+            textAlign="right"
+            colorSchema={colorSchema}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            inputType={input.inputSelectValue}
+            hidden
+            value={input.value.toString()}
+            ref={ref}
+            transparent
+          />
+        );
+      case "number":
+        return (
+          <ItemInput
+            textAlign="right"
+            colorSchema={colorSchema}
+            keyboardType="numeric"
+            value={value.toString()}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            transparent
+            inputType={input.inputSelectValue}
+            error={error}
+            showErrorMessage={showErrorMessage}
+            ref={ref}
+          />
+        );
+      case "date":
+        return (
+          <CalendarPicker
+            colorSchema={colorSchema}
+            value={value as number}
+            onSelect={onChange}
+            editable
+            transparent
+          />
+        );
+      default:
+        return (
+          <ItemInput
+            colorSchema={colorSchema}
+            textAlign="right"
+            value={value.toString()}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            transparent
+            inputType={input.inputSelectValue}
+            error={error}
+            showErrorMessage={showErrorMessage}
+            ref={ref}
+          />
+        );
+    }
   }
-});
-
+);
 
 interface Props {
   heading?: string;
   listIndex?: number;
   inputs: InputRow[];
   value: Record<string, string | number>;
-  error?: Record<string, {isValid: boolean, validationMessage: string}>;
+  error?: Record<string, { isValid: boolean; validationMessage: string }>;
   changeFromInput: (input: InputRow) => (text: string) => void;
   onBlur?: () => void;
   removeItem: () => void;
@@ -177,44 +215,66 @@ const RepeaterFieldListItem: React.FC<Props> = ({
 
   return (
     <Base>
-      <ItemLabel colorSchema={validColorSchema} underline={false}>{heading || "Item"}</ItemLabel>
+      <ItemLabel colorSchema={validColorSchema} underline={false}>
+        {heading || "Item"}
+      </ItemLabel>
       {inputs.map((input, index) => {
-        const errorDetails = error?.[input.id] ? {isValid: error[input.id].isValid, message: error[input.id].validationMessage} : undefined
-        const showErrorMessage = !error?.[input.id]?.isValid
+        const errorDetails = error?.[input.id]
+          ? {
+              isValid: error[input.id].isValid,
+              message: error[input.id].validationMessage,
+            }
+          : undefined;
+        const showErrorMessage = !error?.[input.id]?.isValid;
 
         return (
-        <RepeaterItem
-          colorSchema={validColorSchema}
-          key={`${input.title}.${index}`}
-          style={index === inputs.length - 1 ? { marginBottom: 0 } : { marginBottom: 4 }}
-          error={error && error[input.id] ? error[input.id] : undefined}
-          onPress={ () => {
-            if (inputRefs.current?.[index]?.focus)
-              inputRefs.current[index].focus();
-            else if (inputRefs.current?.[index]?.togglePicker)
-              inputRefs.current[index].togglePicker();
-          }}
-          activeOpacity={1.0}
-        >
-          <InputLabelWrapper>
-            <InputLabel colorSchema={validColorSchema}>{`${input.title}`}</InputLabel>
-          </InputLabelWrapper>
-          <InputWrapper colorSchema={validColorSchema}>
-            <InputComponent 
-              input={input} 
-              onChange={changeFromInput(input)} 
-              error={errorDetails}
-              showErrorMessage={showErrorMessage}
-              onBlur={onBlur} 
-              colorSchema={validColorSchema}
-              value={(value[input.id]) || ''}
-              ref={(el) => {inputRefs.current[index] = el;}}
+          <RepeaterItem
+            colorSchema={validColorSchema}
+            key={`${input.title}.${index}`}
+            style={
+              index === inputs.length - 1
+                ? { marginBottom: 0 }
+                : { marginBottom: 4 }
+            }
+            error={error && error[input.id] ? error[input.id] : undefined}
+            onPress={() => {
+              if (inputRefs.current?.[index]?.focus)
+                inputRefs.current[index].focus();
+              else if (inputRefs.current?.[index]?.togglePicker)
+                inputRefs.current[index].togglePicker();
+            }}
+            activeOpacity={1.0}
+            hidden={input.type === "hidden"}
+          >
+            <InputLabelWrapper>
+              <InputLabel
+                colorSchema={validColorSchema}
+              >{`${input.title}`}</InputLabel>
+            </InputLabelWrapper>
+            <InputWrapper colorSchema={validColorSchema}>
+              <InputComponent
+                input={input}
+                onChange={changeFromInput(input)}
+                error={errorDetails}
+                showErrorMessage={showErrorMessage}
+                onBlur={onBlur}
+                colorSchema={validColorSchema}
+                value={value[input.id] || ""}
+                ref={(el) => {
+                  inputRefs.current[index] = el;
+                }}
               />
             </InputWrapper>
-        </RepeaterItem>
+          </RepeaterItem>
         );
-        })}
-      <DeleteButton z={0} colorSchema="neutral" color={validColorSchema} block onClick={removeItem}>
+      })}
+      <DeleteButton
+        z={0}
+        colorSchema="neutral"
+        color={validColorSchema}
+        block
+        onClick={removeItem}
+      >
         <DeleteButtonText color={validColorSchema}>Ta bort</DeleteButtonText>
       </DeleteButton>
     </Base>
@@ -235,6 +295,6 @@ RepeaterFieldListItem.propTypes = {
   color: PropTypes.string,
 };
 RepeaterFieldListItem.defaultProps = {
-  color: 'blue',
+  color: "blue",
 };
 export default RepeaterFieldListItem;


### PR DESCRIPTION
9Related to [mitt-helsingborg-form-builder#56](https://github.com/helsingborg-stad/mitt-helsingborg-form-builder/pull/56)

## Explain the changes you’ve made

In accordance with #CU-1hduc4e, I've added a way for repeater fields to render hidden fields and submit the data properly.

## Explain your solution

In the repeaterfield component, I've added a case for hidden fields.
I've also added a way to hide the whole `RepeaterItem` in order for the UI to work properly.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Edit a form in the form builder to have a repeater with a hidden field.
3. Submit the form
4. See that the hidden field is submitted with the proper value

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

