### PR TITLE
bug: clear user object on sign out

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -149,7 +149,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   );
 
   const casePersonData = persons.find(
-    (person) => person.personalNumber === authContext.user.personalNumber
+    (person) => person.personalNumber === authContext?.user?.personalNumber
   );
 
   const caseCoApplicantData = persons.find(
@@ -185,7 +185,8 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   const selfNeedsToConfirm =
     isCoApplicant &&
     !caseData.hasSymmetricKey &&
-    currentForm.encryption.publicKeys[authContext.user.personalNumber] === null;
+    currentForm.encryption.publicKeys[authContext?.user?.personalNumber] ===
+      null;
   const isWaitingForCoApplicantConfirm =
     currentForm.encryption.publicKeys &&
     !caseData.hasSymmetricKey &&
@@ -496,7 +497,7 @@ function CaseOverview(props): JSX.Element {
 
       const person = caseData.persons.find(
         (personEntry) =>
-          personEntry.personalNumber === authContext.user.personalNumber
+          personEntry.personalNumber === authContext?.user?.personalNumber
       );
       const isCoApplicant = person?.role === "coApplicant";
 
@@ -523,7 +524,7 @@ function CaseOverview(props): JSX.Element {
         hasShownConfirmationThanksModal: true,
       });
     }
-  }, [authContext.user?.personalNumber, caseItems, dialogState]);
+  }, [authContext?.user?.personalNumber, caseItems, dialogState]);
 
   const activeCaseCards = activeCases.map((caseData) =>
     computeCaseCardComponent(caseData, navigation, authContext, {

--- a/source/store/AuthContext.js
+++ b/source/store/AuthContext.js
@@ -122,7 +122,7 @@ function AuthProvider({ children, initialState }) {
    * This function triggers an action to logout the user.
    */
   async function handleLogout() {
-    removeProfile();
+    dispatch(removeProfile());
     dispatch(await loginFailure());
   }
 


### PR DESCRIPTION
## Explain the changes you’ve made
Fix a bug where the user object weren't cleared after a user has been signed out. 
Also fixed an issue where we check for a personal number from authcontext in CaseOverview even though it has not been fetched before.

## Explain why these changes are made
When a user signs out, it is expected that all user data is deleted.

## Explain your solution
In AuthContext, the AuthReducer action for removing a user profile were missing, causing the user object to not be cleared.

## How to test
1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Sign in with an account of your choice
4. Sign out
5. Sign in with another account and check the user profile tab and check wether the user information is correct.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.