### PR TITLE
feat: use deviceinfo version instead of package.json

### DIFF
--- a/source/helpers/ApiRequest.js
+++ b/source/helpers/ApiRequest.js
@@ -1,8 +1,10 @@
 import axios from "axios";
 import { Platform } from "react-native";
+import DeviceInfo from "react-native-device-info";
+
 import StorageService, { ACCESS_TOKEN_KEY } from "../services/StorageService";
 import { buildServiceUrl } from "./UrlHelper";
-import { name, version } from "../../package.json";
+import { name } from "../../package.json";
 import EnvironmentConfigurationService from "../services/EnvironmentConfigurationService";
 import { getUserFriendlyAppVersion } from "./Misc";
 
@@ -22,8 +24,9 @@ const request = async (endpoint, method, data, headers, params) => {
     EnvironmentConfigurationService.getInstance().activeEndpoint;
 
   const friendlyVersion = getUserFriendlyAppVersion();
+  const applicationVersion = DeviceInfo.getVersion();
 
-  const userAgent = `${name}/${version}/${Platform.OS}/${Platform.Version}/${friendlyVersion}`;
+  const userAgent = `${name}/${applicationVersion}/${Platform.OS}/${Platform.Version}/${friendlyVersion}`;
 
   // Merge custom headers
   const newHeaders = {


### PR DESCRIPTION
## Explain the changes you’ve made
Use DeviceInfo.getInfo to get device application version instead of retrieving it from the package.json file

## Explain why these changes are made


## Explain your solution

A Good example:
This includes a migration, model and controller for user authentication.
I'm using Devise to do the heavy lifting. I ran Devise migrations and those are included here.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure that you have setup version-api with SSM parameters
4. ... or just console.log which applicationVersion that is set in the user header in `apiRequest.js` file

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
