### PR TITLE
fix: test warnings caused by AuthProvider

### DIFF
--- a/test-utils.jsx
+++ b/test-utils.jsx
@@ -4,21 +4,10 @@ import { ThemeProvider } from "styled-components/native";
 import { render } from "@testing-library/react-native";
 import "@testing-library/jest-native/extend-expect";
 
-import { AuthProvider } from "./source/store/AuthContext";
-import { AppProvider } from "./source/store/AppContext";
-
-import ScreenWrapper from "./source/components/molecules/ScreenWrapper";
-
 import theme from "./source/styles/theme";
 
 const RenderWrapper = ({ children }) => (
-  <AppProvider>
-    <AuthProvider>
-      <ThemeProvider theme={theme}>
-        <ScreenWrapper>{children}</ScreenWrapper>
-      </ThemeProvider>
-    </AuthProvider>
-  </AppProvider>
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
 );
 
 const customRender = (ui) => render(ui, { wrapper: RenderWrapper });


### PR DESCRIPTION
## Explain the changes you’ve made
Removed test warnings caused byt AuthProvider by simply removing the AuthProvider from test-utils.
Also removed other providers that were not used when running the tests.

## Explain why these changes are made
AuthProvider was actually not used and only created test warnings when running all the tests. 

## How to test
1. Run all tests by writing `yarn test` in terminal
2. No test warnings should be shown
