### PR TITLE
rename approved to received

### DIFF
--- a/source/helpers/FormatCompletions.ts
+++ b/source/helpers/FormatCompletions.ts
@@ -4,7 +4,7 @@ const getUnapprovedCompletionDescriptions = (
   completions: RequestedCompletions[]
 ): string[] => {
   const unapprovedCompletionDescriptions = completions
-    .filter(({ approved = false }) => !approved)
+    .filter(({ received = false }) => !received)
     .map(({ description }) => description);
 
   return unapprovedCompletionDescriptions;

--- a/source/helpers/test/FormatCompletions.test.ts
+++ b/source/helpers/test/FormatCompletions.test.ts
@@ -2,11 +2,11 @@ import getUnapprovedCompletionDescriptions from "../FormatCompletions";
 
 const mockCompletions = [
   {
-    approved: false,
+    received: false,
     description: "mock description one",
   },
   {
-    approved: true,
+    received: true,
     description: "mock description two",
   },
 ];

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -32,7 +32,7 @@ export interface Administrator {
 
 export interface RequestedCompletions {
   description: string;
-  approved: boolean;
+  received: boolean;
 }
 
 export interface Completions {


### PR DESCRIPTION
## Explain the changes you’ve made
Changed the property on which we are doing completions filtering on in order to hide submitted completions.

## Explain why these changes are made
Before we were doing filtering on the wrong property, which lead to that even submitted completions were shown to the user all the time. Now we are checking the "right" property.
