### PR TITLE
feat: request user notification permisions on ios

### DIFF
--- a/source/store/NotifeeContext.tsx
+++ b/source/store/NotifeeContext.tsx
@@ -72,6 +72,14 @@ const NotifeeProvider = (props: NotifeeProviderInterface): JSX.Element => {
     return notificationData;
   };
 
+  useEffect(() => {
+    const tryRequestPermission = async () => {
+      await notifee.requestPermission();
+    };
+
+    void tryRequestPermission();
+  }, []);
+
   useEffect(
     () =>
       notifee.onForegroundEvent(({ type, detail }) => {


### PR DESCRIPTION
## Explain the changes you’ve made
Requests permissions to show notification on iOs on application startup

## Explain why these changes are made
In order to shown notifications, a user has to accept that the application can show them. In ios there is a modal that asks for permissions handled by the Notifee module

## Explain your solution
Added a requestPermission call to Notifee module on application start

## How to test
1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. A modal will be shown asking for permissions

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
