### PR TITLE
refactor(case-data-converter): insertion of dynamic values in tags ha…

### DIFF
--- a/source/helpers/CaseDataConverter.js
+++ b/source/helpers/CaseDataConverter.js
@@ -31,6 +31,18 @@ export const getFormQuestions = (form) => {
   return formQuestions;
 };
 
+export function replaceTagPart(tag, part, value){
+  const tagParts = tag.split(':')
+  const updatedTagParts = tagParts.map(tagPart => {
+    if(tagPart === part) {
+      return value
+    }
+    return tagPart
+  })
+
+  return updatedTagParts.join(':')
+}
+
 /**
  * Convert answers in context to an array that follows Case API data structure
  * @param {obj} data
@@ -95,7 +107,7 @@ export const convertAnswersToArray = (data, formQuestions) => {
             let newTags = [];
             if (Array.isArray(tags)) {
               newTags = tagsInRepeaterField.map((tag) => {
-                  const updatedTag = tag.replace(':x', `:${childFieldId}`)
+                  const updatedTag = replaceTagPart(tag, 'x', childFieldId)
                   return updatedTag
               });
             }

--- a/source/helpers/CaseDataConverter.js
+++ b/source/helpers/CaseDataConverter.js
@@ -91,21 +91,12 @@ export const convertAnswersToArray = (data, formQuestions) => {
           Object.entries(childItems).forEach((childItem) => {
             const [repeaterItemId, repeaterItemValue] = childItem;
             const repeaterFieldItem = other.inputs.find((obj) => obj.id === repeaterItemId);
-            const { tags } = repeaterFieldItem;
+            const { tags: tagsInRepeaterField } = repeaterFieldItem;
             let newTags = [];
             if (Array.isArray(tags)) {
-              const dynamicTagRegex = new RegExp('.+:x');
-              newTags = tags.map((tag) => {
-                if (dynamicTagRegex.test(tag)) {
-                  const tagStringList = tag.split(':');
-                  const tagStringIndex = tagStringList.findIndex('x');
-                  if (tagStringIndex !== -1) {
-                    tagStringList.array.splice(tagStringIndex, 1);
-                    return [...tagStringList, childFieldId].join(':')
-                  }
-                  return [tag, childFieldId].join(':')
-                }
-                return tag;
+              newTags = tagsInRepeaterField.map((tag) => {
+                  const updatedTag = tag.replace(':x', `:${childFieldId}`)
+                  return updatedTag
               });
             }
 

--- a/source/helpers/CaseDataConverter.js
+++ b/source/helpers/CaseDataConverter.js
@@ -97,8 +97,13 @@ export const convertAnswersToArray = (data, formQuestions) => {
               const dynamicTagRegex = new RegExp('.+:x');
               newTags = tags.map((tag) => {
                 if (dynamicTagRegex.test(tag)) {
-                  const strArray = tag.split(':');
-                  return `${strArray?.[0] || tag}:${childFieldId}`;
+                  const tagStringList = tag.split(':');
+                  const tagStringIndex = tagStringList.findIndex('x');
+                  if (tagStringIndex !== -1) {
+                    tagStringList.array.splice(tagStringIndex, 1);
+                    return [...tagStringList, childFieldId].join(':')
+                  }
+                  return [tag, childFieldId].join(':')
                 }
                 return tag;
               });

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -1,23 +1,57 @@
-import {replaceTagPart} from '../CaseDataConverter'
+import { replaceTagPart } from '../CaseDataConverter';
 
 describe('replaceTagPart', () => {
   
-  it('replaces part in tag on single occurence', () => {
+  it('should replace part in tag on single occurence', () => {
     const input = {
       tag: 'test:example:replace',
       part: 'replace',
       value: 'success'
     }
     const output = 'test:example:success'
-    expect(replaceTagPart([...input]).equal(output))
+    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
   });
 
-  it('replaces part in tag on multiple occurences', () => {
-    expect()
+  it('should replace part in tag on multiple occurences', () => {
+    const input = {
+      tag: 'test:replace:example:replace',
+      part: 'replace',
+      value: 'success'
+    }
+    const output = 'test:example:success'
+    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
   });
 
-  it('does not replace part that contains value of other part in tag', () => {
-    expect()
+  it('should replace part in tag if part is only part', () => {
+    const input = {
+      tag: 'replace',
+      part: 'replace',
+      value: 'success'
+    }
+    const output = 'test:example:success'
+    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+  });
+
+  it('should not replace part in tag if a part contains the value of another part', () => {
+    const input = {
+      tag: 'test:examplereplace:replace',
+      part: 'replace',
+      value: 'success'
+    }
+
+    const output = 'test:examplereplace:success'
+    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+  });
+
+  it('should not replace any parts', () => {
+    const input = {
+      tag: 'test:example:other',
+      part: 'replace',
+      value: 'success'
+    }
+
+    const output = input.tag
+    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
   });
 
 })

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -73,5 +73,4 @@ describe('replaceTagPart', () => {
 
     expect(result).toBe(output)
   });
-
 })

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -1,76 +1,72 @@
-import { replaceTagPart } from '../CaseDataConverter';
+import { replaceTagPart } from "../CaseDataConverter";
 
-
-
-
-
-describe('replaceTagPart', () => {
-  let input: { tag: string, part: string, value: string };
+describe("replaceTagPart", () => {
+  let input: { tag: string; part: string; value: string };
 
   beforeEach(() => {
     input = {
-      tag: '',
-      part: 'replace',
-      value: 'success'
+      tag: "",
+      part: "replace",
+      value: "success",
     };
   });
-  
-  it('should replace part in tag on single occurence', () => {
-    input.tag = 'test:example:replace'
 
-    const output = 'test:example:success'
+  it("should replace part in tag on single occurence", () => {
+    input.tag = "test:example:replace";
 
-    const result = replaceTagPart(input.tag, input.part, input.value)
+    const output = "test:example:success";
+
+    const result = replaceTagPart(input.tag, input.part, input.value);
 
     expect(result).toBe(output);
   });
 
-  it('should replace part at beginning of tag', () => {
-    input.tag = 'replace:example:test'
+  it("should replace part at beginning of tag", () => {
+    input.tag = "replace:example:test";
 
-    const output = 'success:example:test'
-
-    const result = replaceTagPart(input.tag, input.part, input.value)
-
-    expect(result).toBe(output)
-  });
-
-  it('should replace part in tag on multiple occurences', () => {
-    input.tag = 'test:replace:example:replace'
-    
-    const output = 'test:success:example:success'
+    const output = "success:example:test";
 
     const result = replaceTagPart(input.tag, input.part, input.value);
 
-    expect(result).toBe(output)
+    expect(result).toBe(output);
   });
 
-  it('should replace part in tag if part is only part', () => {
-    input.tag = 'replace'
+  it("should replace part in tag on multiple occurences", () => {
+    input.tag = "test:replace:example:replace";
 
-    const output = 'success'
-
-    const result = replaceTagPart(input.tag, input.part, input.value);
-    expect(result).toBe(output)
-  });
-
-  it('should not replace part in tag if a part contains the value of another part', () => {
-    input.tag = 'test:examplereplace:replace'
-
-    const output = 'test:examplereplace:success'
+    const output = "test:success:example:success";
 
     const result = replaceTagPart(input.tag, input.part, input.value);
 
-    expect(result).toBe(output)
+    expect(result).toBe(output);
   });
 
-  it('should not replace any parts', () => {
-    input.tag = 'test:example:other'
+  it("should replace part in tag if part is only part", () => {
+    input.tag = "replace";
 
-    const output = input.tag
+    const output = "success";
+
+    const result = replaceTagPart(input.tag, input.part, input.value);
+    expect(result).toBe(output);
+  });
+
+  it("should not replace part in tag if a part contains the value of another part", () => {
+    input.tag = "test:examplereplace:replace";
+
+    const output = "test:examplereplace:success";
 
     const result = replaceTagPart(input.tag, input.part, input.value);
 
-    expect(result).toBe(output)
+    expect(result).toBe(output);
   });
-})
+
+  it("should not replace any parts", () => {
+    input.tag = "test:example:other";
+
+    const output = input.tag;
+
+    const result = replaceTagPart(input.tag, input.part, input.value);
+
+    expect(result).toBe(output);
+  });
+});

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -1,67 +1,77 @@
 import { replaceTagPart } from '../CaseDataConverter';
 
+
+
+
+
 describe('replaceTagPart', () => {
-  
-  it('should replace part in tag on single occurence', () => {
-    const input = {
-      tag: 'test:example:replace',
+  let input: { tag: string, part: string, value: string };
+
+  beforeEach(() => {
+    input = {
+      tag: '',
       part: 'replace',
       value: 'success'
-    }
+    };
+  });
+  
+  it('should replace part in tag on single occurence', () => {
+    input.tag = 'test:example:replace'
+
     const output = 'test:example:success'
-    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+
+    const result = replaceTagPart(input.tag, input.part, input.value)
+
+    expect(result).toBe(output);
   });
 
   it('should replace part at beginning of tag', () => {
-    const input = {
-      tag: 'replace:example:test',
-      part: 'replace',
-      value: 'success'
-    }
+    input.tag = 'replace:example:test'
+
     const output = 'success:example:test'
-    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+
+    const result = replaceTagPart(input.tag, input.part, input.value)
+
+    expect(result).toBe(output)
   });
 
   it('should replace part in tag on multiple occurences', () => {
-    const input = {
-      tag: 'test:replace:example:replace',
-      part: 'replace',
-      value: 'success'
-    }
+    input.tag = 'test:replace:example:replace'
+    
     const output = 'test:success:example:success'
-    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+
+    const result = replaceTagPart(input.tag, input.part, input.value);
+
+    expect(result).toBe(output)
   });
 
   it('should replace part in tag if part is only part', () => {
-    const input = {
-      tag: 'replace',
-      part: 'replace',
-      value: 'success'
-    }
+    input.tag = 'replace'
+
     const output = 'success'
-    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+
+    const result = replaceTagPart(input.tag, input.part, input.value);
+    expect(result).toBe(output)
   });
 
   it('should not replace part in tag if a part contains the value of another part', () => {
-    const input = {
-      tag: 'test:examplereplace:replace',
-      part: 'replace',
-      value: 'success'
-    }
+    input.tag = 'test:examplereplace:replace'
 
     const output = 'test:examplereplace:success'
-    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+
+    const result = replaceTagPart(input.tag, input.part, input.value);
+
+    expect(result).toBe(output)
   });
 
   it('should not replace any parts', () => {
-    const input = {
-      tag: 'test:example:other',
-      part: 'replace',
-      value: 'success'
-    }
+    input.tag = 'test:example:other'
 
     const output = input.tag
-    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+
+    const result = replaceTagPart(input.tag, input.part, input.value);
+
+    expect(result).toBe(output)
   });
 
 })

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -18,7 +18,7 @@ describe('replaceTagPart', () => {
       part: 'replace',
       value: 'success'
     }
-    const output = 'test:example:success'
+    const output = 'test:success:example:success'
     expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
   });
 
@@ -28,7 +28,7 @@ describe('replaceTagPart', () => {
       part: 'replace',
       value: 'success'
     }
-    const output = 'test:example:success'
+    const output = 'success'
     expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
   });
 

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -1,0 +1,23 @@
+import {replaceTagPart} from '../CaseDataConverter'
+
+describe('replaceTagPart', () => {
+  
+  it('replaces part in tag on single occurence', () => {
+    const input = {
+      tag: 'test:example:replace',
+      part: 'replace',
+      value: 'success'
+    }
+    const output = 'test:example:success'
+    expect(replaceTagPart([...input]).equal(output))
+  });
+
+  it('replaces part in tag on multiple occurences', () => {
+    expect()
+  });
+
+  it('does not replace part that contains value of other part in tag', () => {
+    expect()
+  });
+
+})

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -12,6 +12,16 @@ describe('replaceTagPart', () => {
     expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
   });
 
+  it('should replace part at beginning of tag', () => {
+    const input = {
+      tag: 'replace:example:test',
+      part: 'replace',
+      value: 'success'
+    }
+    const output = 'success:example:test'
+    expect(replaceTagPart(input.tag, input.part, input.value)).toEqual(output)
+  });
+
   it('should replace part in tag on multiple occurences', () => {
     const input = {
       tag: 'test:replace:example:replace',

--- a/source/helpers/test/CaseDataConverter.test.tsx
+++ b/source/helpers/test/CaseDataConverter.test.tsx
@@ -47,6 +47,7 @@ describe("replaceTagPart", () => {
     const output = "success";
 
     const result = replaceTagPart(input.tag, input.part, input.value);
+
     expect(result).toBe(output);
   });
 


### PR DESCRIPTION
## Explain the changes you’ve made
I've added support for manipulation of tags with pattern :x to not exclude in between words in tag strings so tag:other:x will now be accepted and not only tag:x

## Explain why these changes are made

While defining tags for a repeater field a discovery was made that we needed to create more explicit group tags. The background for this discovery was that if several repeater fields hade the same tagging for example  tag1, tag2, tag:x their values could not be seperated while searching through answers. So therefore the need for tag:other:x was a born.
## Explain your solution

The solution was to look if a tag string included :x pattern, if so only replace the x with an dynamic value and stitch the tag together again.  Let's say we have a tag that looks like `tag:other:x`and we want x to have the value `hello` then the result will be tag:other:hello. But before this change the result would be tag:hello (ie :other: have been removed from the tag completely!).

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Go through an form with a repeater field containing a tag that is of format some:thing:x and other with some:x
3. Check so that tags are complete afterwards and that a dynamic value have been added to x ie some:thing:dynamicvalue or some:dynamicvalue 
## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [X] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots (optional)
Screenshots are helpful for UI-related changes. It could be an before and after change as an example.
Even backend code can benefit from a screenshot of the net change.