### PR TITLE
bug: fix bug where bottom modal was shown when signed out

### DIFF
--- a/source/navigator/RootNavigator.tsx
+++ b/source/navigator/RootNavigator.tsx
@@ -52,25 +52,31 @@ const CustomNavigator = ({
 const createRootCustomNavigator = createNavigatorFactory(CustomNavigator);
 const RootCustomNavigator = createRootCustomNavigator();
 
-const RootNavigator = (): JSX.Element => (
-  <RootCustomNavigator.Navigator
-    screenOptions={{
-      cardStyle: { backgroundColor: "transparent" },
-      headerShown: false,
-      cardOverlayEnabled: true,
-      cardShadowEnabled: true,
-    }}
-  >
-    <RootCustomNavigator.Screen
-      name="Main"
-      component={MainNavigator}
-      options={{ headerShown: false }}
-    />
-    <RootCustomNavigator.Screen
-      name="FeatureModal"
-      component={FeatureModalNavigator}
-    />
-  </RootCustomNavigator.Navigator>
-);
+const RootNavigator = (): JSX.Element => {
+  const { userAuthState } = useContext(AuthContext);
+
+  return (
+    <RootCustomNavigator.Navigator
+      screenOptions={{
+        cardStyle: { backgroundColor: "transparent" },
+        headerShown: false,
+        cardOverlayEnabled: true,
+        cardShadowEnabled: true,
+      }}
+    >
+      <RootCustomNavigator.Screen
+        name="Main"
+        component={MainNavigator}
+        options={{ headerShown: false }}
+      />
+      {userAuthState === USER_AUTH_STATE.SIGNED_IN && (
+        <RootCustomNavigator.Screen
+          name="FeatureModal"
+          component={FeatureModalNavigator}
+        />
+      )}
+    </RootCustomNavigator.Navigator>
+  );
+};
 
 export default RootNavigator;


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed a bug where the Bottom modal could be shown even if the user were signed out. Did add the userAuthState variable to the rootnavigator which only rendered the bottom modal if signed in.

## Explain why these changes are made
There are no other places to add a condition that checks if the BottomModal could be rendered or not.

## Explain your solution
Utilised the AuthContext and the userAuthState variable to conditionally render the bottom modal when signed in.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Open the bottom modal by going to the "Calendar tab"
4. Press the "book a meeting" button
5. Wait until the user session expires and signs out the user automatically
6. The Bottom modal should not be rendered (shown)

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
