### PR TITLE
Feat/list completions in form

### DIFF
--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -63,7 +63,8 @@ function Step({
   answerSnapshot,
   attachments,
   isFormEditable,
-}) {
+  completions,
+}): JSX.Element {
   const isSubstep = currentPosition.level !== 0;
   const isLastMainStep =
     currentPosition.level === 0 &&
@@ -232,6 +233,7 @@ function Step({
                         handleFocus(e, isSelect);
                       }}
                       onAddAnswer={onAddAnswer}
+                      completions={completions}
                       {...field}
                     />
                   ))}

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React, { useEffect, useState, useContext } from "react";
 import { InteractionManager, StatusBar } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
@@ -7,8 +6,13 @@ import ScreenWrapper from "../../components/molecules/ScreenWrapper";
 import Step from "../../components/organisms/Step/Step";
 import { evaluateConditionalExpression } from "../../helpers/conditionParser";
 import { CaseStatus } from "../../types/CaseType";
-import { Step as StepType, StepperActions } from "../../types/FormTypes";
+import {
+  Step as StepType,
+  StepperActions,
+  Question,
+} from "../../types/FormTypes";
 import { User } from "../../types/UserTypes";
+import { RequestedCompletions } from "../../types/Case";
 import useForm, {
   FormPeriod,
   FormPosition,
@@ -26,10 +30,9 @@ interface Props {
   connectivityMatrix: StepperActions[][];
   user: User;
   initialAnswers: Record<string, any>;
-  status?: CaseStatus;
+  status: CaseStatus;
   onClose: () => void;
   onSubmit: () => void;
-  onStart: () => any;
   updateCaseInContext: (
     data: Record<string, any>,
     signature: { success: boolean },
@@ -37,7 +40,7 @@ interface Props {
   ) => void;
   period?: FormPeriod;
   editable: boolean;
-  completions: any;
+  completions: RequestedCompletions[];
 }
 
 export const defaultInitialPosition: FormPosition = {
@@ -66,7 +69,7 @@ const Form: React.FC<Props> = ({
   period,
   onClose,
   onSubmit,
-  initialAnswers,
+  initialAnswers = {},
   status,
   updateCaseInContext,
   editable,
@@ -194,9 +197,9 @@ const Form: React.FC<Props> = ({
       questions,
       actions,
       colorSchema,
-    }) => {
-      const questionsToShow = questions
-        ? questions.filter((question) => {
+    }: StepType) => {
+      const questionsToShow: Question[] = questions
+        ? questions.filter((question: Question) => {
             const condition = question.conditionalOn;
             if (!condition || condition.trim() === "") return true;
             return evaluateConditionalExpression(
@@ -250,12 +253,12 @@ const Form: React.FC<Props> = ({
   );
 
   const mainStep = formState.currentPosition.currentMainStepIndex;
-  const [visible, toggleModal] = useModal();
+  const [, toggleModal] = useModal();
   const [scrollViewRef, setRef] = useState<ScrollView>(null);
 
   useEffect(() => {
     if (scrollViewRef && scrollViewRef?.scrollTo) {
-      InteractionManager.runAfterInteractions(() => {
+      void InteractionManager.runAfterInteractions(() => {
         scrollViewRef.scrollTo({ x: 0, y: 0, animated: false });
       });
     }
@@ -299,59 +302,6 @@ const Form: React.FC<Props> = ({
       )}
     </>
   );
-};
-
-Form.propTypes = {
-  /**
-   * FormPosition object that determines where to start the form.
-   */
-  initialPosition: PropTypes.shape({
-    index: PropTypes.number,
-    level: PropTypes.number,
-    currentMainStep: PropTypes.number,
-    currentMainStepIndex: PropTypes.number,
-  }),
-  /**
-   * Function to handle a close action in the form.
-   */
-  onClose: PropTypes.func.isRequired,
-  /**
-   * Function to handle when a form should start.
-   */
-  onStart: PropTypes.func.isRequired,
-  /**
-   * Function to handle when a form is submitting.
-   */
-  onSubmit: PropTypes.func.isRequired,
-  /**
-   * Array of steps that the Form should render.
-   */
-  steps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  connectivityMatrix: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)),
-  /**
-   * The user info.
-   */
-  user: PropTypes.object.isRequired,
-  /**
-   * Initial answer for each question.
-   */
-  initialAnswers: PropTypes.object,
-  /**
-   * Status
-   */
-  status: PropTypes.shape({
-    type: PropTypes.string,
-    name: PropTypes.string,
-    description: PropTypes.string,
-  }),
-  /**
-   * function for updating case in caseContext
-   */
-  updateCaseInContext: PropTypes.func,
-};
-
-Form.defaultProps = {
-  initialAnswers: {},
 };
 
 export default Form;

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -29,12 +29,12 @@ interface Props {
   steps: StepType[];
   connectivityMatrix: StepperActions[][];
   user: User;
-  initialAnswers: Record<string, any>;
+  initialAnswers: Record<string, unknown>;
   status: CaseStatus;
   onClose: () => void;
   onSubmit: () => void;
   updateCaseInContext: (
-    data: Record<string, any>,
+    data: Record<string, unknown>,
     signature: { success: boolean },
     currentPosition: FormPosition
   ) => void;

--- a/source/containers/FormField/FormField.stories.js
+++ b/source/containers/FormField/FormField.stories.js
@@ -1,45 +1,45 @@
-import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react-native';
-import { ScrollView } from 'react-native-gesture-handler';
-import StoryWrapper from '../../components/molecules/StoryWrapper';
-import FormField from './FormField';
+import React, { useState } from "react";
+import { storiesOf } from "@storybook/react-native";
+import { ScrollView } from "react-native-gesture-handler";
+import StoryWrapper from "../../components/molecules/StoryWrapper";
+import FormField from "./FormField";
 
-const heading = 'Green things';
+const heading = "Green things";
 
 const categories = [
-  { category: 'fruit', description: 'Frukter' },
-  { category: 'vegetable', description: 'Grönsaker' },
+  { category: "fruit", description: "Frukter" },
+  { category: "vegetable", description: "Grönsaker" },
 ];
 
 const items = [
   {
-    category: 'fruit',
-    title: 'Banana',
-    formId: 'e366f250-c5a2-11ea-9e21-b7b32d0793c5',
+    category: "fruit",
+    title: "Banana",
+    formId: "e366f250-c5a2-11ea-9e21-b7b32d0793c5",
   },
   {
-    category: 'fruit',
-    title: 'Pear',
-    formId: 'e366f250-c5a2-11ea-9e21-b7b32d0793c5',
+    category: "fruit",
+    title: "Pear",
+    formId: "e366f250-c5a2-11ea-9e21-b7b32d0793c5",
   },
   {
-    category: 'vegetable',
-    title: 'Carrot',
-    formId: 'e366f250-c5a2-11ea-9e21-b7b32d0793c5',
+    category: "vegetable",
+    title: "Carrot",
+    formId: "e366f250-c5a2-11ea-9e21-b7b32d0793c5",
   },
 ];
 
 const radioChoices = [
-  { displayText: 'Choice 1', value: '1' },
-  { displayText: 'Choice 2', value: '2' },
+  { displayText: "Choice 1", value: "1" },
+  { displayText: "Choice 2", value: "2" },
   {
-    displayText: 'Choice 3',
-    value: '3',
+    displayText: "Choice 3",
+    value: "3",
   },
 ];
 
 const DateFormField = () => {
-  const [date, setDate] = useState({ 7: '' });
+  const [date, setDate] = useState({ 7: "" });
   return (
     <FormField
       id="7"
@@ -53,7 +53,7 @@ const DateFormField = () => {
   );
 };
 const RadioGroupFormField = () => {
-  const [value, setValue] = useState({ 8: '' });
+  const [value, setValue] = useState({ 8: "" });
   return (
     <FormField
       id="8"
@@ -66,7 +66,7 @@ const RadioGroupFormField = () => {
     />
   );
 };
-storiesOf('Form Field input', module).add('Default', () => (
+storiesOf("Form Field input", module).add("Default", () => (
   <StoryWrapper>
     <ScrollView>
       <FormField
@@ -115,9 +115,9 @@ storiesOf('Form Field input', module).add('Default', () => (
         placeholder="Your car preference"
         inputType="select"
         items={[
-          { label: 'Ferrari', value: 'ferrari' },
-          { label: 'Buggati', value: 'buggati' },
-          { label: 'Porsche', value: 'porsche' },
+          { label: "Ferrari", value: "ferrari" },
+          { label: "Buggati", value: "buggati" },
+          { label: "Porsche", value: "porsche" },
         ]}
       />
       <DateFormField />

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { View, LayoutAnimation } from "react-native";
 import DynamicCardRenderer from "../DynamicCardRenderer/DynamicCardRenderer";
 import { Input, Label, Select, Text } from "../../components/atoms";
@@ -13,13 +12,17 @@ import {
   RepeaterField,
   RadioGroup,
 } from "../../components/molecules";
-import theme from "../../styles/theme";
 import { getValidColorSchema } from "../../styles/themeHelpers";
 import SummaryList from "../../components/organisms/SummaryList/SummaryList";
 import ImageUploader from "../../components/molecules/ImageUploader/ImageUploader";
 import ImageViewer from "../../components/molecules/ImageViewer/ImageViewer";
 import PdfUploader from "../../components/molecules/PdfUploader/PdfUploader";
 import PdfViewer from "../../components/molecules/PdfViewer/PdfViewer";
+import BulletList from "../../components/organisms/BulletList";
+
+import getUnApprovedCompletionsDescriptions from "../../helpers/FormatCompletions";
+import { FormInputType } from "../../types/FormTypes";
+
 /**
  * Explanation of the properties in this data structure:
  *
@@ -156,26 +159,33 @@ const inputTypes = {
     changeEvent: "onChange",
     props: { answers: true },
   },
+  bulletList: {
+    component: BulletList,
+  },
 };
 
-const FormField = ({
-  label,
-  labelLine,
-  inputType,
-  colorSchema,
-  id,
-  onChange,
-  onBlur,
-  onFocus,
-  onMount,
-  onAddAnswer,
-  value,
-  answers,
-  validationErrors,
-  help,
-  inputSelectValue,
-  ...other
-}) => {
+const FormField = (props) => {
+  const {
+    label,
+    labelLine,
+    inputType,
+    colorSchema,
+    id,
+    onChange,
+    onBlur,
+    onFocus,
+    onMount,
+    onAddAnswer,
+    value,
+    answers,
+    validationErrors,
+    help,
+    inputSelectValue,
+    completions,
+    description,
+    ...other
+  } = props;
+
   const validColorSchema = getValidColorSchema(colorSchema);
   const input = inputTypes[inputType];
   if (input === undefined) {
@@ -234,6 +244,12 @@ const FormField = ({
   if (inputType === "repeaterField" && !!input?.addAnswerEvent)
     inputCompProps[input.addAnswerEvent] = onInputAddAnswer;
 
+  if (inputType === "bulletList") {
+    inputCompProps.values = answers.includes("#COMPLETIONS_LIST")
+      ? getUnApprovedCompletionsDescriptions(completions)
+      : answers;
+  }
+
   const inputComponent =
     input && input.component ? (
       React.createElement(input.component, inputCompProps)
@@ -270,92 +286,6 @@ const FormField = ({
       {inputComponent}
     </View>
   );
-};
-
-FormField.propTypes = {
-  /**
-   * The label for the input field.
-   */
-  label: PropTypes.string,
-  /**
-   * String that determines the input type of the field.
-   */
-  labelLine: PropTypes.bool,
-  /**
-   * Unique id for the input field. Used
-   */
-  id: PropTypes.string,
-  /**
-   * String that determines the input type of the field.
-   */
-  inputType: PropTypes.oneOf(Object.keys(inputTypes)),
-  /**
-   * What happens when the input is changed.
-   * Should be used to store inputs to state.
-   * Should handle objects on the form { id : value }, where value is the new value and id is the uuid for the input-field.
-   */
-  onChange: PropTypes.func,
-  /** What happens when an input field looses focus.  */
-  onBlur: PropTypes.func,
-  onFocus: PropTypes.func,
-
-  onMount: PropTypes.func,
-  /**
-   * sets the value, since the input field component should be managed.
-   */
-  value: PropTypes.any,
-  /**
-   * All the form state answers. Needed because of conditional checks.
-   */
-  answers: PropTypes.object,
-  validationErrors: PropTypes.object,
-  formNavigation: PropTypes.shape({
-    next: PropTypes.func,
-    back: PropTypes.func,
-    up: PropTypes.func,
-    down: PropTypes.func,
-    close: PropTypes.func,
-    start: PropTypes.func,
-    isLastStep: PropTypes.func,
-  }),
-  /**
-   * sets the color theme.
-   */
-  colorSchema: PropTypes.oneOf([...Object.keys(theme.colors.primary), ""]),
-  /*
-   * The function triggers when the button is clicked.
-   */
-  onClick: PropTypes.func,
-  /**
-   * Show a help button
-   */
-  help: PropTypes.shape({
-    text: PropTypes.string,
-    size: PropTypes.number,
-    heading: PropTypes.string,
-    tagline: PropTypes.string,
-    url: PropTypes.string,
-  }),
-  inputSelectValue: PropTypes.oneOf([
-    "text",
-    "number",
-    "hidden",
-    "date",
-    "email",
-    "postalCode",
-    "personalNumber",
-    "phone",
-    "card",
-    "editableList",
-    "checkbox",
-    "navigationButtonGroup",
-    "summaryList",
-    "repeaterField",
-    "imageUploader",
-    "imageViewer",
-    "pdfUploader",
-    "pdfViewer",
-  ]),
 };
 
 FormField.defaultProps = {

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -12,7 +12,7 @@ import {
   RepeaterField,
   RadioGroup,
 } from "../../components/molecules";
-import { getValidColorSchema } from "../../styles/themeHelpers";
+import { getValidColorSchema, PrimaryColor } from "../../styles/themeHelpers";
 import SummaryList from "../../components/organisms/SummaryList/SummaryList";
 import ImageUploader from "../../components/molecules/ImageUploader/ImageUploader";
 import ImageViewer from "../../components/molecules/ImageViewer/ImageViewer";
@@ -21,7 +21,8 @@ import PdfViewer from "../../components/molecules/PdfViewer/PdfViewer";
 import BulletList from "../../components/organisms/BulletList";
 
 import getUnApprovedCompletionsDescriptions from "../../helpers/FormatCompletions";
-import { FormInputType } from "../../types/FormTypes";
+import { FormInputType, InputFieldType } from "../../types/FormTypes";
+import { Answer, RequestedCompletions } from "../../types/Case";
 
 /**
  * Explanation of the properties in this data structure:
@@ -34,7 +35,21 @@ import { FormInputType } from "../../types/FormTypes";
  * onMountEvent: The event that triggers when the input is mounted
  * props: additional props to send into the generated component
  */
-const inputTypes = {
+interface InputTypeProperties {
+  component: React.ReactNode;
+  changeEvent?: string;
+  blurEvent?: string;
+  focusEvent?: string;
+  onMountEvent?: string;
+  initialValue?: undefined | boolean | [] | Record<string, unknown>;
+  helpInComponent?: boolean;
+  helpProp?: string;
+  addAnswerEvent?: string;
+  props?: Record<string, unknown>;
+}
+type inputKeyType = FormInputType | InputFieldType;
+
+const inputTypes: Record<inputKeyType, InputTypeProperties> = {
   text: {
     component: Input,
     changeEvent: "onChangeText",
@@ -164,14 +179,45 @@ const inputTypes = {
   },
 };
 
-const FormField = (props) => {
+interface FormFieldProps {
+  label: string;
+  labelLine?: boolean;
+  id: string;
+  inputType?: FormInputType | InputFieldType;
+  value:
+    | undefined
+    | number
+    | string
+    | Record<string, unknown>
+    | Record<string, unknown>[];
+  answers: Answer;
+  validationErrors: Record<string, { isValid: boolean; message: string }>;
+  colorSchema: PrimaryColor;
+  help: {
+    text: string;
+    size: number;
+    heading: string;
+    tagline: string;
+    url: string;
+  };
+  completions: RequestedCompletions[];
+  inputSelectValue: InputFieldType;
+  onAddAnswer: (_, fieldId: string) => void;
+  onClick: () => void;
+  onMount: () => void;
+  onFocus: () => void;
+  onBlur: () => void;
+  onChange?: () => void;
+}
+
+const FormField = (props: FormFieldProps): JSX.Element => {
   const {
     label,
-    labelLine,
-    inputType,
+    labelLine = true,
+    inputType = "text",
     colorSchema,
     id,
-    onChange,
+    onChange = () => true,
     onBlur,
     onFocus,
     onMount,
@@ -182,7 +228,6 @@ const FormField = (props) => {
     help,
     inputSelectValue,
     completions,
-    description,
     ...other
   } = props;
 
@@ -286,13 +331,6 @@ const FormField = (props) => {
       {inputComponent}
     </View>
   );
-};
-
-FormField.defaultProps = {
-  onClick: () => {},
-  onChange: () => {},
-  labelLine: true,
-  inputType: "text",
 };
 
 export default FormField;

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -36,7 +36,7 @@ import { Answer, RequestedCompletions } from "../../types/Case";
  * props: additional props to send into the generated component
  */
 interface InputTypeProperties {
-  component: React.ReactNode;
+  component: React.FunctionComponent<any>;
   changeEvent?: string;
   blurEvent?: string;
   focusEvent?: string;
@@ -202,7 +202,7 @@ interface FormFieldProps {
   };
   completions: RequestedCompletions[];
   inputSelectValue: InputFieldType;
-  onAddAnswer: (_, fieldId: string) => void;
+  onAddAnswer: (answer: unknown, fieldId: string) => void;
   onClick: () => void;
   onMount: () => void;
   onFocus: () => void;

--- a/source/screens/FormCaseScreen.tsx
+++ b/source/screens/FormCaseScreen.tsx
@@ -104,7 +104,7 @@ const FormCaseScreen = ({
     // If the case is submitted, we should not actually update its data...
     if (
       initialCase !== undefined &&
-      !initialCase.status.type.includes("submitted")
+      !initialCase.status.type.includes(ApplicationStatusType.ACTIVE_SUBMITTED)
     ) {
       const updatedCase: CaseUpdate = {
         user,
@@ -154,12 +154,6 @@ const FormCaseScreen = ({
     }
   };
 
-  /*
-   * Function for handling behavior when a form starts
-   * TO BE IMPLEMENTED
-   * */
-  const handleStartForm = () => null;
-
   // TODO: Update case on form submit.
   const handleSubmitForm = () => {
     navigation.popToTop();
@@ -180,7 +174,6 @@ const FormCaseScreen = ({
       initialPosition={initialPosition}
       user={user}
       onClose={handleCloseForm}
-      onStart={handleStartForm}
       onSubmit={handleSubmitForm}
       initialAnswers={initialAnswers}
       status={initialCase.status || defaultInitialStatus}

--- a/source/store/FormContext.tsx
+++ b/source/store/FormContext.tsx
@@ -13,7 +13,7 @@ interface FindFormError {
 interface FormContextValue {
   getFormIdsByFormTypes?: (formTypes: string[]) => Promise<string[]>;
   findFormsByType?: (formType: string) => Promise<Form[] | FindFormError>;
-  getForm?: (id: string) => Promise<Form | null>;
+  getForm: (id: string) => Promise<Form | null>;
   getFormSummaries?: () => Promise<Form[]>;
 }
 

--- a/source/types/CaseContext.ts
+++ b/source/types/CaseContext.ts
@@ -19,7 +19,7 @@ export interface State {
   error?: unknown;
   isPolling: boolean;
   casesToPoll: Case[];
-  getCase?: (caseId: string) => Case | undefined;
+  getCase: (caseId: string) => Case | undefined;
   getCasesByFormIds?: (formIds: string[]) => Case[];
   fetchCases?: () => Promise<void>;
 }
@@ -57,7 +57,7 @@ export interface UpdateCaseBody extends AnsweredForm {
 
 export interface Dispatch {
   createCase?: (form: Form, callback: (newCase: Case) => void) => void;
-  updateCase?: (
+  updateCase: (
     updateData: CaseUpdate,
     callback: (updatedCase: Case) => void
   ) => void;

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -40,7 +40,17 @@ export type InputFieldType =
   | "phone"
   | "number"
   | "hidden"
-  | "date";
+  | "date"
+  | "card"
+  | "editableList"
+  | "checkbox"
+  | "navigationButtonGroup"
+  | "summaryList"
+  | "repeaterField"
+  | "imageUploader"
+  | "imageViewer"
+  | "pdfUploader"
+  | "pdfViewer";
 
 export type FormInputType =
   | "text"

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -51,7 +51,8 @@ export type FormInputType =
   | "checkbox"
   | "summaryList"
   | "repeaterField"
-  | "imageUploader";
+  | "imageUploader"
+  | "bulletList";
 
 export interface Question {
   label: string;


### PR DESCRIPTION
## Explain the changes you’ve made
Be able to show bullet list and a users completions in a form in the application.

## Explain why these changes are made
In order for a user to see its completions, the bullet list is added

## Explain your solution
In order to show completions, they are transformed into an array of strings instead of array of objects. 
The new bullet list component is then added to the FormField component so the application can render the bullet list.
Logic is also added for text replacement, which is also done in the FormField component by checking the form for #COMPLETIONS_LIST tag.

Files has also been changed from .js/.jsx to .tsx instead and interfaces has been created in favour for proptypes

## How to test
1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a case with status type of `active:completionRequired:viva`
4. Make sure you have a form with the new bullet list component 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

![simulator_screenshot_6A5A729E-8805-4815-A724-9FC8F02D6DB8](https://user-images.githubusercontent.com/81250970/148960004-84e61883-8786-428f-a0df-619355c3a6de.png)

