### PR TITLE
💄 Add CTA button to see decision

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -142,6 +142,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const isWaitingForSign = statusType.includes("active:signature:pending");
   const selfHasSigned = casePersonData?.hasSigned;
   const isCoApplicant = casePersonData?.role === "coApplicant";
+  const isSubmitted = statusType.includes("active:submitted");
 
   const currentForm = caseData?.forms[caseData.currentFormId];
   const selfNeedsToConfirm =
@@ -156,8 +157,11 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const shouldShowCTAButton = isCoApplicant
     ? (isWaitingForSign && !selfHasSigned) ||
       (isWaitingForCoApplicantSign && selfNeedsToConfirm)
-    : isOngoing || isNotStarted || isCompletionRequired || isSigned;
-
+    : isOngoing ||
+      isNotStarted ||
+      isCompletionRequired ||
+      isSigned ||
+      isSubmitted;
   const buttonProps: InternalButtonProps = {
     onClick: () => navigation.navigate("Form", { caseId: caseData.id }),
     text: "",
@@ -176,6 +180,10 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
       });
     },
   };
+
+  if (isSubmitted) {
+    buttonProps.text = "Se beslut";
+  }
 
   if (isOngoing) {
     buttonProps.text = "Fortsätt";

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -142,7 +142,6 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const isWaitingForSign = statusType.includes("active:signature:pending");
   const selfHasSigned = casePersonData?.hasSigned;
   const isCoApplicant = casePersonData?.role === "coApplicant";
-  const isSubmitted = statusType.includes("active:submitted");
 
   const currentForm = caseData?.forms[caseData.currentFormId];
   const selfNeedsToConfirm =
@@ -157,11 +156,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const shouldShowCTAButton = isCoApplicant
     ? (isWaitingForSign && !selfHasSigned) ||
       (isWaitingForCoApplicantSign && selfNeedsToConfirm)
-    : isOngoing ||
-      isNotStarted ||
-      isCompletionRequired ||
-      isSigned ||
-      isSubmitted;
+    : isOngoing || isNotStarted || isCompletionRequired || isSigned || isClosed;
   const buttonProps: InternalButtonProps = {
     onClick: () => navigation.navigate("Form", { caseId: caseData.id }),
     text: "",
@@ -181,7 +176,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
     },
   };
 
-  if (isSubmitted) {
+  if (isClosed) {
     buttonProps.text = "Se beslut";
 
     buttonProps.onClick = () => {

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -183,6 +183,16 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
 
   if (isSubmitted) {
     buttonProps.text = "Se beslut";
+
+    buttonProps.onClick = () => {
+      navigation.navigate("UserEvents", {
+        screen: caseData.caseType.navigateTo,
+        params: {
+          id: caseData.id,
+          name: caseData.caseType.name,
+        },
+      });
+    };
   }
 
   if (isOngoing) {


### PR DESCRIPTION
## Explain the changes you’ve made

I've added a CTA button to a submitted case card in order to see the decision that's been made.

More info, see #CU-1j4kn2e

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Submit a case
3. See the CTA button

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
