### PR TITLE
bugfix/ fix so answers would be encrypted

### DIFF
--- a/source/screens/FormCaseScreen.tsx
+++ b/source/screens/FormCaseScreen.tsx
@@ -115,7 +115,7 @@ const FormCaseScreen = ({
         currentPosition,
         formQuestions: formQuestions || [],
         encryption: initialCase.forms[initialCase.currentFormId].encryption,
-        encryptAnswers: false,
+        encryptAnswers: true,
       };
 
       // We set the initial case to prevent desync issues with the above logic.


### PR DESCRIPTION
## Explain the changes you’ve made
Make sure answers are encrypted when updating a case in the application

## Explain why these changes are made
Because of a refactoring, encryption of answers were lost, this PR make sure we are encrypting answers again in a case.

## Explain your solution
Set the `encryptAnswers` flag to true when updating a case
