### PR TITLE
feat(linting): show lint errors on floating promises

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,9 @@ const config = {
       files: ["*.ts", "*.tsx"],
       plugins: ["@typescript-eslint"],
       parser: "@typescript-eslint/parser",
+      parserOptions: {
+        project: "./tsconfig.json",
+      },
       extends: ["plugin:@typescript-eslint/recommended", "prettier"],
       rules: {
         "no-use-before-define": "off",
@@ -48,6 +51,8 @@ const config = {
         "no-shadow": "off",
         "@typescript-eslint/no-shadow": ["error"],
         "react/require-default-props": "off",
+        "@typescript-eslint/no-floating-promises": ["error"],
+        "no-void": ["error", { allowAsStatement: true }],
       },
     },
   ],


### PR DESCRIPTION
## Explain the changes you’ve made

Added lint rule to show error on floating promises (promises that are not awaited and don't have then/catch).

## Explain why these changes are made

This change is made in order to try to force developers to handle promises correctly, to avoid missing awaits and having unexpected race conditions.

## Explain your solution

* Explicitly added the `no-floating-promises` rule.
  * `parserOptions.project` is set for this to work as well (the parser needs the current tsconfig for type info).
* Allowed using `void` in certain situations in case the developer wants to explicitly not handle a promise.
  * For example, if `someAsyncFunc();` causes error, the developer can "fix" it with `void someAsyncFunc();`. 
  * __This should only be used in very specific circumstances__.


## How to test the changes?

Here's a sample function:

```typescript
async function test(): Promise<number> {
  const wait1s = () =>
    new Promise<void>((resolve) => setTimeout(resolve, 1000));

  wait1s();
  return 5;
}
```

1. Checkout this branch
2. Make sure the sample function correctly shows a linting error for the call to `wait1s();`.
3. Change to `void wait1s();` and verify the error is gone.

## Screenshots

Error as shown in VSCode:
![image](https://user-images.githubusercontent.com/2890987/140898431-2f53213d-8fe1-4411-82c7-198586dea981.png)

