### PR TITLE
Feat: move bookables to its own context

### DIFF
--- a/source/navigator/RootNavigator.tsx
+++ b/source/navigator/RootNavigator.tsx
@@ -34,12 +34,16 @@ const CustomNavigator = ({
   });
 
   const { isDevMode } = useContext(AppContext);
-  const { userAuthState } = useContext(AuthContext);
+  const { userAuthState, user } = useContext(AuthContext);
   const isSignedIn = userAuthState === USER_AUTH_STATE.SIGNED_IN;
 
   return (
     <NotifeeProvider navigation={navigation} isSignedIn={isSignedIn}>
-      <BookablesProvider isSignedIn={isSignedIn} isDevMode={isDevMode}>
+      <BookablesProvider
+        isSignedIn={isSignedIn}
+        isDevMode={isDevMode}
+        user={user}
+      >
         <NavigationHelpersContext.Provider value={navigation}>
           <View style={{ flex: 1, backgroundColor: "transparent" }}>
             {state.routes.map((route) => (

--- a/source/navigator/RootNavigator.tsx
+++ b/source/navigator/RootNavigator.tsx
@@ -11,7 +11,9 @@ import MainNavigator from "./MainNavigator";
 import FeatureModalNavigator from "../screens/featureModalScreens/FeatureModalNavigator";
 
 import AuthContext from "../store/AuthContext";
+import AppContext from "../store/AppContext";
 import { NotifeeProvider } from "../store/NotifeeContext";
+import { BookablesProvider } from "../store/BookablesContext";
 
 import USER_AUTH_STATE from "../types/UserAuthTypes";
 
@@ -31,20 +33,23 @@ const CustomNavigator = ({
     initialRouteName,
   });
 
+  const { isDevMode } = useContext(AppContext);
   const { userAuthState } = useContext(AuthContext);
   const isSignedIn = userAuthState === USER_AUTH_STATE.SIGNED_IN;
 
   return (
     <NotifeeProvider navigation={navigation} isSignedIn={isSignedIn}>
-      <NavigationHelpersContext.Provider value={navigation}>
-        <View style={{ flex: 1, backgroundColor: "transparent" }}>
-          {state.routes.map((route) => (
-            <React.Fragment key={route.key}>
-              {descriptors[route.key].render()}
-            </React.Fragment>
-          ))}
-        </View>
-      </NavigationHelpersContext.Provider>
+      <BookablesProvider isSignedIn={isSignedIn} isDevMode={isDevMode}>
+        <NavigationHelpersContext.Provider value={navigation}>
+          <View style={{ flex: 1, backgroundColor: "transparent" }}>
+            {state.routes.map((route) => (
+              <React.Fragment key={route.key}>
+                {descriptors[route.key].render()}
+              </React.Fragment>
+            ))}
+          </View>
+        </NavigationHelpersContext.Provider>
+      </BookablesProvider>
     </NotifeeProvider>
   );
 };

--- a/source/screens/featureModalScreens/ServiceSelection.tsx
+++ b/source/screens/featureModalScreens/ServiceSelection.tsx
@@ -27,14 +27,8 @@ type ButtonItem = {
 };
 
 const ServiceSelection = ({ onChangeModalScreen }: Props): JSX.Element => {
-  const {
-    bookables,
-    isFetchingBookables,
-    bookablesError,
-    contacts,
-    isFetchingContacts,
-    contactsError,
-  } = useContext(BookablesContext);
+  const { bookables, isFetchingBookables, bookablesError, contacts } =
+    useContext(BookablesContext);
 
   const buttons = useMemo(() => {
     const buttonList: ButtonItem[] = bookables.map((bookable) => ({
@@ -61,7 +55,7 @@ const ServiceSelection = ({ onChangeModalScreen }: Props): JSX.Element => {
     return buttonList;
   }, [bookables, contacts, onChangeModalScreen]);
 
-  let errorText = undefined;
+  let errorText;
   if (bookablesError) {
     errorText = "Ett fel har inträffat. Vänligen försök igen.";
   } else if (buttons.length === 0) {

--- a/source/screens/featureModalScreens/ServiceSelection.tsx
+++ b/source/screens/featureModalScreens/ServiceSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import { ActivityIndicator, SafeAreaView, ScrollView } from "react-native";
 import styled from "styled-components/native";
 import BookablesContext from "../../store/BookablesContext";
@@ -36,25 +36,36 @@ const ServiceSelection = ({ onChangeModalScreen }: Props): JSX.Element => {
     contactsError,
   } = useContext(BookablesContext);
 
-  const buttons: ButtonItem[] = bookables.map((bookable) => ({
-    underline: false,
-    variant: "link",
-    buttonText: bookable.name,
-    icon: "photo-camera",
-    onClick: () => onChangeModalScreen(ModalScreen.BookingForm, bookable),
-  }));
+  const buttons = useMemo(() => {
+    const buttonList: ButtonItem[] = bookables.map((bookable) => ({
+      underline: false,
+      variant: "link",
+      buttonText: bookable.name,
+      icon: "photo-camera",
+      onClick: () => onChangeModalScreen(ModalScreen.BookingForm, bookable),
+    }));
 
-  if (!isFetchingContacts && !contactsError && contacts.length > 0) {
-    buttons.unshift({
-      underline: true,
-      buttonText: "Mina kontakter",
-      icon: "person",
-      onClick: () =>
-        onChangeModalScreen(ModalScreen.BookingForm, {
-          isContactsMode: true,
-          contacts,
-        }),
-    });
+    if (contacts.length > 0) {
+      buttonList.unshift({
+        underline: true,
+        buttonText: "Mina kontakter",
+        icon: "person",
+        onClick: () =>
+          onChangeModalScreen(ModalScreen.BookingForm, {
+            isContactsMode: true,
+            contacts,
+          }),
+      });
+    }
+
+    return buttonList;
+  }, [bookables, contacts, onChangeModalScreen]);
+
+  let errorText = undefined;
+  if (bookablesError) {
+    errorText = "Ett fel har inträffat. Vänligen försök igen.";
+  } else if (buttons.length === 0) {
+    errorText = "Inga tjänster är tillgängliga just nu. Vänligen försök igen.";
   }
 
   return (
@@ -70,24 +81,15 @@ const ServiceSelection = ({ onChangeModalScreen }: Props): JSX.Element => {
             style={{ marginTop: 30 }}
           />
         )}
-        {bookablesError && (
-          <ErrorText type="h5">
-            Ett fel har inträffat. Vänligen försök igen.
-          </ErrorText>
+        {errorText ? (
+          <ErrorText type="h5">{errorText}</ErrorText>
+        ) : (
+          <ButtonList
+            buttonList={buttons}
+            defaultColorSchema="red"
+            defaultVariant={undefined}
+          />
         )}
-        {!bookablesError &&
-          !isFetchingBookables &&
-          (buttons.length === 0 ? (
-            <ErrorText type="h5">
-              Inga tjänster är tillgängliga just nu. Vänligen försök igen.
-            </ErrorText>
-          ) : (
-            <ButtonList
-              buttonList={buttons}
-              defaultColorSchema="red"
-              defaultVariant={undefined}
-            />
-          ))}
       </SafeAreaView>
     </ScrollView>
   );

--- a/source/screens/featureModalScreens/ServiceSelection.tsx
+++ b/source/screens/featureModalScreens/ServiceSelection.tsx
@@ -1,10 +1,6 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useContext } from "react";
 import { ActivityIndicator, SafeAreaView, ScrollView } from "react-native";
 import styled from "styled-components/native";
-import moment from "moment";
-import { getHistoricalAttendees } from "../../services/BookingService";
-import { getReferenceCodeForUser } from "../../helpers/BookingHelper";
-import AuthContext from "../../store/AuthContext";
 import BookablesContext from "../../store/BookablesContext";
 import { Text } from "../../components/atoms";
 
@@ -31,72 +27,35 @@ type ButtonItem = {
 };
 
 const ServiceSelection = ({ onChangeModalScreen }: Props): JSX.Element => {
-  const { user } = useContext(AuthContext);
-  const { bookables, isFetchingBookables, bookablesError } =
-    useContext(BookablesContext);
+  const {
+    bookables,
+    isFetchingBookables,
+    bookablesError,
+    contacts,
+    isFetchingContacts,
+    contactsError,
+  } = useContext(BookablesContext);
 
-  const [isLoading, setLoading] = useState(true);
-  const [buttons, setButtons] = useState<ButtonItem[]>([]);
-  const [error, setError] = useState<Error | undefined>(undefined);
+  const buttons: ButtonItem[] = bookables.map((bookable) => ({
+    underline: false,
+    variant: "link",
+    buttonText: bookable.name,
+    icon: "photo-camera",
+    onClick: () => onChangeModalScreen(ModalScreen.BookingForm, bookable),
+  }));
 
-  useEffect(() => {
-    let canceled = false;
-
-    const fetchData = async () => {
-      try {
-        let contactsList: string[] = [];
-        try {
-          contactsList = await getHistoricalAttendees(
-            getReferenceCodeForUser(user),
-            moment().subtract(6, "months").format(),
-            moment().add(6, "months").format()
-          );
-        } catch (err) {
-          console.log(err);
-        }
-
-        const contacts = [];
-        if (contactsList.length > 0) {
-          contacts.push({
-            underline: true,
-            buttonText: "Mina kontakter",
-            icon: "person",
-            onClick: () =>
-              onChangeModalScreen(ModalScreen.BookingForm, {
-                isContactsMode: true,
-                contactsList,
-              }),
-          });
-        }
-
-        if (!canceled) {
-          const buttonItems: ButtonItem[] = contacts.concat(
-            bookables.map((bookable) => ({
-              underline: false,
-              variant: "link",
-              buttonText: bookable.name,
-              icon: "photo-camera",
-              onClick: () =>
-                onChangeModalScreen(ModalScreen.BookingForm, bookable),
-            }))
-          );
-          setButtons(buttonItems);
-          setLoading(false);
-        }
-      } catch (err) {
-        console.log(err);
-        setError(err as Error);
-        setLoading(false);
-      }
-    };
-    void fetchData();
-    return () => {
-      canceled = true;
-    };
-  }, [user, onChangeModalScreen, bookables]);
-
-  const hasError = error || bookablesError;
-  const isLoadingData = isLoading || isFetchingBookables;
+  if (!isFetchingContacts && !contactsError && contacts.length > 0) {
+    buttons.unshift({
+      underline: true,
+      buttonText: "Mina kontakter",
+      icon: "person",
+      onClick: () =>
+        onChangeModalScreen(ModalScreen.BookingForm, {
+          isContactsMode: true,
+          contacts,
+        }),
+    });
+  }
 
   return (
     <ScrollView
@@ -104,20 +63,20 @@ const ServiceSelection = ({ onChangeModalScreen }: Props): JSX.Element => {
       style={{ backgroundColor: "white" }}
     >
       <SafeAreaView style={{ backgroundColor: "white" }}>
-        {isLoadingData && (
+        {isFetchingBookables && (
           <ActivityIndicator
             size="large"
             color="slategray"
             style={{ marginTop: 30 }}
           />
         )}
-        {hasError && (
+        {bookablesError && (
           <ErrorText type="h5">
             Ett fel har inträffat. Vänligen försök igen.
           </ErrorText>
         )}
-        {!hasError &&
-          !isLoadingData &&
+        {!bookablesError &&
+          !isFetchingBookables &&
           (buttons.length === 0 ? (
             <ErrorText type="h5">
               Inga tjänster är tillgängliga just nu. Vänligen försök igen.

--- a/source/store/BookablesContext.tsx
+++ b/source/store/BookablesContext.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, createContext, useState } from "react";
+
+import { getBookables, BookableItem } from "../services/BookablesService";
+
+interface BookablesProviderInterface {
+  isSignedIn: boolean;
+  children: Element | Element[];
+  isDevMode: boolean;
+}
+
+const BookablesContext = createContext({
+  isFetchingBookables: false,
+  bookables: [] as BookableItem[],
+  bookablesError: null,
+});
+
+const BookablesProvider = (props: BookablesProviderInterface): JSX.Element => {
+  const { children, isSignedIn, isDevMode = true } = props;
+
+  const [bookables, setBookables] = useState<BookableItem[]>([]);
+  const [isFetchingBookables, setIsFetchingBookables] = useState(false);
+  const [bookablesError, setBookablesError] = useState<null | any>(null);
+
+  useEffect(() => {
+    const tryFetchBookables = async () => {
+      try {
+        if (isSignedIn && isDevMode) {
+          setIsFetchingBookables(true);
+          setBookablesError(null);
+
+          const fetchedBookables = await getBookables();
+          setBookables(fetchedBookables as BookableItem[]);
+        }
+      } catch (error) {
+        setBookablesError(error);
+        console.log("Error fetching bookables: ", error);
+      }
+
+      setIsFetchingBookables(false);
+    };
+
+    void tryFetchBookables();
+  }, [isSignedIn, isDevMode]);
+
+  const value = {
+    isFetchingBookables,
+    bookables,
+    bookablesError,
+  };
+
+  return (
+    <BookablesContext.Provider value={value}>
+      {children}
+    </BookablesContext.Provider>
+  );
+};
+
+export default BookablesContext;
+export { BookablesProvider };

--- a/source/store/BookablesContext.tsx
+++ b/source/store/BookablesContext.tsx
@@ -12,12 +12,21 @@ interface BookablesProviderInterface {
   user: Record<string, string>;
 }
 
-const BookablesContext = createContext({
+interface BookablesContextInterface {
+  isFetchingBookables: boolean;
+  bookables: BookableItem[];
+  bookablesError: Error | null;
+  isFetchingContacts: boolean;
+  contacts: string[];
+  contactsError: Error | null;
+}
+
+const BookablesContext = createContext<BookablesContextInterface>({
   isFetchingBookables: false,
-  bookables: [] as BookableItem[],
+  bookables: [],
   bookablesError: null,
   isFetchingContacts: false,
-  contacts: [] as string[],
+  contacts: [],
   contactsError: null,
 });
 
@@ -26,11 +35,11 @@ const BookablesProvider = (props: BookablesProviderInterface): JSX.Element => {
 
   const [bookables, setBookables] = useState<BookableItem[]>([]);
   const [isFetchingBookables, setIsFetchingBookables] = useState(false);
-  const [bookablesError, setBookablesError] = useState<null | any>(null);
+  const [bookablesError, setBookablesError] = useState<null | Error>(null);
 
   const [contacts, setContacts] = useState<string[]>([]);
   const [isFetchingContacts, setIsFetchingContacts] = useState(false);
-  const [contactsError, setContactsError] = useState<null | any>(null);
+  const [contactsError, setContactsError] = useState<null | Error>(null);
 
   useEffect(() => {
     const tryFetchBookables = async () => {
@@ -43,7 +52,7 @@ const BookablesProvider = (props: BookablesProviderInterface): JSX.Element => {
           setBookables(fetchedBookables as BookableItem[]);
         }
       } catch (error) {
-        setBookablesError(error);
+        setBookablesError(error as Error);
         console.log("Error fetching bookables: ", error);
       }
 
@@ -64,7 +73,7 @@ const BookablesProvider = (props: BookablesProviderInterface): JSX.Element => {
           setContacts(fetchedContacts);
         }
       } catch (error) {
-        setContactsError(error);
+        setContactsError(error as Error);
         console.log("Error fetching contacts: ", error);
       }
 

--- a/source/store/BookablesContext.tsx
+++ b/source/store/BookablesContext.tsx
@@ -1,25 +1,36 @@
 import React, { useEffect, createContext, useState } from "react";
 
+import moment from "moment";
+import { getReferenceCodeForUser } from "../helpers/BookingHelper";
+import { getHistoricalAttendees } from "../services/BookingService";
 import { getBookables, BookableItem } from "../services/BookablesService";
 
 interface BookablesProviderInterface {
   isSignedIn: boolean;
   children: Element | Element[];
   isDevMode: boolean;
+  user: Record<string, string>;
 }
 
 const BookablesContext = createContext({
   isFetchingBookables: false,
   bookables: [] as BookableItem[],
   bookablesError: null,
+  isFetchingContacts: false,
+  contacts: [] as string[],
+  contactsError: null,
 });
 
 const BookablesProvider = (props: BookablesProviderInterface): JSX.Element => {
-  const { children, isSignedIn, isDevMode = true } = props;
+  const { children, isSignedIn, isDevMode = true, user } = props;
 
   const [bookables, setBookables] = useState<BookableItem[]>([]);
   const [isFetchingBookables, setIsFetchingBookables] = useState(false);
   const [bookablesError, setBookablesError] = useState<null | any>(null);
+
+  const [contacts, setContacts] = useState<string[]>([]);
+  const [isFetchingContacts, setIsFetchingContacts] = useState(false);
+  const [contactsError, setContactsError] = useState<null | any>(null);
 
   useEffect(() => {
     const tryFetchBookables = async () => {
@@ -39,13 +50,38 @@ const BookablesProvider = (props: BookablesProviderInterface): JSX.Element => {
       setIsFetchingBookables(false);
     };
 
+    const tryFetchContacts = async () => {
+      try {
+        if (isSignedIn && isDevMode && user.personalNumber) {
+          setIsFetchingContacts(true);
+          setContactsError(null);
+
+          const fetchedContacts = await getHistoricalAttendees(
+            getReferenceCodeForUser(user),
+            moment().subtract(6, "months").format(),
+            moment().add(6, "months").format()
+          );
+          setContacts(fetchedContacts);
+        }
+      } catch (error) {
+        setContactsError(error);
+        console.log("Error fetching contacts: ", error);
+      }
+
+      setIsFetchingContacts(false);
+    };
+
     void tryFetchBookables();
-  }, [isSignedIn, isDevMode]);
+    void tryFetchContacts();
+  }, [isSignedIn, isDevMode, user]);
 
   const value = {
     isFetchingBookables,
     bookables,
     bookablesError,
+    isFetchingContacts,
+    contacts,
+    contactsError,
   };
 
   return (


### PR DESCRIPTION
This line can be removed: Read this short article before you start writing https://www.pullrequest.com/blog/writing-a-great-pull-request-description/

## Explain the changes you’ve made
Fetching bookables (i.e. services that a resident can book) is moved to its own context.

## Explain why these changes are made
In order to not fetch bookables every time the bottom modal is opened, and to have data stored till the application is closed/terminated, the fetching is moved to its own context.

## Explain your solution
Created a new context which is used in the ServiceSelection screen. Did use the isDevMode variables from AppContext context in order to only try to fetch bookables when in development mode since the bookingservice is not in production.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Change the APP_ENV environment variable and check if bookables are fetched or not.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
