### PR TITLE
fix: align application status type constant name for viva 

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -38,7 +38,7 @@ import { Case, ApplicationStatusType } from "../../types/Case";
 import { Form } from "../../types/FormTypes";
 
 const {
-  ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA,
+  ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
   ACTIVE_COMPLETION_REQUIRED_VIVA,
   ACTIVE_SIGNATURE_PENDING,
   NOT_STARTED,
@@ -157,7 +157,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const isNotStarted = statusType.includes(NOT_STARTED);
   const isOngoing = statusType.includes(ONGOING);
   const isRandomCheckRequired = statusType.includes(
-    ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA
+    ACTIVE_RANDOM_CHECK_REQUIRED_VIVA
   );
   const isVivaCompletionRequired = statusType.includes(
     ACTIVE_COMPLETION_REQUIRED_VIVA

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -41,7 +41,7 @@ const {
   SIGNED,
   ACTIVE_SIGNATURE_PENDING,
   ACTIVE_COMPLETION_REQUIRED_VIVA,
-  ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA,
+  ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
 } = ApplicationStatusType;
 
 const Container = styled.ScrollView`
@@ -161,7 +161,7 @@ const computeCaseCardComponent = (
   const isOngoing = statusType.includes(ONGOING);
   const isClosed = statusType.includes(CLOSED);
   const isRandomCheckRequired = statusType.includes(
-    ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA
+    ACTIVE_RANDOM_CHECK_REQUIRED_VIVA
   );
   const isVivaCompletionRequired = statusType.includes(
     ACTIVE_COMPLETION_REQUIRED_VIVA

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -11,7 +11,7 @@ export enum ApplicationStatusType {
   SIGNED = "signed",
   ACTIVE = "active",
   NOT_STARTED = "notStarted",
-  ACTIVE_COMPLETION_RANDOM_CHECK_REQUIRED_VIVA = "active:completionRandomCheckRequired:viva",
+  ACTIVE_RANDOM_CHECK_REQUIRED_VIVA = "active:randomCheckRequired:viva",
   ACTIVE_COMPLETION_REQUIRED_VIVA = "active:completionRequired:viva",
   CLOSED_APPROVED_VIVA = "closed:approved:viva",
   CLOSED_COMPLETION_REJECTED_VIVA = "closed:completionRejected:viva",


### PR DESCRIPTION
## Explain the changes you’ve made
Align case status value with the values used in the api repository

## Explain why these changes are made
In order to show correct information (and so forth) about a case in the application, these status values has to align with each other. 

## Explain your solution
Change the constant name and the value the constant holds
