### PR TITLE
feat: show error message after receiving api status message

### DIFF
--- a/source/screens/LoginScreen.tsx
+++ b/source/screens/LoginScreen.tsx
@@ -11,6 +11,7 @@ import Button from "../components/atoms/Button";
 import Heading from "../components/atoms/Heading";
 import Input from "../components/atoms/Input";
 import Text from "../components/atoms/Text";
+import Icon from "../components/atoms/Icon";
 import AuthLoading from "../components/molecules/AuthLoading";
 import BackNavigation from "../components/molecules/BackNavigation";
 import { Modal, useModal } from "../components/molecules/Modal";
@@ -22,6 +23,7 @@ import userAgreementText from "../assets/text/userAgreementText";
 import backgroundImage from "../assets/images/illustrations/onboarding_05_logga-in_2x.png";
 import { getUserFriendlyAppVersion } from "../helpers/Misc";
 import theme from "../styles/theme";
+import { ThemeType } from "../styles/themeHelpers";
 import EnvironmentConfigurationService from "../services/EnvironmentConfigurationService";
 
 const { sanitizePin, validatePin } = ValidationHelper;
@@ -43,18 +45,16 @@ const FlexImageBackground = styled.ImageBackground`
 `;
 
 const Header = styled.View`
-  flex: 3;
-  justify-content: center;
-  padding: 0px 48px 0px 48px;
+  flex: 4;
+  padding: ${UnifiedPadding[1]}px ${UnifiedPadding[1]}px 0px
+    ${UnifiedPadding[1]}px;
 `;
 
 const Form = styled.View`
-  flex: 1;
-  padding: ${UnifiedPadding[0]}px ${UnifiedPadding[1]}px ${UnifiedPadding[0]}px
+  padding: 0px ${UnifiedPadding[1]}px ${UnifiedPadding[0]}px
     ${UnifiedPadding[1]}px;
   justify-content: center;
   align-items: center;
-  height: 250px;
 `;
 
 const UserAgreementForm = styled.View`
@@ -166,6 +166,26 @@ const VersionLabel = styled(Text)`
   align-self: flex-start;
 `;
 
+interface ApiStatusMessageContainerProps {
+  theme: ThemeType;
+}
+const ApiStatusMessageContainer = styled.View<ApiStatusMessageContainerProps>`
+  position: relative;
+  top: -160px;
+  min-height: 220px;
+  align-self: center;
+  justify-content: space-evenly;
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: ${({ theme: themeProp }) =>
+    themeProp.colors.complementary.red[3]};
+  border: ${({ theme: themeProp }) =>
+    `2px solid ${themeProp.colors.complementary.red[0]}`}
+  padding: 0px 24px 0px 24px;
+`;
+
 const pickerSelectStyles = {
   inputIOS: {
     fontSize: 12,
@@ -192,6 +212,7 @@ function LoginScreen(): JSX.Element {
     isResolved,
     error,
     handleSetError,
+    apiStatusMessage,
   } = useContext(AuthContext);
   const showNotification = useNotification();
 
@@ -281,6 +302,32 @@ function LoginScreen(): JSX.Element {
             </ContentText>
           </Header>
 
+          {!!apiStatusMessage && (
+            <ApiStatusMessageContainer>
+              <Icon
+                name="error-outline"
+                size={48}
+                color={theme.colors.primary.red[2]}
+              />
+              <Text
+                strong
+                type="h5"
+                style={{ color: theme.colors.primary.red[0] }}
+              >
+                Oh no!
+              </Text>
+              <Text
+                strong
+                style={{
+                  color: theme.colors.primary.red[0],
+                  textAlign: "center",
+                }}
+              >
+                {apiStatusMessage}
+              </Text>
+            </ApiStatusMessageContainer>
+          )}
+
           {(isLoading || isResolved) && (
             <Form>
               <AuthLoading
@@ -293,7 +340,7 @@ function LoginScreen(): JSX.Element {
             </Form>
           )}
 
-          {(isIdle || isRejected) && (
+          {(isIdle || isRejected) && !apiStatusMessage && (
             <Form>
               <Button
                 z={0}
@@ -308,7 +355,7 @@ function LoginScreen(): JSX.Element {
               <Link onPress={toggleLoginModal}>Fler alternativ</Link>
             </Form>
           )}
-          {isDevMode && (
+          {isDevMode && !apiStatusMessage && (
             <RNPickerSelect
               onValueChange={onEnvironmentSelectionChange}
               placeholder={{}}
@@ -323,16 +370,18 @@ function LoginScreen(): JSX.Element {
             />
           )}
 
-          <Footer>
-            <FooterText>
-              När du använder appen Mitt Helsingborg behandlar Helsingborgs stad
-              dina{" "}
-              <ParagraphLink onPress={toggleAgreementModal}>
-                personuppgifter
-              </ParagraphLink>
-              .
-            </FooterText>
-          </Footer>
+          {!apiStatusMessage && (
+            <Footer>
+              <FooterText>
+                När du använder appen Mitt Helsingborg behandlar Helsingborgs
+                stad dina{" "}
+                <ParagraphLink onPress={toggleAgreementModal}>
+                  personuppgifter
+                </ParagraphLink>
+                .
+              </FooterText>
+            </Footer>
+          )}
         </FlexImageBackground>
       </SafeAreaViewTop>
 

--- a/source/services/ApiStatusService.ts
+++ b/source/services/ApiStatusService.ts
@@ -1,0 +1,13 @@
+import { get } from "../helpers/ApiRequest";
+
+const getApiStatus = async (): Promise<string> => {
+  const response = await get("/status");
+
+  if (response.status !== 200) {
+    return "Just nu har vi tekniska problem i appen. Vi jobbar på att lösa dessa. Kom tillbaka om en liten stund och testa igen.";
+  }
+
+  return response?.data?.data?.attributes?.message || "";
+};
+
+export default getApiStatus;

--- a/source/services/ApiStatusService.ts
+++ b/source/services/ApiStatusService.ts
@@ -4,7 +4,7 @@ const getApiStatus = async (): Promise<string> => {
   const response = await get("/status");
 
   if (response.status !== 200) {
-    return "Just nu har vi tekniska problem i appen. Vi jobbar på att lösa dessa. Kom tillbaka om en liten stund och testa igen.";
+    return "Tjänsten är för nuvarande otillgänglig. Försök igen senare.";
   }
 
   return response?.data?.data?.attributes?.message || "";

--- a/source/services/ApiStatusService.ts
+++ b/source/services/ApiStatusService.ts
@@ -7,7 +7,7 @@ const getApiStatus = async (): Promise<string> => {
     return "Tjänsten är för närvarande otillgänglig. Försök igen senare.";
   }
 
-  return response?.data?.data?.attributes?.message || "";
+  return response?.data?.data?.message || "";
 };
 
 export default getApiStatus;

--- a/source/services/ApiStatusService.ts
+++ b/source/services/ApiStatusService.ts
@@ -4,7 +4,7 @@ const getApiStatus = async (): Promise<string> => {
   const response = await get("/status");
 
   if (response.status !== 200) {
-    return "Tjänsten är för nuvarande otillgänglig. Försök igen senare.";
+    return "Tjänsten är för närvarande otillgänglig. Försök igen senare.";
   }
 
   return response?.data?.data?.attributes?.message || "";

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -4,6 +4,7 @@ import env from "react-native-config";
 import USER_AUTH_STATE from "../types/UserAuthTypes";
 import AppContext from "./AppContext";
 import * as authService from "../services/AuthService";
+import getApiStatus from "../services/ApiStatusService";
 
 import AuthReducer, {
   initialState as defaultInitialState,
@@ -22,6 +23,7 @@ import {
   setStatus,
   setError,
   setAuthenticateOnExternalDevice,
+  setApiStatusMessage,
 } from "./actions/AuthActions";
 
 const AuthContext = React.createContext();
@@ -142,6 +144,13 @@ function AuthProvider({ children, initialState }) {
   }
 
   /**
+   * Sets any API status message in state.
+   */
+  function handleSetApiStatusMessage(message) {
+    dispatch(setApiStatusMessage(message));
+  }
+
+  /**
    * Set status.
    */
   function handleSetStatus(status) {
@@ -185,7 +194,15 @@ function AuthProvider({ children, initialState }) {
   useEffect(() => {
     const trySignIn = async () => {
       try {
-        if (await isAccessTokenValid()) {
+        const apiStatusMessage = await getApiStatus();
+
+        if (apiStatusMessage) {
+          handleSetApiStatusMessage(apiStatusMessage);
+        } else if (!apiStatusMessage) {
+          handleSetApiStatusMessage("");
+        }
+
+        if ((await isAccessTokenValid()) && !apiStatusMessage) {
           await handleAddProfile();
           handleLogin();
         } else {

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -144,7 +144,7 @@ function AuthProvider({ children, initialState }) {
   }
 
   /**
-   * Sets any API status message in state.
+   * Sets API status message in state.
    */
   function handleSetApiStatusMessage(message) {
     dispatch(setApiStatusMessage(message));

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -202,7 +202,8 @@ function AuthProvider({ children, initialState }) {
           handleSetApiStatusMessage("");
         }
 
-        if ((await isAccessTokenValid()) && !apiStatusMessage) {
+        const canLogin = (await isAccessTokenValid()) && !apiStatusMessage;
+        if (canLogin) {
           await handleAddProfile();
           handleLogin();
         } else {

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -31,7 +31,7 @@ const AuthContext = React.createContext();
 function AuthProvider({ children, initialState }) {
   const [state, dispatch] = useReducer(AuthReducer, initialState);
 
-  const { handleSetMode } = useContext(AppContext);
+  const { handleSetMode, isDevMode } = useContext(AppContext);
 
   /**
    * Starts polling for an order response if status is pending and orderRef and autoStartToken is set in state.
@@ -194,13 +194,13 @@ function AuthProvider({ children, initialState }) {
   useEffect(() => {
     const trySignIn = async () => {
       try {
-        const apiStatusMessage = await getApiStatus();
+        let apiStatusMessage = "";
 
-        if (apiStatusMessage) {
-          handleSetApiStatusMessage(apiStatusMessage);
-        } else if (!apiStatusMessage) {
-          handleSetApiStatusMessage("");
+        if (!isDevMode) {
+          apiStatusMessage = await getApiStatus();
         }
+
+        handleSetApiStatusMessage(apiStatusMessage);
 
         const canLogin = (await isAccessTokenValid()) && !apiStatusMessage;
         if (canLogin) {
@@ -215,7 +215,7 @@ function AuthProvider({ children, initialState }) {
     };
 
     trySignIn();
-  }, [isAccessTokenValid]);
+  }, [isAccessTokenValid, isDevMode]);
 
   useEffect(() => {
     const tryFetchUser = async () => {

--- a/source/store/actions/AuthActions.js
+++ b/source/store/actions/AuthActions.js
@@ -20,6 +20,7 @@ export const actionTypes = {
   setError: "SET_ERROR",
   signSuccess: "SIGN_SUCCESS",
   setAuthenticateOnExternalDevice: "SET_AUTH_ON_EXTERNAL_DEVICE",
+  apiStatusMessage: "API_STATUS_MESSAGE",
 };
 
 export async function mockedAuth() {
@@ -57,6 +58,12 @@ export function setStatus(status) {
   };
 }
 
+export function removeProfile() {
+  return {
+    type: actionTypes.removeProfile,
+  };
+}
+
 export function setError(error) {
   return {
     type: actionTypes.setError,
@@ -86,12 +93,6 @@ export async function addProfile() {
   return {
     type: actionTypes.addProfile,
     payload: userProfile,
-  };
-}
-
-export function removeProfile() {
-  return {
-    type: actionTypes.removeProfile,
   };
 }
 
@@ -237,5 +238,12 @@ export function setAuthenticateOnExternalDevice(value) {
   return {
     type: actionTypes.setAuthenticateOnExternalDevice,
     authenticateOnExternalDevice: value,
+  };
+}
+
+export function setApiStatusMessage(apiStatusMessage) {
+  return {
+    type: actionTypes.apiStatusMessage,
+    apiStatusMessage,
   };
 }

--- a/source/store/reducers/AuthReducer.js
+++ b/source/store/reducers/AuthReducer.js
@@ -123,6 +123,12 @@ export default function AuthReducer(state, action) {
         authenticateOnExternalDevice: action.authenticateOnExternalDevice,
       };
 
+    case actionTypes.apiStatusMessage:
+      return {
+        ...state,
+        apiStatusMessage: action.apiStatusMessage,
+      };
+
     default:
       return state;
   }


### PR DESCRIPTION
## Explain the changes you’ve made
Log out user and show an error message on login screen if we fetches an api status message from backend.

## Explain why these changes are made
This functionality is added because we want to make users aware if any issues has arisen in backend which would make the application unusable.

## Explain your solution
On application start, we fetch the latest status from our backend. If we receive an message, we sign out the user and shows the message. Otherwise we continue the auth flow.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Simulate (as of now) by changing the response from apiStatusMessage service. The values returned should be a string or an empty one.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots
![simulator_screenshot_AA6027E0-B2A9-49F2-92C4-5DD6C4315108](https://user-images.githubusercontent.com/81250970/150099007-8d5c6086-09bd-4d90-97bf-ce8a873750a1.png)


