### PR TITLE
feat: handle new type for submitted completions

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -40,6 +40,7 @@ import { Form } from "../../types/FormTypes";
 const {
   ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
   ACTIVE_COMPLETION_REQUIRED_VIVA,
+  ACTIVE_COMPLETION_SUBMITTED,
   ACTIVE_SIGNATURE_PENDING,
   NOT_STARTED,
   ONGOING,
@@ -162,6 +163,9 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const isVivaCompletionRequired = statusType.includes(
     ACTIVE_COMPLETION_REQUIRED_VIVA
   );
+  const isVivaCompletionSubmitted = statusType.includes(
+    ACTIVE_COMPLETION_SUBMITTED
+  );
   const isSigned = statusType.includes(SIGNED);
   const isClosed = statusType.includes(CLOSED);
   const isWaitingForSign = statusType.includes(ACTIVE_SIGNATURE_PENDING);
@@ -193,7 +197,8 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
       isRandomCheckRequired ||
       isSigned ||
       isClosed ||
-      isVivaCompletionRequired;
+      isVivaCompletionRequired ||
+      isVivaCompletionSubmitted;
   const buttonProps: InternalButtonProps = {
     onClick: () => navigation.navigate("Form", { caseId: caseData.id }),
     text: "",
@@ -285,6 +290,12 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
 
   if (isVivaCompletionRequired) {
     buttonProps.text = "Komplettera ansökan";
+    cardProps.subtitle = "Ansökan behöver kompletteras";
+  }
+
+  if (isVivaCompletionSubmitted) {
+    buttonProps.text = "Komplettera ansökan";
+    cardProps.subtitle = "Komplettering inskickad";
   }
 
   const giveDate = payments?.payment?.givedate

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -288,14 +288,8 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
     buttonProps.text = "Granska och signera";
   }
 
-  if (isVivaCompletionRequired) {
+  if (isVivaCompletionRequired || isCompletionSubmitted) {
     buttonProps.text = "Komplettera ansökan";
-    cardProps.subtitle = "Ansökan behöver kompletteras";
-  }
-
-  if (isCompletionSubmitted) {
-    buttonProps.text = "Komplettera ansökan";
-    cardProps.subtitle = "Komplettering inskickad";
   }
 
   const giveDate = payments?.payment?.givedate

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -163,7 +163,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const isVivaCompletionRequired = statusType.includes(
     ACTIVE_COMPLETION_REQUIRED_VIVA
   );
-  const isVivaCompletionSubmitted = statusType.includes(
+  const isCompletionSubmitted = statusType.includes(
     ACTIVE_COMPLETION_SUBMITTED
   );
   const isSigned = statusType.includes(SIGNED);
@@ -198,7 +198,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
       isSigned ||
       isClosed ||
       isVivaCompletionRequired ||
-      isVivaCompletionSubmitted;
+      isCompletionSubmitted;
   const buttonProps: InternalButtonProps = {
     onClick: () => navigation.navigate("Form", { caseId: caseData.id }),
     text: "",
@@ -293,7 +293,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
     cardProps.subtitle = "Ansökan behöver kompletteras";
   }
 
-  if (isVivaCompletionSubmitted) {
+  if (isCompletionSubmitted) {
     buttonProps.text = "Komplettera ansökan";
     cardProps.subtitle = "Komplettering inskickad";
   }

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -7,6 +7,7 @@ export enum ApplicationStatusType {
   ACTIVE_SIGNATURE_COMPLETED = "active:signature:completed",
   ACTIVE_SIGNATURE_PENDING = "active:signature:pending",
   ACTIVE_SUBMITTED = "active:submitted",
+  ACTIVE_COMPLETION_SUBMITTED = "active:completion:submitted",
   CLOSED = "closed",
   SIGNED = "signed",
   ACTIVE = "active",


### PR DESCRIPTION
## Explain the changes you’ve made
Added support for the new case status type `active:completion:submitted` in CaseOverview.tsx file

## Explain why these changes are made
In order to display to the user that its completions has been submitted, this new status type is added.

## Explain your solution
The new status type is added to the `ApplicationStatusType` enum, this enum is the used in CaseOverview.tsx file where we change the button text accordingly.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a case with the status type of `active:completion:submitted`

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

![simulator_screenshot_7E266228-9762-45F4-B1A6-1C343724EEB4](https://user-images.githubusercontent.com/81250970/150996009-5dbdc7af-9393-4d22-99b2-bf0abb8aedf0.png)

