### PR TITLE
fix: remove case data when user is signed out

### DIFF
--- a/source/store/CaseContext.tsx
+++ b/source/store/CaseContext.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useReducer,
-  useEffect,
-  useCallback,
-  useMemo,
-} from "react";
+import React, { useContext, useReducer, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { getStoredSymmetricKey } from "../services/encryption/EncryptionHelper";
 import { filterAsync } from "../helpers/Objects";
@@ -82,10 +76,7 @@ function CaseProvider({
   const [state, dispatch] = useReducer(CaseReducer, initialState);
   const { user, userAuthState } = useContext(AuthContext);
 
-  const isSignedIn = useMemo(
-    () => userAuthState === USER_AUTH_STATE.SIGNED_IN,
-    [userAuthState]
-  );
+  const isSignedIn = userAuthState === USER_AUTH_STATE.SIGNED_IN;
 
   async function createCase(form: Form, callback: (newCase: Case) => void) {
     dispatch(await create(form, callback));

--- a/source/store/CaseContext.tsx
+++ b/source/store/CaseContext.tsx
@@ -195,7 +195,7 @@ function CaseProvider({
   }, [pollLoop, state.isPolling, user]);
 
   useEffect(() => {
-    if (isSignedIn && user) {
+    if (isSignedIn && user !== null) {
       void fetchCases();
     }
 

--- a/source/store/reducers/CaseReducer.ts
+++ b/source/store/reducers/CaseReducer.ts
@@ -62,6 +62,9 @@ export default function CaseReducer(state: State, action: Action): State {
       newState.error = payload;
       return newState;
 
+    case ActionTypes.RESET:
+      return { ...initialState };
+
     default:
       return state;
   }

--- a/source/store/reducers/CaseReducer.ts
+++ b/source/store/reducers/CaseReducer.ts
@@ -43,18 +43,19 @@ export default function CaseReducer(state: State, action: Action): State {
     case ActionTypes.POLL_CASE: {
       const polledPayload = payload as PolledCaseResult;
       const updatedCase = polledPayload.case;
-      newState.cases[updatedCase.id] = updatedCase;
+      if (newState.cases[updatedCase.id] !== undefined) {
+        newState.cases[updatedCase.id] = updatedCase;
+      }
       return newState;
     }
 
     case ActionTypes.SET_POLLING_CASES: {
-      newState.isPolling = true;
       newState.casesToPoll = payload as Case[];
       return newState;
     }
 
-    case ActionTypes.SET_POLLING_DONE: {
-      newState.isPolling = false;
+    case ActionTypes.SET_IS_POLLING: {
+      newState.isPolling = payload as boolean;
       return newState;
     }
 

--- a/source/types/CaseContext.ts
+++ b/source/types/CaseContext.ts
@@ -12,6 +12,7 @@ export enum ActionTypes {
   API_ERROR = "API_ERROR",
   SET_POLLING_CASES = "SET_POLLING_CASES",
   SET_POLLING_DONE = "SET_POLLING_DONE",
+  RESET = "RESET",
 }
 
 export interface State {

--- a/source/types/CaseContext.ts
+++ b/source/types/CaseContext.ts
@@ -11,7 +11,7 @@ export enum ActionTypes {
   POLL_CASE = "POLL_CASE",
   API_ERROR = "API_ERROR",
   SET_POLLING_CASES = "SET_POLLING_CASES",
-  SET_POLLING_DONE = "SET_POLLING_DONE",
+  SET_IS_POLLING = "SET_POLLING_DONE",
   RESET = "RESET",
 }
 
@@ -73,5 +73,6 @@ export interface Action {
     | Case[]
     | PolledCaseResult
     | string
+    | boolean
     | Error;
 }


### PR DESCRIPTION
## Explain the changes you’ve made
clear case data when user is not signed in

## Explain why these changes are made
A user were able to see old user case data if a new user signed in on the same device.

## Explain your solution
Created a new useEffect in caseContext which dispatches a reset action and clears the case data if a user is signed in.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Sign in with a user of your liking and make sure that user has a case to be displayed
4. Sign out that user
5. Sign in with another user with no cases (or cases if you like) and make sure another case (or no case) is displayed.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
