### PR TITLE
feat: be able to show viva completions in case card

### DIFF
--- a/source/components/molecules/Card/Card.js
+++ b/source/components/molecules/Card/Card.js
@@ -1,8 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import styled from 'styled-components/native';
-import { Button, Text, Heading, Progressbar } from '../../atoms';
-import { colorPalette } from '../../../styles/palette';
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components/native";
+import { Button, Text, Heading, Progressbar } from "../../atoms";
+import BulletList from "../../organisms/BulletList";
+import { colorPalette } from "../../../styles/palette";
 
 const Container = styled.View`
   display: flex;
@@ -15,17 +16,19 @@ const Container = styled.View`
 
 const Body = styled.TouchableHighlight`
   background-color: ${(props) =>
-    props.colorSchema === 'neutral'
+    props.colorSchema === "neutral"
       ? props.theme.colors.neutrals[7]
       : props.theme.colors.complementary[props.colorSchema][3]};
   ${(props) => {
     // Overrides colorSchema without affecting it's children
     if (props.color) {
       switch (props.color) {
-        case 'neutral':
+        case "neutral":
           return `background-color: ${props.theme.colors.neutrals[7]};`;
         default:
-          return `background-color: ${props.theme.colors.complementary[props.color][3]};`;
+          return `background-color: ${
+            props.theme.colors.complementary[props.color][3]
+          };`;
       }
     }
   }}
@@ -44,10 +47,12 @@ const Body = styled.TouchableHighlight`
   ${(props) => {
     if (props.outlined) {
       switch (props.colorSchema) {
-        case 'neutral':
+        case "neutral":
           return `border: 2px solid ${props.theme.colors.neutrals[0]};`;
         default:
-          return `border: 2px solid ${props.theme.colors.primary[props.colorSchema][0]};`;
+          return `border: 2px solid ${
+            props.theme.colors.primary[props.colorSchema][0]
+          };`;
       }
     }
   }}
@@ -72,7 +77,7 @@ const BodyContainer = styled.View`
 
 const CardTitle = styled(Heading)`
   color: ${(props) =>
-    props.colorSchema === 'neutral'
+    props.colorSchema === "neutral"
       ? props.theme.colors.neutrals[1]
       : props.theme.colors.primary[props.colorSchema][0]};
   margin-bottom: 0;
@@ -80,7 +85,7 @@ const CardTitle = styled(Heading)`
 
 const CardSubTitle = styled(Text)`
   color: ${(props) =>
-    props.colorSchema === 'neutral'
+    props.colorSchema === "neutral"
       ? props.theme.colors.neutrals[0]
       : props.theme.colors.primary[props.colorSchema][1]};
   font-size: ${(props) => props.theme.fontSizes[2]}px;
@@ -102,15 +107,15 @@ const CardButton = styled(Button)`
 const Outset = styled.View`
   padding-top: 8px;
   padding-bottom: 8px;
-  ${({ firstChild }) => firstChild && 'padding-top: 0px;'}
-  ${({ lastChild }) => lastChild && 'padding-bottom: 0px;'}
+  ${({ firstChild }) => firstChild && "padding-top: 0px;"}
+  ${({ lastChild }) => lastChild && "padding-bottom: 0px;"}
 `;
 
 const CardImage = styled.Image`
   width: 80px;
   height: 80px;
   resize-mode: contain;
-  ${({ circle }) => circle && 'border-radius: 50px;'}
+  ${({ circle }) => circle && "border-radius: 50px;"}
 `;
 
 const CardProgressbar = styled(Progressbar)`
@@ -123,18 +128,21 @@ const CardProgressbar = styled(Progressbar)`
  */
 const Card = ({ children, colorSchema, ...props }) => {
   // First filter out falsy child components. Then clone each child and add additional props
-  const childrenWithProps = React.Children.toArray(children).reduce((filtered, child, index) => {
-    if (child) {
-      const childWithProps = React.cloneElement(child, {
-        key: index,
-        colorSchema,
-        firstChild: index === 0,
-        lastChild: index === React.Children.count(children) - 1,
-      });
-      filtered.push(childWithProps);
-    }
-    return filtered;
-  }, []);
+  const childrenWithProps = React.Children.toArray(children).reduce(
+    (filtered, child, index) => {
+      if (child) {
+        const childWithProps = React.cloneElement(child, {
+          key: index,
+          colorSchema,
+          firstChild: index === 0,
+          lastChild: index === React.Children.count(children) - 1,
+        });
+        filtered.push(childWithProps);
+      }
+      return filtered;
+    },
+    []
+  );
 
   return <Container {...props}>{childrenWithProps}</Container>;
 };
@@ -148,12 +156,14 @@ Card.Body = ({ children, colorSchema, color, ...props }) => {
   const filteredChildren = React.Children.toArray(children).filter(Boolean);
 
   let underlayColor =
-    colorSchema === 'neutral'
+    colorSchema === "neutral"
       ? colorPalette.neutrals[5]
       : colorPalette.complementary[colorSchema][2];
   if (color) {
     underlayColor =
-      color === 'neutral' ? colorPalette.neutrals[5] : colorPalette.complementary[color][2];
+      color === "neutral"
+        ? colorPalette.neutrals[5]
+        : colorPalette.complementary[color][2];
   }
 
   const imageWithProps = [];
@@ -188,7 +198,9 @@ Card.Body = ({ children, colorSchema, color, ...props }) => {
       {...props}
     >
       <BodyWrapper>
-        {imageWithProps.length > 0 && <BodyImageContainer>{imageWithProps}</BodyImageContainer>}
+        {imageWithProps.length > 0 && (
+          <BodyImageContainer>{imageWithProps}</BodyImageContainer>
+        )}
         <BodyContainer>{childrenWithProps}</BodyContainer>
       </BodyWrapper>
     </Body>
@@ -247,7 +259,14 @@ Card.Text = ({ children, lastChild, firstChild, ...props }) => (
  * Renders a button
  * @param {props} props
  */
-Card.Button = ({ children, colorSchema, firstChild, lastChild, mt, ...props }) => (
+Card.Button = ({
+  children,
+  colorSchema,
+  firstChild,
+  lastChild,
+  mt,
+  ...props
+}) => (
   <Outset lastChild={lastChild} firstChild={firstChild}>
     <CardButton variant="link" z={0} colorSchema={colorSchema} block {...props}>
       {children}
@@ -269,49 +288,80 @@ Card.Image = ({ firstChild, lastChild, ...props }) => (
  * Renders a progress bar
  * @param {props} props
  */
-Card.Progressbar = ({ children, firstChild, lastChild, colorSchema, ...props }) => (
+Card.Progressbar = ({
+  children,
+  firstChild,
+  lastChild,
+  colorSchema,
+  ...props
+}) => (
   <Outset lastChild={lastChild} firstChild={firstChild}>
     <CardProgressbar rounded colorSchema={colorSchema} {...props} />
   </Outset>
 );
 
+/**
+ * Renders a bullet list
+ * @param {props} props
+ */
+Card.BulletList = ({ firstChild, lastChild, values }) => (
+  <Outset lastChild={lastChild} firstChild={firstChild}>
+    <BulletList values={values} />
+  </Outset>
+);
+
 Card.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Sets a color schema for the component */
-  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
+  colorSchema: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
 };
 
 Card.defaultProps = {
-  colorSchema: 'neutral',
+  colorSchema: "neutral",
 };
 
 Card.Body.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Sets a color schema for the component */
-  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
+  colorSchema: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
   /** Sets a color for the body that does not overrides colorSchema  */
-  color: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
+  color: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
 };
 
 Card.Title.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Sets a color schema for the component */
-  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
+  colorSchema: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
 };
 
 Card.SubTitle.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Sets a color schema for the component */
-  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
+  colorSchema: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
 };
 
 Card.Text.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Equals true if child is first in children array */
   firstChild: PropTypes.bool,
   /** Equals true if child is last in children array */
@@ -320,7 +370,10 @@ Card.Text.propTypes = {
 
 Card.Image.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Equals true if child is first in children array */
   firstChild: PropTypes.bool,
   /** Equals true if child is last in children array */
@@ -329,20 +382,26 @@ Card.Image.propTypes = {
 
 Card.Progressbar.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Equals true if child is first in children array */
   firstChild: PropTypes.bool,
   /** Equals true if child is last in children array */
   lastChild: PropTypes.bool,
   /** Sets a color schema for the component */
-  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
+  colorSchema: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
 };
 
 Card.Button.propTypes = {
   /** List of every immediate child */
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /** Sets a color schema for the component */
-  colorSchema: PropTypes.oneOf(['neutral', 'blue', 'red', 'purple', 'green']),
+  colorSchema: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
   /** Equals true if child is first in children array */
   firstChild: PropTypes.bool,
   /** Equals true if child is last in children array */

--- a/source/components/molecules/CaseCard/CaseCard.tsx
+++ b/source/components/molecules/CaseCard/CaseCard.tsx
@@ -39,6 +39,7 @@ interface CaseCardProps {
   bookingTime?: string;
   dateTimeCardSize?: "large" | "small";
   buttonColorScheme?: string;
+  completions?: string[];
 }
 
 const CaseCard = ({
@@ -65,6 +66,7 @@ const CaseCard = ({
   bookingTime,
   dateTimeCardSize = "large",
   buttonColorScheme = "red",
+  completions = [],
 }: CaseCardProps): JSX.Element => (
   <Card colorSchema={colorSchema}>
     <Card.Body shadow color="neutral" onPress={onCardClick}>
@@ -106,6 +108,8 @@ const CaseCard = ({
           Avslaget: {declinedAmount}
         </Card.Text>
       )}
+
+      {completions.length > 0 && <Card.BulletList values={completions} />}
 
       {showButton && (
         <Card.Button onClick={onButtonClick} colorSchema={buttonColorScheme}>

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -1,9 +1,7 @@
-interface CompletionsType {
-  approved: boolean;
-  description: string;
-}
+import { RequestedCompletions } from "../types/Case";
+
 const getUnapprovedCompletionDescriptions = (
-  completions: CompletionsType[]
+  completions: RequestedCompletions[]
 ): string[] => {
   const unapprovedCompletions = completions.filter(
     ({ approved = false }) => !approved

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -5,11 +5,11 @@ interface CompletionsType {
 const getUnapprovedCompletionDescriptions = (
   completions: CompletionsType[]
 ): string[] => {
-  const unApprovedCompletions = completions.filter(
+  const unapprovedCompletions = completions.filter(
     ({ approved = false }) => !approved
   );
 
-  const completionDescriptions = unApprovedCompletions.map(
+  const completionDescriptions = unapprovedCompletions.map(
     ({ description }) => description
   );
 

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -3,7 +3,7 @@ import { RequestedCompletions } from "../types/Case";
 const getUnapprovedCompletionDescriptions = (
   completions: RequestedCompletions[]
 ): string[] => {
-  return completions
+  const completionDescriptions = completions
     .filter(({ approved = false }) => !approved)
     .map(({ description }) => description);
 

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -1,0 +1,22 @@
+type CompletionsType = {
+  approved: boolean;
+  description: string;
+};
+
+const getUnApprovedCompletionsDescriptions = (
+  completions: CompletionsType[]
+): string[] => {
+  const completionsList = completions.reduce(
+    (previous: string[], current: CompletionsType) => {
+      if (!current?.approved) {
+        return [...previous, current.description];
+      }
+      return [...previous];
+    },
+    []
+  );
+
+  return completionsList;
+};
+
+export default getUnApprovedCompletionsDescriptions;

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -3,13 +3,9 @@ import { RequestedCompletions } from "../types/Case";
 const getUnapprovedCompletionDescriptions = (
   completions: RequestedCompletions[]
 ): string[] => {
-  const unapprovedCompletions = completions.filter(
-    ({ approved = false }) => !approved
-  );
-
-  const completionDescriptions = unapprovedCompletions.map(
-    ({ description }) => description
-  );
+  return completions
+    .filter(({ approved = false }) => !approved)
+    .map(({ description }) => description);
 
   return completionDescriptions;
 };

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -3,11 +3,11 @@ import { RequestedCompletions } from "../types/Case";
 const getUnapprovedCompletionDescriptions = (
   completions: RequestedCompletions[]
 ): string[] => {
-  const completionDescriptions = completions
+  const unapprovedCompletionDescriptions = completions
     .filter(({ approved = false }) => !approved)
     .map(({ description }) => description);
 
-  return completionDescriptions;
+  return unapprovedCompletionDescriptions;
 };
 
 export default getUnapprovedCompletionDescriptions;

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -5,16 +5,12 @@ interface CompletionsType {
 const getUnapprovedCompletionDescriptions = (
   completions: CompletionsType[]
 ): string[] => {
-  const completionDescriptions = completions.reduce(
-    (previous: string[], current: CompletionsType) => {
-      const unapprovedCompletion = !current?.approved;
+  const unApprovedCompletions = completions.filter(
+    ({ approved = false }) => !approved
+  );
 
-      if (unapprovedCompletion) {
-        return [...previous, current.description];
-      }
-      return previous;
-    },
-    []
+  const completionDescriptions = unApprovedCompletions.map(
+    ({ description }) => description
   );
 
   return completionDescriptions;

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -2,20 +2,22 @@ interface CompletionsType {
   approved: boolean;
   description: string;
 }
-const getUnApprovedCompletionsDescriptions = (
+const getUnapprovedCompletionDescriptions = (
   completions: CompletionsType[]
 ): string[] => {
-  const completionsList = completions.reduce(
+  const completionDescriptions = completions.reduce(
     (previous: string[], current: CompletionsType) => {
-      if (!current?.approved) {
+      const unapprovedCompletion = !current?.approved;
+
+      if (unapprovedCompletion) {
         return [...previous, current.description];
       }
-      return [...previous];
+      return previous;
     },
     []
   );
 
-  return completionsList;
+  return completionDescriptions;
 };
 
-export default getUnApprovedCompletionsDescriptions;
+export default getUnapprovedCompletionDescriptions;

--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -1,8 +1,7 @@
-type CompletionsType = {
+interface CompletionsType {
   approved: boolean;
   description: string;
-};
-
+}
 const getUnApprovedCompletionsDescriptions = (
   completions: CompletionsType[]
 ): string[] => {

--- a/source/helpers/test/FormatCompletions.test.ts
+++ b/source/helpers/test/FormatCompletions.test.ts
@@ -1,0 +1,21 @@
+import getUnApprovedCompletionsDescriptions from "../FormatCompletions";
+
+const mockCompletions = [
+  {
+    approved: false,
+    description: "mock description one",
+  },
+  {
+    approved: true,
+    description: "mock description two",
+  },
+];
+
+describe("FormatCompletions", () => {
+  it("returns unapproved completions and its descriptions", () => {
+    const result = getUnApprovedCompletionsDescriptions(mockCompletions);
+
+    expect(result).toHaveLength(1);
+    expect(result).toEqual(["mock description one"]);
+  });
+});

--- a/source/helpers/test/FormatCompletions.test.ts
+++ b/source/helpers/test/FormatCompletions.test.ts
@@ -1,4 +1,4 @@
-import getUnApprovedCompletionsDescriptions from "../FormatCompletions";
+import getUnapprovedCompletionDescriptions from "../FormatCompletions";
 
 const mockCompletions = [
   {
@@ -13,7 +13,7 @@ const mockCompletions = [
 
 describe("FormatCompletions", () => {
   it("returns unapproved completions and its descriptions", () => {
-    const result = getUnApprovedCompletionsDescriptions(mockCompletions);
+    const result = getUnapprovedCompletionDescriptions(mockCompletions);
 
     expect(result).toHaveLength(1);
     expect(result).toEqual(["mock description one"]);

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -37,6 +37,17 @@ import { wait } from "../../helpers/Misc";
 import { Case, ApplicationStatusType } from "../../types/Case";
 import { Form } from "../../types/FormTypes";
 
+const {
+  ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA,
+  ACTIVE_COMPLETION_REQUIRED_VIVA,
+  ACTIVE_SIGNATURE_PENDING,
+  NOT_STARTED,
+  ONGOING,
+  SIGNED,
+  CLOSED,
+  ACTIVE,
+} = ApplicationStatusType;
+
 const ButtonContainer = styled.View`
   display: flex;
   flex-direction: column;
@@ -143,24 +154,21 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const completions = caseData?.details?.completions?.requested || [];
 
   const statusType = caseData?.status?.type || "";
-  const isNotStarted = statusType.includes(ApplicationStatusType.NOT_STARTED);
-  const isOngoing = statusType.includes(ApplicationStatusType.ONGOING);
+  const isNotStarted = statusType.includes(NOT_STARTED);
+  const isOngoing = statusType.includes(ONGOING);
   const isRandomCheckRequired = statusType.includes(
-    ApplicationStatusType.ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA
+    ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA
   );
   const isVivaCompletionRequired = statusType.includes(
-    ApplicationStatusType.ACTIVE_COMPLETION_REQUIRED_VIVA
+    ACTIVE_COMPLETION_REQUIRED_VIVA
   );
-  const isSigned = statusType.includes(ApplicationStatusType.SIGNED);
-  const isClosed = statusType.includes(ApplicationStatusType.CLOSED);
-  const isWaitingForSign = statusType.includes(
-    ApplicationStatusType.ACTIVE_SIGNATURE_PENDING
-  );
+  const isSigned = statusType.includes(SIGNED);
+  const isClosed = statusType.includes(CLOSED);
+  const isWaitingForSign = statusType.includes(ACTIVE_SIGNATURE_PENDING);
 
-  const unApprovedCompletionDescriptions: string[] =
-    statusType === ApplicationStatusType.ACTIVE_COMPLETION_REQUIRED_VIVA
-      ? getUnapprovedCompletionDescriptions(completions)
-      : [];
+  const unApprovedCompletionDescriptions: string[] = isVivaCompletionRequired
+    ? getUnapprovedCompletionDescriptions(completions)
+    : [];
 
   const selfHasSigned = casePersonData?.hasSigned;
   const isCoApplicant = casePersonData?.role === "coApplicant";
@@ -360,11 +368,11 @@ function CaseOverview(props): JSX.Element {
     });
 
   const activeCases = getCasesByStatuses([
-    ApplicationStatusType.NOT_STARTED,
-    ApplicationStatusType.ACTIVE,
-    ApplicationStatusType.ACTIVE_COMPLETION_REQUIRED_VIVA,
+    NOT_STARTED,
+    ACTIVE,
+    ACTIVE_COMPLETION_REQUIRED_VIVA,
   ]);
-  const closedCases = getCasesByStatuses([ApplicationStatusType.CLOSED]);
+  const closedCases = getCasesByStatuses([CLOSED]);
 
   const onFailedToFetchCases = (error: Error) => {
     console.error("failed to fetch cases", error);

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -367,11 +367,7 @@ function CaseOverview(props): JSX.Element {
       return matchesStatus;
     });
 
-  const activeCases = getCasesByStatuses([
-    NOT_STARTED,
-    ACTIVE,
-    ACTIVE_COMPLETION_REQUIRED_VIVA,
-  ]);
+  const activeCases = getCasesByStatuses([NOT_STARTED, ACTIVE]);
   const closedCases = getCasesByStatuses([CLOSED]);
 
   const onFailedToFetchCases = (error: Error) => {

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -140,6 +140,8 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
     (person) => person.personalNumber === authContext.user.personalNumber
   );
 
+  const completions = caseData?.details?.completions?.requested || [];
+
   const statusType = caseData?.status?.type || "";
   const isNotStarted = statusType.includes(ApplicationStatusType.NOT_STARTED);
   const isOngoing = statusType.includes(ApplicationStatusType.ONGOING);
@@ -154,6 +156,11 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const isWaitingForSign = statusType.includes(
     ApplicationStatusType.ACTIVE_SIGNATURE_PENDING
   );
+
+  const unApprovedCompletionsDescriptions: string[] =
+    statusType === ApplicationStatusType.ACTIVE_COMPLETION_REQUIRED_VIVA
+      ? getUnApprovedCompletionsDescriptions(completions)
+      : [];
 
   const selfHasSigned = casePersonData?.hasSigned;
   const isCoApplicant = casePersonData?.role === "coApplicant";
@@ -277,15 +284,6 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
         payments.payment.givedate.split("-")[2]
       } ${getSwedishMonthNameByTimeStamp(payments.payment.givedate, true)}`
     : undefined;
-
-  const unApprovedCompletionsDescriptions: string[] =
-    caseData?.status?.type ===
-      ApplicationStatusType.ACTIVE_COMPLETION_REQUIRED_VIVA &&
-    caseData?.details?.completions?.requested?.length > 0
-      ? getUnApprovedCompletionsDescriptions(
-          caseData.details.completions.requested
-        )
-      : [];
 
   return (
     <CaseCard

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -18,7 +18,7 @@ import Body from "../../components/molecules/Dialog/Body";
 import BackgroundBlur from "../../components/molecules/Dialog/BackgroundBlur";
 import Button from "../../components/atoms/Button";
 import icons from "../../helpers/Icons";
-import getUnApprovedCompletionsDescriptions from "../../helpers/FormatCompletions";
+import getUnapprovedCompletionDescriptions from "../../helpers/FormatCompletions";
 import { Text, Icon } from "../../components/atoms";
 import {
   Card,
@@ -157,9 +157,9 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
     ApplicationStatusType.ACTIVE_SIGNATURE_PENDING
   );
 
-  const unApprovedCompletionsDescriptions: string[] =
+  const unApprovedCompletionDescriptions: string[] =
     statusType === ApplicationStatusType.ACTIVE_COMPLETION_REQUIRED_VIVA
-      ? getUnApprovedCompletionsDescriptions(completions)
+      ? getUnapprovedCompletionDescriptions(completions)
       : [];
 
   const selfHasSigned = casePersonData?.hasSigned;
@@ -306,7 +306,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
       onCardClick={cardProps.onClick}
       onButtonClick={buttonProps.onClick}
       buttonColorScheme={buttonProps.colorSchema || colorSchema}
-      completions={unApprovedCompletionsDescriptions}
+      completions={unApprovedCompletionDescriptions}
     />
   );
 };

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -269,7 +269,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   }
 
   if (isVivaCompletionRequired) {
-    buttonProps.text = "Komplettera ansölan";
+    buttonProps.text = "Komplettera ansökan";
   }
 
   const giveDate = payments?.payment?.givedate

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -1,13 +1,17 @@
 import { EncryptionDetails } from "./Encryption";
 
 export enum ApplicationStatusType {
+  ONGOING = "ongoing",
   ACTIVE_ONGOING = "active:ongoing",
   ACTIVE_PROCESSING = "active:processing",
   ACTIVE_SIGNATURE_COMPLETED = "active:signature:completed",
   ACTIVE_SIGNATURE_PENDING = "active:signature:pending",
   ACTIVE_SUBMITTED = "active:submitted",
   CLOSED = "closed",
+  SIGNED = "signed",
+  ACTIVE = "active",
   NOT_STARTED = "notStarted",
+  ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA = "active:completionRandomCheckRequired:viva",
   ACTIVE_COMPLETION_REQUIRED_VIVA = "active:completionRequired:viva",
   CLOSED_APPROVED_VIVA = "closed:approved:viva",
   CLOSED_COMPLETION_REJECTED_VIVA = "closed:completionRejected:viva",

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -38,6 +38,7 @@ export interface RequestedCompletions {
 export interface Completions {
   requested: RequestedCompletions[];
   randomCheck: boolean;
+  completed: boolean;
 }
 
 export interface Period {

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -30,6 +30,16 @@ export interface Administrator {
   title: string;
 }
 
+export interface RequestedCompletions {
+  description: string;
+  approved: boolean;
+}
+
+export interface Completions {
+  requested: RequestedCompletions[];
+  randomCheck: boolean;
+}
+
 export interface Period {
   endDate: number;
   startDate: number;
@@ -37,6 +47,7 @@ export interface Period {
 
 export interface VIVACaseDetails {
   administrators: Administrator[];
+  completions: Completions;
   period: Period;
   workflowId: string;
 }

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -1,17 +1,13 @@
 import { EncryptionDetails } from "./Encryption";
 
 export enum ApplicationStatusType {
-  ONGOING = "ongoing",
   ACTIVE_ONGOING = "active:ongoing",
   ACTIVE_PROCESSING = "active:processing",
   ACTIVE_SIGNATURE_COMPLETED = "active:signature:completed",
   ACTIVE_SIGNATURE_PENDING = "active:signature:pending",
   ACTIVE_SUBMITTED = "active:submitted",
   CLOSED = "closed",
-  SIGNED = "signed",
-  ACTIVE = "active",
   NOT_STARTED = "notStarted",
-  ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA = "active:completionRandomCheckRequired:viva",
   ACTIVE_COMPLETION_REQUIRED_VIVA = "active:completionRequired:viva",
   CLOSED_APPROVED_VIVA = "closed:approved:viva",
   CLOSED_COMPLETION_REJECTED_VIVA = "closed:completionRejected:viva",


### PR DESCRIPTION
## Explain the changes you’ve made
Added the ability to display a completions list in the case card component in CaseOverview screen

Also did utilise the ApplicationStatusType in CaseOverview screen to avoid having dangling strings.

## Explain why these changes are made
As part of the task where a user should be able to see completions for its case, this PR is added. This PR adds the possibility for a user to see which completions is needed in caseoverview as a bullet list in CaseCard.

## Explain your solution
The CaseOverview screen checks the caseData property if any completions exists. If they exists then extract the descriptions from the from the complections object. 

## How to test
1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a case with the status type `active:completionRequired:viva` or whichever type you want for testing purposes
4. Make sure you have a form (in formbuilder) with the BulletList question type
5. 
## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

![simulator_screenshot_7C24B8D1-54D9-49B1-8911-2907931F741E](https://user-images.githubusercontent.com/81250970/147949572-957aff6f-4ec1-4d20-99fe-632b50e3175c.png)

