### PR TITLE
feat: add ability to remove a scheduled notification by its id

### DIFF
--- a/source/store/NotifeeContext.tsx
+++ b/source/store/NotifeeContext.tsx
@@ -31,6 +31,7 @@ export interface NotifeeState {
   ScheduledNotificationType: (
     options: ScheduledNotificationType
   ) => Promise<void>;
+  removeScheduledNotification: (notificationId: string) => Promise<void>;
 }
 
 interface NotifeeProviderInterface {
@@ -43,6 +44,7 @@ const NotifeeContext = createContext({
   showLocalNotification: (_options: LocalNotificationType) => Promise.resolve(),
   showScheduledNotification: (_options: ScheduledNotificationType) =>
     Promise.resolve(),
+  removeScheduledNotification: (_notificationId: string) => Promise.resolve(),
 });
 
 const NotifeeProvider = (props: NotifeeProviderInterface): JSX.Element => {
@@ -176,7 +178,15 @@ const NotifeeProvider = (props: NotifeeProviderInterface): JSX.Element => {
     );
   };
 
-  const value = { showLocalNotification, showScheduledNotification };
+  const removeScheduledNotification = async (notificationId: string) => {
+    await notifee.cancelTriggerNotification(notificationId);
+  };
+
+  const value = {
+    showLocalNotification,
+    showScheduledNotification,
+    removeScheduledNotification,
+  };
   return (
     <NotifeeContext.Provider value={value}>{children}</NotifeeContext.Provider>
   );


### PR DESCRIPTION
## Explain the changes you’ve made
Made it possible to remove a scheduled notification

## Explain why these changes are made
When a user creates a booking, a notification is created and shown to the user 24 hours before the meeting starts. If that meeting is deleted then we have no way of deleting that notification. This PR adds the ability to remove that notification by its id.

## Explain your solution
Added a function in NotifeeContext which calls the Notifee module to remote it

## How to test
1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Add a button on whichever screen you like and use the NotifeeContext to create a scheduled notification. Add an id which you can use for removing the notification.
4. Use the id from bullet 3 and use it as parameter on the newly added function removeScheduledNotification added in the NotifeeContext

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.