### PR TITLE
Feat/show completion submitted in case summary

### DIFF
--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -42,6 +42,7 @@ const {
   ACTIVE_SIGNATURE_PENDING,
   ACTIVE_COMPLETION_REQUIRED_VIVA,
   ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
+  ACTIVE_COMPLETION_SUBMITTED,
 } = ApplicationStatusType;
 
 const Container = styled.ScrollView`
@@ -166,6 +167,9 @@ const computeCaseCardComponent = (
   const isVivaCompletionRequired = statusType.includes(
     ACTIVE_COMPLETION_REQUIRED_VIVA
   );
+  const isCompletionSubmitted = statusType.includes(
+    ACTIVE_COMPLETION_SUBMITTED
+  );
   const isSigned = statusType.includes(SIGNED);
   const isWaitingForSign = statusType.includes(ACTIVE_SIGNATURE_PENDING);
   const selfHasSigned = casePersonData?.hasSigned;
@@ -188,7 +192,8 @@ const computeCaseCardComponent = (
       isNotStarted ||
       isRandomCheckRequired ||
       isSigned ||
-      isVivaCompletionRequired;
+      isVivaCompletionRequired ||
+      isCompletionSubmitted;
 
   const buttonProps = {
     onClick: () => navigation.navigate("Form", { caseId: caseData.id }),
@@ -208,6 +213,10 @@ const computeCaseCardComponent = (
   }
 
   if (isVivaCompletionRequired) {
+    buttonProps.text = "Komplettera ansökan";
+  }
+
+  if (isCompletionSubmitted) {
     buttonProps.text = "Komplettera ansökan";
   }
 
@@ -231,9 +240,10 @@ const computeCaseCardComponent = (
       } ${getSwedishMonthNameByTimeStamp(payments.payment.givedate, true)}`
     : null;
 
-  const unApprovedCompletionDescriptions: string[] = isVivaCompletionRequired
-    ? getUnapprovedCompletionDescriptions(completions)
-    : [];
+  const unApprovedCompletionDescriptions: string[] =
+    isVivaCompletionRequired || isCompletionSubmitted
+      ? getUnapprovedCompletionDescriptions(completions)
+      : [];
 
   return (
     <CaseCard

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -212,11 +212,7 @@ const computeCaseCardComponent = (
     buttonProps.text = "Starta stickprov";
   }
 
-  if (isVivaCompletionRequired) {
-    buttonProps.text = "Komplettera ansökan";
-  }
-
-  if (isCompletionSubmitted) {
+  if (isVivaCompletionRequired || isCompletionSubmitted) {
     buttonProps.text = "Komplettera ansökan";
   }
 

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -7,6 +7,7 @@ export enum ApplicationStatusType {
   ACTIVE_SIGNATURE_COMPLETED = "active:signature:completed",
   ACTIVE_SIGNATURE_PENDING = "active:signature:pending",
   ACTIVE_SUBMITTED = "active:submitted",
+  ACTIVE_COMPLETION_SUBMITTED = "active:completion:submitted",
   CLOSED = "closed",
   SIGNED = "signed",
   ACTIVE = "active",


### PR DESCRIPTION
## Explain the changes you’ve made
Added support for the new case status type `active:completion:submitted` in CaseSummary.tsx file

## Explain why these changes are made
In order to display to the user that its completions has been submitted, this new status type is added.

## Explain your solution
The new status type is added to the `ApplicationStatusType` enum, this enum is the used in CaseSummary.tsx file where we change the button text accordingly.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a case with the status type of `active:completion:submitted`

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

![simulator_screenshot_0BA4AE5A-695D-4AB9-963F-814BE077EC6C](https://user-images.githubusercontent.com/81250970/151005428-02e5a7da-7e22-438d-a746-d340a1c79cc8.png)

