### PR TITLE
Feat/timeslot picker component

### DIFF
--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.stories.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.stories.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { storiesOf } from "@storybook/react-native";
+import moment from "moment";
+import StoryWrapper from "../StoryWrapper";
+import TimeSlotPicker from "./TimeSlotPicker";
+
+const mockAvailableTimes = {
+  [moment().add(2, "days").format("yyyy-MM-DD")]: [
+    {
+      startTime: "09:00:00",
+      endTime: "10:00:00",
+    },
+    {
+      startTime: "10:15:00",
+      endTime: "11:15:00",
+    },
+  ],
+  [moment().add(7, "days").format("yyyy-MM-DD")]: [
+    {
+      startTime: "09:15:00",
+      endTime: "10:15:00",
+    },
+    {
+      startTime: "13:00:00",
+      endTime: "14:00:00",
+    },
+    {
+      startTime: "14:15:00",
+      endTime: "15:15:00",
+    },
+    {
+      startTime: "15:30:00",
+      endTime: "16:30:00",
+    },
+  ],
+  [moment().add(1, "months").format("yyyy-MM-DD")]: [
+    {
+      startTime: "08:00:00",
+      endTime: "09:00:00",
+    },
+    {
+      startTime: "14:15:00",
+      endTime: "15:15:00",
+    },
+  ],
+};
+
+const TimeSlotPickerStory = () => {
+  const [value, setValue] = useState(undefined);
+
+  return (
+    <TimeSlotPicker
+      value={value}
+      availableTimes={mockAvailableTimes}
+      onChange={setValue}
+    />
+  );
+};
+
+storiesOf("Time Slot Picker", module).add("Default", (props) => (
+  <StoryWrapper {...props}>
+    <TimeSlotPickerStory />
+  </StoryWrapper>
+));

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.stories.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.stories.tsx
@@ -57,8 +57,8 @@ const TimeSlotPickerStory = () => {
   );
 };
 
-storiesOf("Time Slot Picker", module).add("Default", (props) => (
-  <StoryWrapper {...props}>
+storiesOf("Time Slot Picker", module).add("Default", (storyContext) => (
+  <StoryWrapper kind={storyContext?.kind} name={storyContext?.name}>
     <TimeSlotPickerStory />
   </StoryWrapper>
 ));

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
@@ -44,7 +44,7 @@ const TimeSlotPicker = ({
     t1: TimeSpan | Record<string, never>,
     t2: TimeSpan | Record<string, never>
   ) => {
-    if (!t1 || !t2) return false;
+    if (!t1 || !t2 || t1 === {} || t2 === {}) return false;
     return t1.startTime === t2.startTime && t1.endTime === t2.endTime;
   };
 

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
@@ -14,7 +14,7 @@ interface ValueType {
 }
 
 interface TimeSlotPickerProps {
-  value: ValueType;
+  value: ValueType | undefined;
   onChange: (newObject: Partial<ValueType>) => void;
   availableTimes: Record<string, TimeSpan[]>;
 }
@@ -40,8 +40,13 @@ const TimeSlotPicker = ({
   const formatTimeSpanText = (timeSpan: TimeSpan) =>
     `${timeSpan.startTime.substr(0, 5)}-${timeSpan.endTime.substr(0, 5)}`;
 
-  const timeSpanIsEqual = (t1: TimeSpan, t2: TimeSpan) =>
-    t1.startTime === t2.startTime && t1.endTime === t2.endTime;
+  const timeSpanIsEqual = (
+    t1: TimeSpan | Record<string, never>,
+    t2: TimeSpan | Record<string, never>
+  ) => {
+    if (!t1 || !t2) return false;
+    return t1.startTime === t2.startTime && t1.endTime === t2.endTime;
+  };
 
   const renderTimeSpanButton = (timeSpan: TimeSpan) => {
     const selected = timeSpanIsEqual(timeSpan, currentTimeSpan);

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
@@ -4,10 +4,19 @@ import { ScrollView } from "react-native-gesture-handler";
 import stringify from "json-stable-stringify";
 import { DayPicker, TimeSpanButton } from "..";
 
+interface TimeSpan {
+  startTime: string;
+  endTime: string;
+}
+interface ValueType {
+  date: string;
+  timeSpan: TimeSpan;
+}
+
 interface TimeSlotPickerProps {
-  value: any;
-  onChange: (newObject: any) => void;
-  availableTimes: any;
+  value: ValueType;
+  onChange: (newObject: Partial<ValueType>) => void;
+  availableTimes: Record<string, TimeSpan[]>;
 }
 
 const TimeSlotPicker = ({
@@ -17,17 +26,44 @@ const TimeSlotPicker = ({
 }: TimeSlotPickerProps): JSX.Element => {
   const dates = Object.keys(availableTimes);
 
-  const currentDate = value && value.date ? value.date : "";
-  const timeObject = value && value.times ? value.times : [];
-
-  const currentTimes = currentDate ? availableTimes[currentDate] : [];
+  const currentDate = value?.date || "";
+  const currentTimeSpan = value?.timeSpan || {};
+  const currentAvailableTimes = availableTimes[currentDate] || [];
 
   const updateDate = (date: string) => {
     onChange({ date });
   };
 
-  const updateTime = (times: any) => {
-    onChange({ ...value, times });
+  const updateTime = (timeSpan: TimeSpan) => {
+    onChange({ ...value, timeSpan });
+  };
+
+  const formatTimeSpanText = (timeSpan: TimeSpan) =>
+    `${timeSpan.startTime.substr(0, 5)}-${timeSpan.endTime.substr(0, 5)}`;
+
+  const timeSpanIsEqual = (t1: TimeSpan, t2: TimeSpan) =>
+    t1.startTime === t2.startTime && t1.endTime === t2.endTime;
+
+  const renderTimeSpanButton = (timeSpan: TimeSpan) => {
+    const selected = timeSpanIsEqual(timeSpan, currentTimeSpan);
+    const formattedText = formatTimeSpanText(timeSpan);
+    const textColor = selected ? "white" : "black";
+    const keyString = `TimeSpanButton-${currentDate}-${timeSpan.startTime}`;
+    return (
+      <TimeSpanButton
+        key={keyString}
+        onClick={() => updateTime(timeSpan)}
+        selected={selected}
+      >
+        <Text
+          style={{
+            color: textColor,
+          }}
+        >
+          {formattedText}
+        </Text>
+      </TimeSpanButton>
+    );
   };
 
   return (
@@ -44,27 +80,7 @@ const TimeSlotPicker = ({
           justifyContent: "space-evenly",
         }}
       >
-        {currentTimes.map((times: any) => {
-          const selected = stringify(times) === stringify(timeObject);
-          const formattedText =
-            `${times.startTime.substr(0, 5)}-` +
-            `${times.endTime.substr(0, 5)}`;
-          return (
-            <TimeSpanButton
-              key={`TimeSpanButton-${times.startTime}-${times.endTime}`}
-              onClick={() => updateTime(times)}
-              selected={selected}
-            >
-              <Text
-                style={{
-                  color: selected ? "white" : "black",
-                }}
-              >
-                {formattedText}
-              </Text>
-            </TimeSpanButton>
-          );
-        })}
+        {currentAvailableTimes.map(renderTimeSpanButton)}
       </ScrollView>
     </View>
   );

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+import stringify from "json-stable-stringify";
+import { DayPicker, TimeSpanButton } from "..";
+
+interface TimeSlotPickerProps {
+  value: any;
+  onChange: (newObject: any) => void;
+  availableTimes: any[];
+}
+
+const TimeSlotPicker = ({
+  value,
+  onChange,
+  availableTimes,
+}: TimeSlotPickerProps): JSX.Element => {
+  const dates = Object.keys(availableTimes);
+
+  const currentDate = value && value.date ? value.date : "";
+  const timeObject = value && value.times ? value.times : [];
+
+  const currentTimes = currentDate ? availableTimes[currentDate] : [];
+
+  const updateDate = (date: string) => {
+    onChange({ date });
+  };
+
+  const updateTime = (times: any) => {
+    onChange({ ...value, times });
+  };
+
+  return (
+    <View>
+      <DayPicker
+        selectedDate={currentDate}
+        availableDates={dates}
+        onDateSelected={updateDate}
+      />
+      <ScrollView
+        horizontal
+        contentContainerStyle={{
+          display: "flex",
+          justifyContent: "space-evenly",
+        }}
+      >
+        {currentTimes.map((times: any) => {
+          const selected = stringify(times) === stringify(timeObject);
+          const formattedText =
+            `${times.startTime.substr(0, 5)}-` +
+            `${times.endTime.substr(0, 5)}`;
+          return (
+            <TimeSpanButton
+              key={`TimeSpanButton-${times.startTime}-${times.endTime}`}
+              onClick={() => updateTime(times)}
+              selected={selected}
+            >
+              <Text
+                style={{
+                  color: selected ? "white" : "black",
+                }}
+              >
+                {formattedText}
+              </Text>
+            </TimeSpanButton>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+};
+
+export default TimeSlotPicker;

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { View, Text } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
-import stringify from "json-stable-stringify";
 import { DayPicker, TimeSpanButton } from "..";
 
 interface TimeSpan {

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
@@ -7,6 +7,7 @@ interface TimeSpan {
   startTime: string;
   endTime: string;
 }
+
 interface ValueType {
   date: string;
   timeSpan: TimeSpan;
@@ -24,7 +25,6 @@ const TimeSlotPicker = ({
   availableTimes,
 }: TimeSlotPickerProps): JSX.Element => {
   const dates = Object.keys(availableTimes);
-
   const currentDate = value?.date || "";
   const currentTimeSpan = value?.timeSpan || {};
   const currentAvailableTimes = availableTimes[currentDate] || [];

--- a/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/source/components/molecules/TimeSlotPicker/TimeSlotPicker.tsx
@@ -7,7 +7,7 @@ import { DayPicker, TimeSpanButton } from "..";
 interface TimeSlotPickerProps {
   value: any;
   onChange: (newObject: any) => void;
-  availableTimes: any[];
+  availableTimes: any;
 }
 
 const TimeSlotPicker = ({

--- a/source/components/molecules/TimeSlotPicker/index.ts
+++ b/source/components/molecules/TimeSlotPicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TimeSlotPicker";

--- a/source/components/molecules/index.ts
+++ b/source/components/molecules/index.ts
@@ -24,3 +24,4 @@ export { default as FloatingButton } from "./FloatingButton";
 export { default as TimeSpanButton } from "./TimeSpanButton";
 export { default as DateTimeCard } from "./DateTimeCard";
 export { default as AddressCard } from "./AddressCard";
+export { default as TimeSlotPicker } from "./TimeSlotPicker";

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -20,7 +20,6 @@ import ImageUploader from '../../components/molecules/ImageUploader/ImageUploade
 import ImageViewer from '../../components/molecules/ImageViewer/ImageViewer';
 import PdfUploader from '../../components/molecules/PdfUploader/PdfUploader';
 import PdfViewer from '../../components/molecules/PdfViewer/PdfViewer';
-import TimeSlotPicker from '../../components/molecules/TimeSlotPicker';
 /**
  * Explanation of the properties in this data structure:
  *
@@ -156,11 +155,6 @@ const inputTypes = {
     component: PdfViewer,
     changeEvent: 'onChange',
     props: { answers: true },
-  },
-  timeslot: {
-    component: TimeSlotPicker,
-    changeEvent: 'onChange',
-    props: {},
   },
 };
 

--- a/source/containers/FormField/FormField.js
+++ b/source/containers/FormField/FormField.js
@@ -20,6 +20,7 @@ import ImageUploader from '../../components/molecules/ImageUploader/ImageUploade
 import ImageViewer from '../../components/molecules/ImageViewer/ImageViewer';
 import PdfUploader from '../../components/molecules/PdfUploader/PdfUploader';
 import PdfViewer from '../../components/molecules/PdfViewer/PdfViewer';
+import TimeSlotPicker from '../../components/molecules/TimeSlotPicker';
 /**
  * Explanation of the properties in this data structure:
  *
@@ -155,6 +156,11 @@ const inputTypes = {
     component: PdfViewer,
     changeEvent: 'onChange',
     props: { answers: true },
+  },
+  timeslot: {
+    component: TimeSlotPicker,
+    changeEvent: 'onChange',
+    props: {},
   },
 };
 

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -41,6 +41,7 @@ function loadStories() {
   require("../source/components/molecules/PersonField/PersonField.stories");
   require("../source/components/molecules/RadioGroup/RadioGroup.stories");
   require("../source/components/molecules/RepeaterField/RepeaterField.stories");
+  require("../source/components/molecules/TimeSlotPicker/TimeSlotPicker.stories");
   require("../source/components/molecules/TimeSpanButton/TimeSpanButton.stories");
   require("../source/components/molecules/ToastNotification/ToastNotifications.stories");
   require("../source/components/organisms/ButtonList/ButtonList.stories");
@@ -96,6 +97,7 @@ const stories = [
   "../source/components/molecules/PersonField/PersonField.stories",
   "../source/components/molecules/RadioGroup/RadioGroup.stories",
   "../source/components/molecules/RepeaterField/RepeaterField.stories",
+  "../source/components/molecules/TimeSlotPicker/TimeSlotPicker.stories",
   "../source/components/molecules/TimeSpanButton/TimeSpanButton.stories",
   "../source/components/molecules/ToastNotification/ToastNotifications.stories",
   "../source/components/organisms/ButtonList/ButtonList.stories",


### PR DESCRIPTION
## Explain the changes you’ve made

Added a new `TimeSlotPicker` component which behaves similar to the components used in `FormField`.

## Explain why these changes are made

This component allows the `DayPicker` component and the `TimeSpanButton` component to be used in `FormField`. This is necessary in order to be able to choose a time in a booking form.

## Explain your solution

The component essentially wraps the two components `DayPicker` and `TimeSpanButton` into a new component that has a `value` prop similar to the other components in 

## How to test the changes?

1. Checkout this branch
2. Swap the application to run Storybook
3. Fire upp the simulator by running the command `yarn ios`
4. The component can be found in the Storybook under "Time Slot Picker"

## Was this feature tested in the following environments?
- [X] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [X] Building the Application on a Android device/simulator.
