### PR TITLE
[WIP] Add small interaction for pull to refresh

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -9,6 +9,7 @@ import React, {
 import { Animated, Easing, RefreshControl } from "react-native";
 import styled from "styled-components/native";
 import { useFocusEffect } from "@react-navigation/native";
+import { CardTitle } from "app/components/molecules/CharacterCard/styled";
 import { Modal } from "../../components/molecules/Modal";
 
 import Wrapper from "../../components/molecules/Dialog/Wrapper";
@@ -83,6 +84,14 @@ const RefreshCardBody = styled(Card.Body)`
       console.log("props", props);
       return props.theme.colors.neutrals[5];
     }};
+`;
+
+const CenteredCardBody = styled(Card.Body)`
+  text-align: center;
+`;
+
+const StyledIcon = styled(Icon)`
+  color: ${(props) => props.theme.colors.primary[colorSchema][0]};
 `;
 
 /**
@@ -579,15 +588,27 @@ function CaseOverview(props): JSX.Element {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
       >
-        {/* <Card colorSchema="red">
-          <RefreshCardBody>
-            <Card.Text>Dra för att ladda om sidan</Card.Text>
-          </RefreshCardBody>
-        </Card> */}
-        <Card.Button colorSchema="red" disabled>
-          <Icon name={refreshing ? "refresh" : "arrow-upward"} />
-          <Text>Dra för att ladda om sidan</Text>
-        </Card.Button>
+        {activeCases.length === 0 && closedCases.length === 0 ? (
+          <Card colorSchema="red">
+            <Card.Body colorSchema="red">
+              <Card.Text align="center">
+                <StyledIcon
+                  name={refreshing ? "refresh" : "arrow-downward"}
+                  size={32}
+                />
+              </Card.Text>
+              <Card.Title align="center">Här var det tomt!</Card.Title>
+              <Card.Text align="center" colorSchema="red">
+                Dra för att ladda om sidan om det borde finnas något här.
+              </Card.Text>
+            </Card.Body>
+          </Card>
+        ) : (
+          <Card.Button colorSchema="red" disabled>
+            <Icon name={refreshing ? "refresh" : "arrow-upward"} />
+            <Text>Dra för att ladda om sidan</Text>
+          </Card.Button>
+        )}
         <ListHeading type="h5">Aktiva</ListHeading>
         {activeCases.length > 0 && (
           <Animated.View style={{ opacity: fadeAnimation }}>

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -605,7 +605,7 @@ function CaseOverview(props): JSX.Element {
           </Card>
         ) : (
           <Card.Button colorSchema="red" disabled>
-            <Icon name={refreshing ? "refresh" : "arrow-upward"} />
+            <Icon name={refreshing ? "refresh" : "arrow-downward"} />
             <Text>Dra för att ladda om sidan</Text>
           </Card.Button>
         )}

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -78,18 +78,6 @@ const CardMessageBody = styled(Card.Body)`
 
 const colorSchema = "red";
 
-const RefreshCardBody = styled(Card.Body)`
-  border: 1px solid
-    ${(props) => {
-      console.log("props", props);
-      return props.theme.colors.neutrals[5];
-    }};
-`;
-
-const CenteredCardBody = styled(Card.Body)`
-  text-align: center;
-`;
-
 const StyledIcon = styled(Icon)`
   color: ${(props) => props.theme.colors.primary[colorSchema][0]};
 `;

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -17,7 +17,7 @@ import Body from "../../components/molecules/Dialog/Body";
 import BackgroundBlur from "../../components/molecules/Dialog/BackgroundBlur";
 import Button from "../../components/atoms/Button";
 import icons from "../../helpers/Icons";
-import { Text } from "../../components/atoms";
+import { Text, Icon } from "../../components/atoms";
 import {
   Card,
   CaseCard,
@@ -76,6 +76,14 @@ const CardMessageBody = styled(Card.Body)`
 `;
 
 const colorSchema = "red";
+
+const RefreshCardBody = styled(Card.Body)`
+  border: 1px solid
+    ${(props) => {
+      console.log("props", props);
+      return props.theme.colors.neutrals[5];
+    }};
+`;
 
 /**
  * Returns a case card component depending on it's status
@@ -571,6 +579,15 @@ function CaseOverview(props): JSX.Element {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
       >
+        {/* <Card colorSchema="red">
+          <RefreshCardBody>
+            <Card.Text>Dra för att ladda om sidan</Card.Text>
+          </RefreshCardBody>
+        </Card> */}
+        <Card.Button colorSchema="red" disabled>
+          <Icon name={refreshing ? "refresh" : "arrow-upward"} />
+          <Text>Dra för att ladda om sidan</Text>
+        </Card.Button>
         <ListHeading type="h5">Aktiva</ListHeading>
         {activeCases.length > 0 && (
           <Animated.View style={{ opacity: fadeAnimation }}>


### PR DESCRIPTION
## Explain the changes you’ve made

In accordance with #CU-1kcj38a, I've added a small text box with an icon telling the user about pulling to refresh.

## Explain your solution

This solution consists of two parts.

When there's no cases, we show a card with the interaction pattern "Pull to refresh". The icon changes to a refresh icon during the refresh.

When there is cases, we show a disabled button component with the same pattern.

## How to test the changes?

Concrete example:
1. Checkout this branch
2. Check the cases screen without any cases
3. Pull to refresh
4. Check the cases screen while having cases
5. Pull to refresh


## Was this feature tested in the following environments?
- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

