### PR TITLE
✨ Add select dropdown rendering to repeater field

### DIFF
--- a/source/components/molecules/RepeaterField/RepeaterField.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterField.tsx
@@ -19,7 +19,7 @@ const AddButton = styled(Button)`
 export interface InputRow {
   id: string;
   title: string;
-  type: "text" | "date" | "number" | "hidden";
+  type: "text" | "date" | "number" | "hidden" | 'select';
   inputSelectValue: InputFieldType;
   value?: string;
 }

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import { Text, Input } from "../../atoms";
 import Button from "../../atoms/Button";
 import Label from "../../atoms/Label";
+import Select from "../../atoms/Select";
 import { InputRow } from "./RepeaterField";
 import CalendarPicker from "../CalendarPicker/CalendarPickerForm";
 import theme from "../../../styles/theme";
@@ -76,6 +77,16 @@ const ItemInput = styled(Input)`
   color: ${(props) => props.theme.repeater[props.colorSchema].inputText};
   padding: 5px;
 `;
+
+const SelectInput = styled(Select)`
+  text-align: right;
+  min-width: 80%;
+  font-weight: 500;
+  color: ${(props) => props.theme.repeater[props.colorSchema].inputText};
+  padding: 5px;
+  margin-bottom: 0px;
+`;
+
 const DeleteButton = styled(Button)<{ color: string }>`
   margin-top: 10px;
   margin-bottom: 10px;
@@ -167,6 +178,20 @@ const InputComponent = React.forwardRef(
             onSelect={onChange}
             editable
             transparent
+          />
+        );
+      case "select":
+        return (
+          <SelectInput
+            items={input.items}
+            colorSchema={colorSchema}
+            value={value.toString()}
+            onValueChange={onChange}
+            onBlur={onBlur}
+            transparent
+            error={error}
+            showErrorMessage={showErrorMessage}
+            ref={ref}
           />
         );
       default:


### PR DESCRIPTION
## Explain the changes you’ve made

I've added support for rendering a select dropdown in repeater fields.

## Explain why these changes are made

See #CU-1hyra8n

## How to test the changes?

Concrete example:
1. Checkout the latest development branch of the form builder
2. Checkout this branch
3. Edit a form to have a select dropdown in a repeater field
4. Start a case with the form
5. See that the app renders a dropdown select in the repeated
6. Submit the case
7. See data in database

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
