### PR TITLE
🩹 Change from using json to just-copy for deep cloning

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "axios-mock-adapter": "^1.19.0",
     "babel-plugin-module-resolver": "^4.0.0",
     "json-stable-stringify": "^1.0.1",
+    "just-clone": "^5.0.0",
     "jwt-decode": "^3.1.2",
     "metro-react-native-babel-preset": "^0.66.2",
     "moment": "^2.29.1",

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -1,3 +1,4 @@
+import { deepCopy } from 'app/helpers/Objects';
 import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
 import { LayoutAnimation, Platform } from 'react-native';
@@ -210,7 +211,7 @@ function EditableList({
   };
 
   const onChange = (key, text) => {
-    const updatedState = JSON.parse(JSON.stringify(state));
+    const updatedState = deepCopy(state);
     updatedState[key] = text;
     onInputChange(updatedState);
     setState(updatedState);

--- a/source/components/molecules/EditableList/EditableList.js
+++ b/source/components/molecules/EditableList/EditableList.js
@@ -1,8 +1,8 @@
-import { deepCopy } from 'app/helpers/Objects';
 import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
 import { LayoutAnimation, Platform } from 'react-native';
 import styled from 'styled-components/native';
+import { deepCopy } from '../../../helpers/Objects';
 import { Button, Fieldset, Input, Text } from '../../atoms';
 import Select from '../../atoms/Select';
 import CalendarPicker from '../CalendarPicker/CalendarPickerForm';

--- a/source/components/molecules/GroupedListWithAvatar/GroupedListWithAvatar.js
+++ b/source/components/molecules/GroupedListWithAvatar/GroupedListWithAvatar.js
@@ -6,7 +6,7 @@ import { TouchableHighlight } from 'react-native-gesture-handler';
 import AvatarListItem from '../ListItem/AvatarListItem';
 import { Text, Icon } from '../../atoms';
 import Button from '../../atoms/Button/Button';
-import { deepCopy } from 'app/helpers/Objects';
+import { deepCopy } from '../../../helpers/Objects';
 
 const SectionHeader = styled(Text)`
   margin-left: 15px;

--- a/source/components/molecules/GroupedListWithAvatar/GroupedListWithAvatar.js
+++ b/source/components/molecules/GroupedListWithAvatar/GroupedListWithAvatar.js
@@ -6,6 +6,7 @@ import { TouchableHighlight } from 'react-native-gesture-handler';
 import AvatarListItem from '../ListItem/AvatarListItem';
 import { Text, Icon } from '../../atoms';
 import Button from '../../atoms/Button/Button';
+import { deepCopy } from 'app/helpers/Objects';
 
 const SectionHeader = styled(Text)`
   margin-left: 15px;
@@ -35,21 +36,21 @@ const GroupListWithAvatar = ({ heading, value, onChange, formId }) => {
   const [showModal, setShowModal] = React.useState(false);
 
   const updateValue = (index) => (newValue) => {
-    const vs = value && value.length > 0 ? JSON.parse(JSON.stringify(value)) : [];
+    const vs = value && value.length > 0 ? deepCopy(value) : [];
     vs[index] = newValue;
     onChange(vs);
   };
 
   const addItem = () => {
     setShowModal(true);
-    const vs = value && value.length > 0 ? JSON.parse(JSON.stringify(value)) : [];
+    const vs = value && value.length > 0 ? deepCopy(value) : [];
     vs.push({});
     onChange(vs);
   };
 
   const removeItem = (index) => () => {
     setShowModal(false);
-    const vs = value && value.length > 0 ? JSON.parse(JSON.stringify(value)) : [];
+    const vs = value && value.length > 0 ? deepCopy(value) : [];
     vs.splice(index, 1);
     onChange(vs);
   };

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -3,6 +3,7 @@ import { replaceMarkdownTextInSteps } from './textReplacement';
 import { FormReducerState } from './useForm';
 import { validateInput } from '../../../helpers/ValidationHelper';
 import { evaluateConditionalExpression } from '../../../helpers/conditionParser';
+import { deepCopy } from 'app/helpers/Objects';
 
 /**
  * Action for replacing title markdown in steps.
@@ -218,7 +219,7 @@ export function submitForm(
  */
 export function updateAnswer(state: FormReducerState, answer: Record<string, any>) {
   // make a deep copy of the formAnswers, and use that to update. Not sure if completely needed.
-  const updatedAnswers: Record<string, any> = JSON.parse(JSON.stringify(state.formAnswers));
+  const updatedAnswers: Record<string, any> = deepCopy(state.formAnswers);
   Object.keys(answer).forEach(key => (updatedAnswers[key] = answer[key]));
 
   return {
@@ -481,7 +482,7 @@ export function dirtyField(
 
 export const createSnapshot = (state: FormReducerState) => ({
   ...state,
-  formAnswerSnapshot: JSON.parse(JSON.stringify(state.formAnswers)),
+  formAnswerSnapshot: deepCopy(state.formAnswers),
 });
 
 export const restoreSnapshot = (state: FormReducerState) => {
@@ -495,7 +496,7 @@ export const restoreSnapshot = (state: FormReducerState) => {
 
   return {
     ...state,
-    formAnswers: JSON.parse(JSON.stringify(state.formAnswerSnapshot)),
+    formAnswers: deepCopy(state.formAnswerSnapshot),
     formAnswerSnapshot: {},
   };
 }

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -3,7 +3,7 @@ import { replaceMarkdownTextInSteps } from './textReplacement';
 import { FormReducerState } from './useForm';
 import { validateInput } from '../../../helpers/ValidationHelper';
 import { evaluateConditionalExpression } from '../../../helpers/conditionParser';
-import { deepCopy } from 'app/helpers/Objects';
+import { deepCopy } from '../../../helpers/Objects';
 
 /**
  * Action for replacing title markdown in steps.

--- a/source/helpers/Objects.tsx
+++ b/source/helpers/Objects.tsx
@@ -1,10 +1,23 @@
 import stringify from "json-stable-stringify";
 import { NativeModules } from "react-native";
 
+import clone from "just-clone";
+
 const { Aes } = NativeModules;
 
 export function deepCopyViaJson<T>(original: T): T {
   return JSON.parse(JSON.stringify(original)) as T;
+}
+
+/**
+ * Deep copies objects and arrays, doesn't clone functions
+ * This is just an alias of just-clone, so in the case we ever need to change this, we don't have to do it at 4 billion places.
+ * @see https://www.npmjs.com/package/just-clone
+ * @param original The object to copy
+ * @returns The copied object
+ */
+export function deepCopy<T extends Record<any, any>>(original: T): T {
+  return clone(original);
 }
 
 export function filterAsync<T>(

--- a/source/helpers/test/Objects.test.tsx
+++ b/source/helpers/test/Objects.test.tsx
@@ -55,16 +55,30 @@ describe("Object helper functions", () => {
 });
 
 describe("Deep copy", () => {
-  const data = { hello: "world" };
+  const data = {
+    hello: "world",
+    deep: {
+      nested: {
+        things: true,
+        arr: ["1", "2", "3"],
+      },
+    },
+  };
 
   const copiedData = deepCopy(data);
 
   it("Should clone without references", () => {
     copiedData.hello = "not world!";
+    copiedData.deep.nested.things = false;
+    copiedData.deep.nested.arr.push("4");
     expect(copiedData.hello).toBe("not world!");
+    expect(copiedData.deep.nested.things).toBe(false);
+    expect(copiedData.deep.nested.arr).toContain("4");
   });
 
   it("Should not modify the original object", () => {
     expect(data.hello).toBe("world");
+    expect(data.deep.nested.things).toBe(true);
+    expect(data.deep.nested.arr).not.toContain("4");
   });
 });

--- a/source/helpers/test/Objects.test.tsx
+++ b/source/helpers/test/Objects.test.tsx
@@ -55,17 +55,32 @@ describe("Object helper functions", () => {
 });
 
 describe("Deep copy", () => {
-  const data = {
-    hello: "world",
+  interface DeepCopyTestObject {
+    hello: string,
     deep: {
       nested: {
-        things: true,
-        arr: ["1", "2", "3"],
-      },
-    },
-  };
+        things: boolean,
+        arr: string[]
+      }
+    }
+  }
 
-  const copiedData = deepCopy(data);
+  let data: DeepCopyTestObject;
+  let copiedData: DeepCopyTestObject;
+
+  beforeAll(() => {
+    data = {
+      hello: "world",
+      deep: {
+        nested: {
+          things: true,
+          arr: ["1", "2", "3"],
+        },
+      },
+    };
+
+    copiedData = deepCopy(data);
+  });
 
   it("Should clone without references", () => {
     copiedData.hello = "not world!";

--- a/source/helpers/test/Objects.test.tsx
+++ b/source/helpers/test/Objects.test.tsx
@@ -56,13 +56,13 @@ describe("Object helper functions", () => {
 
 describe("Deep copy", () => {
   interface DeepCopyTestObject {
-    hello: string,
+    hello: string;
     deep: {
       nested: {
-        things: boolean,
-        arr: string[]
-      }
-    }
+        things: boolean;
+        arr: string[];
+      };
+    };
   }
 
   let data: DeepCopyTestObject;

--- a/source/helpers/test/Objects.test.tsx
+++ b/source/helpers/test/Objects.test.tsx
@@ -1,4 +1,9 @@
-import { deepCompareEquals, deepCopyViaJson, filterAsync } from "../Objects";
+import {
+  deepCompareEquals,
+  deepCopyViaJson,
+  filterAsync,
+  deepCopy,
+} from "../Objects";
 
 describe("Object helper functions", () => {
   test("deepCopyViaJson", () => {
@@ -46,5 +51,20 @@ describe("Object helper functions", () => {
     expect(firstThird).toEqual(true);
     expect(secondThird).toEqual(true);
     expect(firstFourth).toEqual(false);
+  });
+});
+
+describe("Deep copy", () => {
+  const data = { hello: "world" };
+
+  const copiedData = deepCopy(data);
+
+  it("Should clone without references", () => {
+    copiedData.hello = "not world!";
+    expect(copiedData.hello).toBe("not world!");
+  });
+
+  it("Should not modify the original object", () => {
+    expect(data.hello).toBe("world");
   });
 });

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -201,7 +201,7 @@ export async function setupSymmetricKey(
   forms: AnsweredForm
 ): Promise<AnsweredForm> {
   // Ugly deep copy of forms.
-  const formsCopy = JSON.parse(JSON.stringify(forms));
+  const formsCopy = deepCopy(forms);
 
   const otherUserPersonalNumber = Object.keys(
     formsCopy.encryption.publicKeys

--- a/source/services/encryption/EncryptionService.ts
+++ b/source/services/encryption/EncryptionService.ts
@@ -1,4 +1,4 @@
-import { deepCopyViaJson } from "app/helpers/Objects";
+import { deepCopy } from "app/helpers/Objects";
 import { NativeModules } from "react-native";
 import {
   AnsweredForm,
@@ -286,7 +286,7 @@ export function deserializeCryptoNumberIfPossible(
 }
 
 export function serializeForm(form: AnsweredForm): AnsweredForm {
-  const formCopy = deepCopyViaJson(form);
+  const formCopy = deepCopy(form);
   const { encryption } = formCopy;
 
   if (encryption.primes !== undefined) {
@@ -319,7 +319,7 @@ export function serializeForm(form: AnsweredForm): AnsweredForm {
 }
 
 export function deserializeForm(form: AnsweredForm): AnsweredForm {
-  const formCopy = deepCopyViaJson(form);
+  const formCopy = deepCopy(form);
   const { encryption } = formCopy;
 
   if (encryption.primes !== undefined) {

--- a/source/services/encryption/test/EncryptionService.test.tsx
+++ b/source/services/encryption/test/EncryptionService.test.tsx
@@ -1,5 +1,5 @@
 import getException from "../../../../.jest/helpers";
-import { deepCopyViaJson } from "../../../helpers/Objects";
+import { deepCopy } from "../../../helpers/Objects";
 import { AnsweredForm, EncryptedAnswersWrapper } from "../../../types/Case";
 import {
   CryptoNumber,
@@ -92,7 +92,7 @@ describe("EncryptionService", () => {
 
     const encryptedForm = await encryptFormAnswers(
       testUser,
-      deepCopyViaJson(testForm) as AnsweredForm
+      deepCopy(testForm) as AnsweredForm
     );
 
     assertIsEncryptedAnswers(encryptedForm.answers);
@@ -100,7 +100,7 @@ describe("EncryptionService", () => {
 
     const decryptedForm = await decryptFormAnswers(
       testUser,
-      deepCopyViaJson(encryptedForm)
+      deepCopy(encryptedForm)
     );
 
     expect(decryptedForm.answers).toEqual(testForm.answers);
@@ -139,7 +139,7 @@ describe("EncryptionService", () => {
 
     const mainApplicantFirstForm = await setupSymmetricKey(
       mainApplicantYlva,
-      deepCopyViaJson(testForm) as AnsweredForm
+      deepCopy(testForm) as AnsweredForm
     );
 
     {
@@ -153,7 +153,7 @@ describe("EncryptionService", () => {
 
     const coApplicantForm = await setupSymmetricKey(
       coApplicantStina,
-      deepCopyViaJson(mainApplicantFirstForm)
+      deepCopy(mainApplicantFirstForm)
     );
 
     {
@@ -168,7 +168,7 @@ describe("EncryptionService", () => {
 
     const mainApplicantSecondForm = await setupSymmetricKey(
       mainApplicantYlva,
-      deepCopyViaJson(coApplicantForm)
+      deepCopy(coApplicantForm)
     );
 
     const mainApplicantSymmetricKey = await getStoredSymmetricKey(

--- a/source/store/actions/CaseActions.ts
+++ b/source/store/actions/CaseActions.ts
@@ -12,7 +12,7 @@ import {
 } from "../../services/encryption/EncryptionService";
 import { get, post, put } from "../../helpers/ApiRequest";
 import { convertAnswersToArray } from "../../helpers/CaseDataConverter";
-import { deepCompareEquals, deepCopyViaJson } from "../../helpers/Objects";
+import { deepCompareEquals, deepCopy } from "../../helpers/Objects";
 import {
   decryptFormAnswers,
   encryptFormAnswers,
@@ -189,7 +189,7 @@ export async function fetchCases(user: UserInterface): Promise<Action> {
               deserializedForm
             );
 
-            const rawCaseCopy = deepCopyViaJson(rawCase);
+            const rawCaseCopy = deepCopy(rawCase);
             const decryptedCase = {
               ...rawCaseCopy,
               forms: {

--- a/source/store/reducers/CaseReducer.ts
+++ b/source/store/reducers/CaseReducer.ts
@@ -1,4 +1,4 @@
-import { deepCopyViaJson } from "../../helpers/Objects";
+import { deepCopy } from "../../helpers/Objects";
 import { Case } from "../../types/Case";
 import {
   Action,
@@ -16,7 +16,7 @@ export const initialState: State = {
 
 export default function CaseReducer(state: State, action: Action): State {
   const { type, payload } = action;
-  const newState = deepCopyViaJson(state);
+  const newState = deepCopy(state);
   switch (type) {
     case ActionTypes.UPDATE_CASE: {
       const casePayload = payload as Case;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6201,6 +6201,11 @@ jsonify@~0.0.0:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
+just-clone@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/just-clone/-/just-clone-5.0.1.tgz#e2978fe886046267cad1df7c6aabcf3aa2a1b6a9"
+  integrity sha512-y6hFQ8X4fhJTZzdNvrE9mnCQX33uN4xV0hZ+5WNgs6yCcrRzs9ieFXuYRKznWqQ/gOSZpJu0yQ6hRHLCU6ezyw==
+
 jwt-decode@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"


### PR DESCRIPTION
## Explain the changes you’ve made

I've added the deep-clone package in order to remove the usage of `JSON.stringify` for deep cloning.

I've also changed all usages of `deepCloneUsingJSON` to the new `deepCopy` function.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Deep clone an object

## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
