### PR TITLE
feat: add new application status types

### DIFF
--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -1,13 +1,17 @@
 import { EncryptionDetails } from "./Encryption";
 
 export enum ApplicationStatusType {
+  ONGOING = "ongoing",
   ACTIVE_ONGOING = "active:ongoing",
   ACTIVE_PROCESSING = "active:processing",
   ACTIVE_SIGNATURE_COMPLETED = "active:signature:completed",
   ACTIVE_SIGNATURE_PENDING = "active:signature:pending",
   ACTIVE_SUBMITTED = "active:submitted",
   CLOSED = "closed",
+  SIGNED = "signed",
+  ACTIVE = "active",
   NOT_STARTED = "notStarted",
+  ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA = "active:completionRandomCheckRequired:viva",
   ACTIVE_COMPLETION_REQUIRED_VIVA = "active:completionRequired:viva",
   CLOSED_APPROVED_VIVA = "closed:approved:viva",
   CLOSED_COMPLETION_REJECTED_VIVA = "closed:completionRejected:viva",


### PR DESCRIPTION
This line can be removed: Read this short article before you start writing https://www.pullrequest.com/blog/writing-a-great-pull-request-description/

## Explain the changes you’ve made
Added new application status types

## Explain why these changes are made
The application uses the application status type enum for checking the status type of a case. The new status types is added to decouple some tasks from each other.

## Explain your solution
Added the new types in the case.ts file 

## How to test
N/A
