### PR TITLE
feat: make application able to use local notifications

### DIFF
--- a/jestSetupFile.js
+++ b/jestSetupFile.js
@@ -133,3 +133,10 @@ NativeModules.RNDateTimePickerManager.getDefaultDisplayValue = jest.fn(() =>
     determinedDisplayValue: "spinner",
   })
 );
+
+/**
+ * Mock @notifee/react-native native module
+ */
+NativeModules.NotifeeApiModule = {
+  addListener: jest.fn(),
+};

--- a/source/navigator/RootNavigator.tsx
+++ b/source/navigator/RootNavigator.tsx
@@ -8,6 +8,7 @@ import BottomBarNavigator from "./BottomBarNavigator";
 import FeatureModal from "../screens/featureModalScreens/FeatureModalNavigator";
 
 import AuthContext from "../store/AuthContext";
+import { NotifeeProvider } from "../store/NotifeeContext";
 import USER_AUTH_STATE from "../types/UserAuthTypes";
 
 const MainStack = createStackNavigator();
@@ -20,52 +21,57 @@ const forFade = ({ current }) => ({
   },
 });
 
-const MainStackScreen = (): JSX.Element => {
+const MainStackScreen = ({ navigation }: any): JSX.Element => {
   const { userAuthState } = useContext(AuthContext);
 
   return (
-    <CustomStackNavigator screenOptions={{ headerShown: false }}>
-      <>
-        {userAuthState === USER_AUTH_STATE.PENDING && (
-          <MainStack.Screen name="Start" component={SplashScreen} />
-        )}
+    <NotifeeProvider
+      navigation={navigation}
+      isSignedIn={userAuthState === USER_AUTH_STATE.SIGNED_IN}
+    >
+      <CustomStackNavigator screenOptions={{ headerShown: false }}>
+        <>
+          {userAuthState === USER_AUTH_STATE.PENDING && (
+            <MainStack.Screen name="Start" component={SplashScreen} />
+          )}
 
-        {userAuthState === USER_AUTH_STATE.SIGNED_OUT && (
-          <MainStack.Screen
-            name="Auth"
-            component={AuthStack}
-            options={{ cardStyleInterpolator: forFade }}
-          />
-        )}
+          {userAuthState === USER_AUTH_STATE.SIGNED_OUT && (
+            <MainStack.Screen
+              name="Auth"
+              component={AuthStack}
+              options={{ cardStyleInterpolator: forFade }}
+            />
+          )}
 
-        {userAuthState === USER_AUTH_STATE.SIGNED_IN && (
-          <>
-            <MainStack.Screen
-              name="App"
-              component={BottomBarNavigator}
-              options={{
-                cardStyleInterpolator: forFade,
-                gestureEnabled: false,
-              }}
-            />
-            <MainStack.Screen
-              name="Form"
-              component={FormCaseScreen}
-              options={{
-                gestureEnabled: false,
-              }}
-            />
-            <MainStack.Screen
-              name="DevFeatures"
-              component={DevFeaturesScreen}
-              options={{
-                gestureEnabled: false,
-              }}
-            />
-          </>
-        )}
-      </>
-    </CustomStackNavigator>
+          {userAuthState === USER_AUTH_STATE.SIGNED_IN && (
+            <>
+              <MainStack.Screen
+                name="App"
+                component={BottomBarNavigator}
+                options={{
+                  cardStyleInterpolator: forFade,
+                  gestureEnabled: false,
+                }}
+              />
+              <MainStack.Screen
+                name="Form"
+                component={FormCaseScreen}
+                options={{
+                  gestureEnabled: false,
+                }}
+              />
+              <MainStack.Screen
+                name="DevFeatures"
+                component={DevFeaturesScreen}
+                options={{
+                  gestureEnabled: false,
+                }}
+              />
+            </>
+          )}
+        </>
+      </CustomStackNavigator>
+    </NotifeeProvider>
   );
 };
 


### PR DESCRIPTION
## Explain the changes you’ve made
Added the Notifee provider to RootNavigator in order to be able to use local notifications in the application

## Explain why these changes are made
Added the Notifee provider to RootNavigator because that component gives us access to both the userAuthState and the navgation object which is used in the NotifeeContext.

## Explain your solution
N/A

## How to test

1. Checkout this branch
2. Run application on android or IOS
3. If you have not approved notifications on IOS before, a modal should be displayed telling you to accept it
4. If you want to test the notifications, place a button on whichever application screen you want
5. Use the Notifee context and use on of the functions that is returned from it (showLocalNotification or showScheduledNotification)
6. Trigger one of above functions with

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

![image](https://user-images.githubusercontent.com/81250970/144242815-8ca4b8e9-8ed4-4786-87dd-d0194fba156e.png)
