### PR TITLE
Bug/reopen form issue

### DIFF
--- a/source/components/molecules/CloseDialog/CloseDialog.tsx
+++ b/source/components/molecules/CloseDialog/CloseDialog.tsx
@@ -23,20 +23,12 @@ const PopupContainer = styled.View`
 
 const Dialog = styled.View`
   width: 80%;
-  /* height: auto; */
   z-index: 1000;
   display: flex;
   flex-direction: column;
-  /* align-items: center; */
-  /* justify-content: center; */
   border-radius: 10px;
   background: ${(props) => props.theme.colors.neutrals[5]};
   padding: 12px;
-  /* elevation: 2;
-  shadow-offset: 0px 2px;
-  shadow-color: red;
-  shadow-opacity: 0.3;
-  shadow-radius: 2px; */
 `;
 
 const Content = styled.View`

--- a/source/components/molecules/CloseDialog/CloseDialog.tsx
+++ b/source/components/molecules/CloseDialog/CloseDialog.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import styled from "styled-components/native";
 import { BlurView } from "@react-native-community/blur";
 import { Modal } from "react-native";
-import Button from "../../../atoms/Button";
-import Heading from "../../../atoms/Heading";
-import Text from "../../../atoms/Text";
-import { PrimaryColor } from "../../../../styles/themeHelpers";
+import Button from "../../atoms/Button";
+import Heading from "../../atoms/Heading";
+import Text from "../../atoms/Text";
+import { PrimaryColor } from "../../../styles/themeHelpers";
 
 const BackgroundBlur = styled(BlurView)`
   position: absolute;
@@ -23,18 +23,20 @@ const PopupContainer = styled.View`
 
 const Dialog = styled.View`
   width: 80%;
-  height: auto;
+  /* height: auto; */
   z-index: 1000;
-  align-items: center;
-  justify-content: center;
+  display: flex;
+  flex-direction: column;
+  /* align-items: center; */
+  /* justify-content: center; */
   border-radius: 10px;
   background: ${(props) => props.theme.colors.neutrals[5]};
   padding: 12px;
-  elevation: 2;
+  /* elevation: 2;
   shadow-offset: 0px 2px;
-  shadow-color: black;
+  shadow-color: red;
   shadow-opacity: 0.3;
-  shadow-radius: 2px;
+  shadow-radius: 2px; */
 `;
 
 const Content = styled.View`
@@ -59,6 +61,7 @@ const DialogButton = styled(Button)`
 `;
 
 const ButtonRow = styled.View`
+  display: flex;
   flex-direction: row;
   justify-content: space-evenly;
   margin: 0px;
@@ -107,9 +110,8 @@ const CloseDialog: React.FC<CloseDialogProps> = ({
           {body && body.length > 0 ? <DialogText>{body}</DialogText> : null}
         </Content>
         <ButtonRow>
-          {buttons.map(({ text, color, clickHandler }, index) => (
-            /* @ts-ignore */
-            <ButtonWrapper key={index}>
+          {buttons.map(({ text, color, clickHandler }) => (
+            <ButtonWrapper key={text}>
               <DialogButton
                 block
                 z={0}

--- a/source/components/molecules/CloseDialog/index.ts
+++ b/source/components/molecules/CloseDialog/index.ts
@@ -1,0 +1,3 @@
+import CloseDialog from "./CloseDialog";
+
+export default CloseDialog;

--- a/source/components/organisms/FormList/FormList.tsx
+++ b/source/components/organisms/FormList/FormList.tsx
@@ -1,9 +1,11 @@
-import React, { useContext, useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import styled from 'styled-components/native';
-import { Heading, Text } from '../../atoms';
-import { ListItem } from '../../molecules';
-import FormContext from '../../../store/FormContext';
+import React, { useContext, useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components/native";
+import { Heading, Text } from "../../atoms";
+import { ListItem } from "../../molecules";
+import FormContext from "../../../store/FormContext";
+
+import { Form } from "../../../types/FormTypes";
 
 const List = styled.ScrollView`
   margin-top: 24px;
@@ -14,18 +16,30 @@ const ListHeading = styled(Heading)`
   margin-bottom: 8px;
 `;
 
-const FormList = ({ onClickCallback, heading, showSubforms }) => {
-  const [formSummaries, setFormSummaries] = useState([]);
+interface FormListProps {
+  heading: string;
+  showSubforms: boolean;
+  onClickCallback: (form: Form | null) => void;
+}
+const FormList = ({
+  onClickCallback,
+  heading,
+  showSubforms,
+}: FormListProps): JSX.Element => {
+  const [formSummaries, setFormSummaries] = useState<Form[]>([]);
   const { getFormSummaries, getForm } = useContext(FormContext);
 
   useEffect(() => {
     async function fetchForms() {
-      const formSummaries = await getFormSummaries();
-      setFormSummaries(formSummaries.filter((f) => (showSubforms ? f.subform : !f.subform)));
+      const formSummariesResult = await getFormSummaries();
+      setFormSummaries(
+        formSummariesResult.filter((f) =>
+          showSubforms ? f.subform : !f.subform
+        )
+      );
     }
-    fetchForms();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showSubforms]);
+    void fetchForms();
+  }, [showSubforms, getFormSummaries]);
 
   return (
     <List>
@@ -59,7 +73,7 @@ FormList.propTypes = {
 };
 
 FormList.defaultProps = {
-  heading: 'Formulär',
+  heading: "Formulär",
   showSubforms: false,
 };
 

--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -129,10 +129,12 @@ function Step({
   /** TODO: move out of this scope, this logic should be defined on the form component */
   const closeForm = () => {
     if (!isLastMainStep && isFormEditable) {
-      if (onFieldChange) {
+      const hasAnswers = Object.keys(answers).length > 0;
+
+      if (onFieldChange && hasAnswers) {
         onFieldChange(answers);
       }
-      if (updateCaseInContext) {
+      if (updateCaseInContext && hasAnswers) {
         updateCaseInContext(answers, undefined, currentPosition);
       }
     }

--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components/native";
 import FormField from "../../../containers/FormField";
 import Progressbar from "../../atoms/Progressbar/Progressbar";
 import BackNavigation from "../../molecules/BackNavigation/BackNavigation";
-import CloseDialog from "./CloseDialog/CloseDialog";
+import CloseDialog from "../../molecules/CloseDialog/CloseDialog";
 import Banner from "./StepBanner/StepBanner";
 import StepDescription from "./StepDescription/StepDescription";
 import StepFooter from "./StepFooter/StepFooter";
@@ -97,13 +97,14 @@ function Step({
   onFieldMount,
   onAddAnswer,
   isBackBtnVisible,
-  updateCaseInContext,
+  onUpdateCase,
   currentPosition,
   totalStepNumber,
   answerSnapshot,
   attachments,
   isFormEditable,
   completions,
+  onCloseForm,
 }): JSX.Element {
   const isSubstep = currentPosition.level !== 0;
   const isLastMainStep =
@@ -126,27 +127,9 @@ function Step({
   const [dialogIsVisible, setDialogIsVisible] = useState(false);
   const [dialogTemplate, setDialogTemplate] = useState(initialDialogTemplate);
 
-  /** TODO: move out of this scope, this logic should be defined on the form component */
-  const closeForm = () => {
-    if (!isLastMainStep && isFormEditable) {
-      const hasAnswers = Object.keys(answers).length > 0;
-
-      if (onFieldChange && hasAnswers) {
-        onFieldChange(answers);
-      }
-      if (updateCaseInContext && hasAnswers) {
-        updateCaseInContext(answers, undefined, currentPosition);
-      }
-    }
-
-    if (formNavigation?.close) {
-      formNavigation.close(() => {});
-    }
-  };
-
   const closeDialogAndForm = () => {
     setDialogIsVisible(false);
-    closeForm();
+    void onCloseForm();
   };
 
   const navigateToMainForm = () => {
@@ -329,7 +312,7 @@ function Step({
                 formNavigation={formNavigation}
                 currentPosition={currentPosition}
                 onUpdate={onFieldChange}
-                updateCaseInContext={updateCaseInContext}
+                onUpdateCase={onUpdateCase}
                 validateStepAnswers={validateStepAnswers}
                 attachments={attachments}
               />
@@ -345,7 +328,7 @@ function Step({
         onBack={backButtonBehavior}
         onClose={() => {
           if (isLastMainStep) {
-            closeForm();
+            void onCloseForm();
           } else {
             setDialogIsVisible(true);
           }
@@ -420,7 +403,7 @@ Step.propTypes = {
   /**
    * The function to update values in context (and thus the backend)
    */
-  updateCaseInContext: PropTypes.func,
+  onUpdateCase: PropTypes.func,
   /**
    * Properties to adjust the banner at the top of a step
    */

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -1,13 +1,13 @@
-import React, { useContext } from 'react';
-import styled from 'styled-components/native';
-import PropTypes from 'prop-types';
-import AuthContext from '../../../../store/AuthContext';
-import { Button, Text } from '../../../atoms';
-import { Action, Question } from '../../../../types/FormTypes';
-import { CaseStatus } from '../../../../types/CaseType';
-import { FormPosition } from '../../../../containers/Form/hooks/useForm';
-import { useNotification } from '../../../../store/NotificationContext';
-import { evaluateConditionalExpression } from '../../../../helpers/conditionParser';
+import React, { useContext } from "react";
+import styled from "styled-components/native";
+import PropTypes from "prop-types";
+import AuthContext from "../../../../store/AuthContext";
+import { Button, Text } from "../../../atoms";
+import { Action, Question } from "../../../../types/FormTypes";
+import { CaseStatus } from "../../../../types/CaseType";
+import { FormPosition } from "../../../../containers/Form/hooks/useForm";
+import { useNotification } from "../../../../store/NotificationContext";
+import { evaluateConditionalExpression } from "../../../../helpers/conditionParser";
 
 const ActionContainer = styled.View`
   width: 100%;
@@ -43,13 +43,16 @@ interface Props {
   };
   onUpdate: (answers: Record<string, any>) => void;
   onSubmit: () => void;
-  updateCaseInContext: (
+  onUpdateCase: (
     answers: Record<string, any>,
     signature: { success: boolean },
     currentPosition: FormPosition
   ) => void;
   currentPosition: FormPosition;
-  validateStepAnswers: (errorCallback: () => void, onValidCallback: () => void) => void;
+  validateStepAnswers: (
+    errorCallback: () => void,
+    onValidCallback: () => void
+  ) => void;
 }
 
 const StepFooter: React.FC<Props> = ({
@@ -60,58 +63,60 @@ const StepFooter: React.FC<Props> = ({
   formNavigation,
   onUpdate,
   onSubmit,
-  updateCaseInContext,
+  onUpdateCase,
   currentPosition,
   children,
   validateStepAnswers,
 }) => {
-  const { user, handleSign, isLoading, authenticateOnExternalDevice } = useContext(AuthContext);
+  const { user, handleSign, isLoading, authenticateOnExternalDevice } =
+    useContext(AuthContext);
   const showNotification = useNotification();
 
   const actionMap = (action: Action) => {
     switch (action.type) {
-      case 'start': {
+      case "start": {
         return formNavigation.start || null;
       }
-      case 'close': {
+      case "close": {
         return () => {
-          if (onUpdate && caseStatus.type.includes('ongoing')) onUpdate(answers);
+          if (onUpdate && caseStatus.type.includes("ongoing"))
+            onUpdate(answers);
           if (formNavigation.close) formNavigation.close();
         };
       }
-      case 'submit': {
+      case "submit": {
         return onSubmit || null;
       }
-      case 'backToMain': {
+      case "backToMain": {
         return () => {
           const errorCallback = () => {};
-  
+
           const onValidCallback = () => {
             formNavigation.goToMainForm();
-          }
-  
+          };
+
           validateStepAnswers(errorCallback, onValidCallback);
         };
       }
-      case 'backToMainAndNext': {
+      case "backToMainAndNext": {
         return formNavigation.goToMainFormAndNext;
       }
       default: {
         return () => {
           const errorCallback = () => {
             showNotification(
-              'Oj, fel inmatning!',
-              'Vänligen rätta fel innan ni går vidare',
-              'error',
+              "Oj, fel inmatning!",
+              "Vänligen rätta fel innan ni går vidare",
+              "error",
               8000
             );
           };
 
           const onValidCallback = async () => {
-            if (action.type === 'sign') {
+            if (action.type === "sign") {
               await handleSign(
                 user.personalNumber,
-                action?.signMessage || 'Signering Mitt Helsingborg.',
+                action?.signMessage || "Signering Mitt Helsingborg.",
                 authenticateOnExternalDevice
               );
 
@@ -123,14 +128,16 @@ const StepFooter: React.FC<Props> = ({
 
           if (
             onUpdate &&
-            (caseStatus.type.includes('ongoing') || caseStatus.type.includes('notStarted'))
+            (caseStatus.type.includes("ongoing") ||
+              caseStatus.type.includes("notStarted"))
           )
             onUpdate(answers);
           if (
-            updateCaseInContext &&
-            (caseStatus.type.includes('ongoing') || caseStatus.type.includes('notStarted'))
+            onUpdateCase &&
+            (caseStatus.type.includes("ongoing") ||
+              caseStatus.type.includes("notStarted"))
           )
-            updateCaseInContext(answers, undefined, currentPosition);
+            onUpdateCase(answers, undefined, currentPosition);
 
           validateStepAnswers(errorCallback, onValidCallback);
         };
@@ -139,22 +146,25 @@ const StepFooter: React.FC<Props> = ({
   };
 
   const checkCondition = (condition?: string) => {
-    if (!condition || condition === '') return false;
+    if (!condition || condition === "") return false;
     return !evaluateConditionalExpression(condition, answers, allQuestions);
   };
 
   const buttons = actions.map((action, index) => (
-        <Flex key={`${index}-${action.label}`}>
-          <Button
-            onClick={actionMap(action)}
-            colorSchema={action.color}
-            disabled={isLoading || (action.hasCondition && checkCondition(action.conditionalOn))}
-            z={0}
-          >
-            <Text>{action.label}</Text>
-          </Button>
-        </Flex>
-      ));
+    <Flex key={`${index}-${action.label}`}>
+      <Button
+        onClick={actionMap(action)}
+        colorSchema={action.color}
+        disabled={
+          isLoading ||
+          (action.hasCondition && checkCondition(action.conditionalOn))
+        }
+        z={0}
+      >
+        <Text>{action.label}</Text>
+      </Button>
+    </Flex>
+  ));
 
   return (
     <ActionContainer>
@@ -167,7 +177,10 @@ const StepFooter: React.FC<Props> = ({
 };
 
 StepFooter.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   /**
    * Properties for actions in the footer of the step.
    */
@@ -208,7 +221,7 @@ StepFooter.propTypes = {
   onUpdate: PropTypes.func,
   onSubmit: PropTypes.func,
   /** Behaviour for updating case in context and backend */
-  updateCaseInContext: PropTypes.func,
+  onUpdateCase: PropTypes.func,
   currentPosition: PropTypes.shape({
     index: PropTypes.number,
     level: PropTypes.number,

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -137,7 +137,6 @@ const Form: React.FC<Props> = ({
     authenticateOnExternalDevice,
   } = useContext(AuthContext);
 
-  const [canCloseForm, setCanCloseForm] = useState(false);
   const [updateCaseState, setUpdateCaseState] = useState(
     UPDATE_CASE_STATE.IDLE
   );
@@ -229,17 +228,6 @@ const Form: React.FC<Props> = ({
     }
   }, [mainStep, scrollViewRef]);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (canCloseForm) {
-        setUpdateCaseState(UPDATE_CASE_STATE.IDLE);
-        formNavigation.close();
-      }
-    }, CLOSE_FORM_DELAY);
-
-    return () => clearTimeout(timer);
-  }, [canCloseForm, formNavigation]);
-
   const handleCloseForm = async () => {
     setUpdateCaseState(UPDATE_CASE_STATE.UPDATING);
 
@@ -257,10 +245,13 @@ const Form: React.FC<Props> = ({
       if (result?.type === ActionTypes.API_ERROR) {
         setUpdateCaseState(UPDATE_CASE_STATE.ERROR);
       } else {
-        setCanCloseForm(true);
+        setTimeout(() => {
+          setUpdateCaseState(UPDATE_CASE_STATE.IDLE);
+          onClose();
+        }, CLOSE_FORM_DELAY);
       }
     } else {
-      formNavigation.close();
+      onClose();
     }
   };
 
@@ -273,7 +264,7 @@ const Form: React.FC<Props> = ({
           {
             text: "Nej",
             color: "neutral" as PrimaryColor,
-            clickHandler: () => formNavigation.close(),
+            clickHandler: onClose,
           },
           {
             text: "Ja",

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -6,7 +6,7 @@ import ScreenWrapper from "../../components/molecules/ScreenWrapper";
 import Step from "../../components/organisms/Step/Step";
 import { evaluateConditionalExpression } from "../../helpers/conditionParser";
 import { CaseStatus } from "../../types/CaseType";
-import { ActionTypes, Action } from "../../types/CaseContext";
+import { ActionTypes, Action, Answer } from "../../types/CaseContext";
 import {
   Step as StepType,
   StepperActions,
@@ -27,16 +27,8 @@ import { Image } from "../../components/molecules/ImageDisplay/ImageDisplay";
 import CloseDialog from "../../components/molecules/CloseDialog";
 import { PrimaryColor } from "../../styles/themeHelpers";
 
-enum UPDATE_CASE_STATE {
-  PENDING = "pending",
-  UPDATING = "updating",
-  ERROR = "error",
-}
+import { UPDATE_CASE_STATE, DialogText } from "./types";
 
-interface DialogText {
-  title: string;
-  body: string;
-}
 const dialogText: Record<UPDATE_CASE_STATE, DialogText> = {
   [UPDATE_CASE_STATE.UPDATING]: {
     title: "Vänligen vänta",
@@ -62,10 +54,10 @@ interface Props {
   onClose: () => void;
   onSubmit: () => void;
   onUpdateCase: (
-    data: Record<string, unknown>,
+    data: Record<string, Answer>,
     signature: { success: boolean } | undefined,
     currentPosition: FormPosition
-  ) => Promise<Action>;
+  ) => Promise<Action | void>;
   period?: FormPeriod;
   editable: boolean;
   completions: RequestedCompletions[];
@@ -256,13 +248,13 @@ const Form: React.FC<Props> = ({
       formState.currentPosition.currentMainStep === formState.totalStepNumber;
 
     if (!isLastMainStep && editable) {
-      const { type } = await onUpdateCase(
+      const result = await onUpdateCase(
         answers,
         undefined,
         formState.currentPosition
       );
 
-      if (type === ActionTypes.API_ERROR) {
+      if (result?.type === ActionTypes.API_ERROR) {
         setUpdateCaseState(UPDATE_CASE_STATE.ERROR);
       } else {
         setCanCloseForm(true);

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -32,11 +32,11 @@ enum UPDATE_CASE_STATE {
   UPDATING = "updating",
   ERROR = "error",
 }
+
 interface DialogText {
   title: string;
   body: string;
 }
-
 const dialogText: Record<UPDATE_CASE_STATE, DialogText> = {
   [UPDATE_CASE_STATE.UPDATING]: {
     title: "Vänligen vänta",

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -6,7 +6,7 @@ import ScreenWrapper from "../../components/molecules/ScreenWrapper";
 import Step from "../../components/organisms/Step/Step";
 import { evaluateConditionalExpression } from "../../helpers/conditionParser";
 import { CaseStatus } from "../../types/CaseType";
-import { ActionTypes } from "../../types/CaseContext";
+import { ActionTypes, Action } from "../../types/CaseContext";
 import {
   Step as StepType,
   StepperActions,
@@ -65,7 +65,7 @@ interface Props {
     data: Record<string, unknown>,
     signature: { success: boolean } | undefined,
     currentPosition: FormPosition
-  ) => Promise<void>;
+  ) => Promise<Action>;
   period?: FormPeriod;
   editable: boolean;
   completions: RequestedCompletions[];

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -38,7 +38,7 @@ const dialogText: Record<UPDATE_CASE_STATE, DialogText> = {
     title: "Ett fel har uppstått!",
     body: "Vill du försöka igen?",
   },
-  [UPDATE_CASE_STATE.PENDING]: {
+  [UPDATE_CASE_STATE.IDLE]: {
     title: "",
     body: "",
   },
@@ -139,7 +139,7 @@ const Form: React.FC<Props> = ({
 
   const [canCloseForm, setCanCloseForm] = useState(false);
   const [updateCaseState, setUpdateCaseState] = useState(
-    UPDATE_CASE_STATE.PENDING
+    UPDATE_CASE_STATE.IDLE
   );
 
   const answers: Record<string, Image | any> = formState.formAnswers;
@@ -232,7 +232,7 @@ const Form: React.FC<Props> = ({
   useEffect(() => {
     const timer = setTimeout(() => {
       if (canCloseForm) {
-        setUpdateCaseState(UPDATE_CASE_STATE.PENDING);
+        setUpdateCaseState(UPDATE_CASE_STATE.IDLE);
         formNavigation.close();
       }
     }, CLOSE_FORM_DELAY);
@@ -264,7 +264,7 @@ const Form: React.FC<Props> = ({
     }
   };
 
-  const showDialog = updateCaseState !== UPDATE_CASE_STATE.PENDING;
+  const showDialog = updateCaseState !== UPDATE_CASE_STATE.IDLE;
   const dialogTitle = dialogText[updateCaseState].title;
   const dialogBody = dialogText[updateCaseState].body;
   const dialogButtons =

--- a/source/containers/Form/types.ts
+++ b/source/containers/Form/types.ts
@@ -1,0 +1,10 @@
+export const enum UPDATE_CASE_STATE {
+  PENDING = "pending",
+  UPDATING = "updating",
+  ERROR = "error",
+}
+
+export interface DialogText {
+  title: string;
+  body: string;
+}

--- a/source/containers/Form/types.ts
+++ b/source/containers/Form/types.ts
@@ -1,5 +1,5 @@
 export const enum UPDATE_CASE_STATE {
-  PENDING = "pending",
+  IDLE = "idle",
   UPDATING = "updating",
   ERROR = "error",
 }

--- a/source/screens/DevFeaturesScreen.tsx
+++ b/source/screens/DevFeaturesScreen.tsx
@@ -36,13 +36,11 @@ const DeveloperScreen = (props: any): JSX.Element => {
         <FormList
           heading="Ansökningsformulär"
           onClickCallback={async (form) => {
-            createCase(
-              form,
-              async (newCase) => {
-                navigation.navigate("Form", { caseData: newCase });
-              },
-              true
-            );
+            if (createCase !== undefined) {
+              createCase(form, async ({ id }) => {
+                navigation.navigate("Form", { caseId: id });
+              });
+            }
           }}
         />
 

--- a/source/screens/FormCaseScreen.tsx
+++ b/source/screens/FormCaseScreen.tsx
@@ -13,7 +13,7 @@ import AuthContext from "../store/AuthContext";
 import FormContext from "../store/FormContext";
 import { CaseDispatch, CaseState } from "../store/CaseContext";
 import { Case, FormPosition, ApplicationStatusType } from "../types/Case";
-import { CaseUpdate, Answer, Signature } from "../types/CaseContext";
+import { CaseUpdate, Answer, Signature, Action } from "../types/CaseContext";
 
 const SpinnerContainer = styled.View`
   flex: 1;
@@ -87,7 +87,7 @@ const FormCaseScreen = ({
     answerObject: Record<string, Answer>,
     signature: Signature | undefined,
     currentPosition: FormPosition
-  ) => {
+  ): Promise<Action | void> => {
     // If the case is submitted, we should not actually update its data...
     if (
       !initialCase?.status?.type?.includes(

--- a/source/screens/FormCaseScreen.tsx
+++ b/source/screens/FormCaseScreen.tsx
@@ -83,15 +83,16 @@ const FormCaseScreen = ({
     navigation.popToTop();
   };
 
-  const updateCaseContext = (
+  const handleUpdateCase = async (
     answerObject: Record<string, Answer>,
-    signature: Signature,
+    signature: Signature | undefined,
     currentPosition: FormPosition
   ) => {
     // If the case is submitted, we should not actually update its data...
     if (
-      initialCase !== undefined &&
-      !initialCase.status.type.includes(ApplicationStatusType.ACTIVE_SUBMITTED)
+      !initialCase?.status?.type?.includes(
+        ApplicationStatusType.ACTIVE_SUBMITTED
+      )
     ) {
       const updatedCase: CaseUpdate = {
         user,
@@ -105,19 +106,20 @@ const FormCaseScreen = ({
         encryptAnswers: true,
       };
 
-      const callback = (putResponse: Case) => {
+      const callback = async (putResponse: Case) => {
         if (
           putResponse?.status?.type?.includes(
             ApplicationStatusType.ACTIVE_SIGNATURE_COMPLETED
           )
         ) {
           updatedCase.encryptAnswers = false;
-          updateCase(updatedCase, () => true);
+          await updateCase(updatedCase, () => Promise.resolve());
         }
       };
 
-      updateCase(updatedCase, callback);
+      return updateCase(updatedCase, callback);
     }
+    return Promise.resolve();
   };
 
   // TODO: Update case on form submit.
@@ -146,7 +148,7 @@ const FormCaseScreen = ({
       status={initialCase?.status || defaultInitialStatus}
       period={initialCase?.details?.period}
       completions={initialCase?.details?.completions?.requested || []}
-      updateCaseInContext={updateCaseContext}
+      onUpdateCase={handleUpdateCase}
       editable={!isSignMode}
       {...props}
     />

--- a/source/store/CaseContext.tsx
+++ b/source/store/CaseContext.tsx
@@ -183,8 +183,7 @@ function CaseProvider({
     if (user) {
       void fetchCases();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user]);
+  }, [user, fetchCases]);
 
   const providedState: ContextState = {
     ...state,

--- a/source/store/CaseContext.tsx
+++ b/source/store/CaseContext.tsx
@@ -10,6 +10,7 @@ import {
   CaseUpdate,
   PolledCaseResult,
   ActionTypes,
+  Action,
 } from "../types/CaseContext";
 import AuthContext from "./AuthContext";
 import CaseReducer, {
@@ -79,8 +80,8 @@ function CaseProvider({
 
   async function updateCase(
     updateData: Omit<CaseUpdate, "user">,
-    callback: (updatedCase: Case) => void
-  ) {
+    callback: (updatedCase: Case) => Promise<Action>
+  ): Promise<Action> {
     const fullUpdateData: CaseUpdate = {
       ...updateData,
       user,

--- a/source/store/CaseContext.tsx
+++ b/source/store/CaseContext.tsx
@@ -87,6 +87,7 @@ function CaseProvider({
     };
     const updateResult = await update(fullUpdateData, callback);
     dispatch(updateResult);
+    return updateResult;
   }
 
   function getCase(caseId: string): Case | undefined {

--- a/source/store/actions/CaseActions.ts
+++ b/source/store/actions/CaseActions.ts
@@ -66,6 +66,12 @@ export async function updateCase(
     if (callback) {
       callback(flatUpdatedCase);
     }
+
+    flatUpdatedCase.forms[formId] = await decryptFormAnswers(
+      user,
+      flatUpdatedCase.forms[formId]
+    );
+
     return {
       type: ActionTypes.UPDATE_CASE,
       payload: flatUpdatedCase,

--- a/source/store/actions/CaseActions.ts
+++ b/source/store/actions/CaseActions.ts
@@ -36,7 +36,7 @@ export async function updateCase(
     encryptAnswers = true,
     encryption,
   }: CaseUpdate,
-  callback: (updatedCase: Case) => void
+  callback: (updatedCase: Case) => Promise<Action>
 ): Promise<Action> {
   let updateCaseRequestBody: UpdateCaseBody = {
     answers: convertAnswersToArray(answerObject, formQuestions),

--- a/source/types/CaseContext.ts
+++ b/source/types/CaseContext.ts
@@ -60,7 +60,7 @@ export interface Dispatch {
   updateCase: (
     updateData: CaseUpdate,
     callback: (updatedCase: Case) => Promise<void>
-  ) => void;
+  ) => Promise<Action>;
   deleteCase?: (caseId: string) => void;
 }
 

--- a/source/types/CaseContext.ts
+++ b/source/types/CaseContext.ts
@@ -59,7 +59,7 @@ export interface Dispatch {
   createCase?: (form: Form, callback: (newCase: Case) => void) => void;
   updateCase: (
     updateData: CaseUpdate,
-    callback: (updatedCase: Case) => void
+    callback: (updatedCase: Case) => Promise<void>
   ) => void;
   deleteCase?: (caseId: string) => void;
 }


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed a bug where opening a form a second time would cause the app to only show a loading spinner. This is due to that the application, after a form has been closed, saves the case with encrypted answers in application state, which we don't decrypt, causing the logic to fail.

The solution was to save the answers unencrypted in the application state to be able to show the form again.
Also added a modal telling the user that an update is ongoing when trying to close the form, this is to make sure that we have the same data in backend as in the application state.
Also added a modal if something goes wrong when closing the form.

## Explain why these changes are made
A user needs to be able to open the form more than once without experiencing any errors. And we also want the same data in backend as in the application state.

## Explain your solution

## How to test

**Successful case update**

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Open a case in the application
4. Do changes in the form and close it. At least one modal should appear
5. If successful updating the case, open it again and check if values you entered before are still there.

**Unsuccessful case update**

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure (either in application or backend) that updating a case will fail
4. Open a case in the application
5. Do changes in the form and close it. An error modal should appear

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots

 **Iphone:**
![simulator_screenshot_B38B32AD-9724-4654-B444-B9A1F4C5BC60](https://user-images.githubusercontent.com/81250970/153140008-8857866a-d2dd-4363-9cb1-ebbbb51e6690.png)

![simulator_screenshot_3FC196D5-65D1-4E63-A680-05EDD5104354](https://user-images.githubusercontent.com/81250970/153140524-25cdf657-bf11-456d-9c3d-82b6f7731fce.png)

**Android:**

