### PR TITLE
feat: show completion due date on case card

### DIFF
--- a/source/components/molecules/Card/Card.js
+++ b/source/components/molecules/Card/Card.js
@@ -268,7 +268,14 @@ Card.Button = ({
   ...props
 }) => (
   <Outset lastChild={lastChild} firstChild={firstChild}>
-    <CardButton variant="link" z={0} colorSchema={colorSchema} block {...props}>
+    <CardButton
+      mt={mt}
+      variant="link"
+      z={0}
+      colorSchema={colorSchema}
+      block
+      {...props}
+    >
       {children}
     </CardButton>
   </Outset>

--- a/source/components/molecules/Card/Card.js
+++ b/source/components/molecules/Card/Card.js
@@ -122,6 +122,10 @@ const CardProgressbar = styled(Progressbar)`
   height: 7px;
 `;
 
+const ProgressBarContainer = styled.View`
+  ${(props) => props.mt && `margin-top: ${8 * props.mt}px;`}
+`;
+
 /**
  * Card component
  * @param {props} props
@@ -300,11 +304,14 @@ Card.Progressbar = ({
   firstChild,
   lastChild,
   colorSchema,
+  mt = 0,
   ...props
 }) => (
-  <Outset lastChild={lastChild} firstChild={firstChild}>
-    <CardProgressbar rounded colorSchema={colorSchema} {...props} />
-  </Outset>
+  <ProgressBarContainer mt={mt}>
+    <Outset lastChild={lastChild} firstChild={firstChild}>
+      <CardProgressbar rounded colorSchema={colorSchema} {...props} />
+    </Outset>
+  </ProgressBarContainer>
 );
 
 /**

--- a/source/components/molecules/Card/Card.js
+++ b/source/components/molecules/Card/Card.js
@@ -95,7 +95,7 @@ const CardSubTitle = styled(Text)`
 
 const CardText = styled(Text)`
   padding: 0;
-  font-size: ${(props) => props.theme.fontSizes[3]}px;
+  font-size: ${(props) => props.fontSize ?? props.theme.fontSizes[3]}px;
   ${(props) => props.italic && `color: ${props.theme.colors.neutrals[3]};`}
   ${(props) => props.mt && `margin-top: ${8 * props.mt}px;`}
 `;

--- a/source/components/molecules/CaseCard/CaseCard.tsx
+++ b/source/components/molecules/CaseCard/CaseCard.tsx
@@ -115,7 +115,7 @@ const CaseCard = ({
       {completions.length > 0 && <Card.BulletList values={completions} />}
 
       {completionDuedate && (
-        <Card.Text mt={1.5} colorSchema="neutral" fontSize={12}>
+        <Card.Text mt={1} colorSchema="neutral" fontSize={12}>
           Skicka in senast: <Text type="a">{completionDuedate}</Text>
         </Card.Text>
       )}

--- a/source/components/molecules/CaseCard/CaseCard.tsx
+++ b/source/components/molecules/CaseCard/CaseCard.tsx
@@ -111,16 +111,20 @@ const CaseCard = ({
         </Card.Text>
       )}
 
+      {completions.length > 0 && <Card.BulletList values={completions} />}
+
       {completionDuedate && (
         <Card.Text mt={1.5} colorSchema="neutral" fontSize={12}>
           Skicka in senast: <Text type="a">{completionDuedate}</Text>
         </Card.Text>
       )}
 
-      {completions.length > 0 && <Card.BulletList values={completions} />}
-
       {showButton && (
-        <Card.Button onClick={onButtonClick} colorSchema={buttonColorScheme}>
+        <Card.Button
+          mt={1}
+          onClick={onButtonClick}
+          colorSchema={buttonColorScheme}
+        >
           <Text>{buttonText}</Text>
           <Icon name={buttonIconName || "arrow-forward"} />
         </Card.Button>

--- a/source/components/molecules/CaseCard/CaseCard.tsx
+++ b/source/components/molecules/CaseCard/CaseCard.tsx
@@ -40,6 +40,7 @@ interface CaseCardProps {
   dateTimeCardSize?: "large" | "small";
   buttonColorScheme?: string;
   completions?: string[];
+  completionDuedate: string;
 }
 
 const CaseCard = ({
@@ -67,6 +68,7 @@ const CaseCard = ({
   dateTimeCardSize = "large",
   buttonColorScheme = "red",
   completions = [],
+  completionDuedate,
 }: CaseCardProps): JSX.Element => (
   <Card colorSchema={colorSchema}>
     <Card.Body shadow color="neutral" onPress={onCardClick}>
@@ -106,6 +108,12 @@ const CaseCard = ({
       {showPayments && declinedAmount && (
         <Card.Text mt={1} strong colorSchema="neutral">
           Avslaget: {declinedAmount}
+        </Card.Text>
+      )}
+
+      {completionDuedate && (
+        <Card.Text mt={1.5} colorSchema="neutral" fontSize={12}>
+          Skicka in senast: <Text type="a">{completionDuedate}</Text>
         </Card.Text>
       )}
 

--- a/source/components/molecules/CaseCard/CaseCard.tsx
+++ b/source/components/molecules/CaseCard/CaseCard.tsx
@@ -92,6 +92,7 @@ const CaseCard = ({
         <Card.Progressbar
           currentStep={currentStep}
           totalStepNumber={totalSteps}
+          mt={1}
         />
       )}
 

--- a/source/components/organisms/BulletList/styled.ts
+++ b/source/components/organisms/BulletList/styled.ts
@@ -11,7 +11,6 @@ const Background = styled.View<BackgroundProps>`
   width: 100%;
   background: ${({ color }) => color};
   border-radius: 10px;
-  margin-bottom: 24px;
 `;
 
 interface BulletsContainerProps {

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -9,6 +9,7 @@ import React, {
 import { Animated, Easing, RefreshControl } from "react-native";
 import styled from "styled-components/native";
 import { useFocusEffect } from "@react-navigation/native";
+import moment from "moment";
 import { hasGeneratedSymmetricKey } from "../../services/encryption/EncryptionService";
 import { Modal } from "../../components/molecules/Modal";
 
@@ -159,8 +160,9 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   );
 
   const completions = caseData?.details?.completions?.requested || [];
-  const completionDuedate =
-    caseData?.details?.workflow?.application?.completionduedate || "";
+  const completionDuedate = caseData?.details?.completions?.dueDate
+    ? moment(caseData?.details?.completions?.dueDate).format("YYYY-MM-DD")
+    : "";
 
   const statusType = caseData?.status?.type || "";
   const isNotStarted = statusType.includes(NOT_STARTED);

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -159,6 +159,8 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
   );
 
   const completions = caseData?.details?.completions?.requested || [];
+  const completionDuedate =
+    caseData?.details?.workflow?.application?.completionduedate || "";
 
   const statusType = caseData?.status?.type || "";
   const isNotStarted = statusType.includes(NOT_STARTED);
@@ -327,6 +329,7 @@ const computeCaseCardComponent = (caseData, navigation, authContext, extra) => {
       onButtonClick={buttonProps.onClick}
       buttonColorScheme={buttonProps.colorSchema || colorSchema}
       completions={unApprovedCompletionDescriptions}
+      completionDuedate={completionDuedate}
     />
   );
 };

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -241,6 +241,9 @@ const computeCaseCardComponent = (
       ? getUnapprovedCompletionDescriptions(completions)
       : [];
 
+  const completionDuedate =
+    caseData?.details?.workflow?.application?.completionduedate || "";
+
   return (
     <CaseCard
       colorSchema={colorSchema}
@@ -262,6 +265,7 @@ const computeCaseCardComponent = (
       onButtonClick={isClosed ? toggleModal : buttonProps.onClick}
       buttonIconName={isClosed ? "remove-red-eye" : "arrow-forward"}
       completions={unApprovedCompletionDescriptions}
+      completionDuedate={completionDuedate}
     />
   );
 };

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -9,6 +9,7 @@ import { View, Animated, Easing, ScrollView } from "react-native";
 import PropTypes from "prop-types";
 import styled from "styled-components/native";
 import { useIsFocused } from "@react-navigation/native";
+import moment from "moment";
 import { CaseState } from "../../store/CaseContext";
 import FormContext from "../../store/FormContext";
 import icons from "../../helpers/Icons";
@@ -241,8 +242,9 @@ const computeCaseCardComponent = (
       ? getUnapprovedCompletionDescriptions(completions)
       : [];
 
-  const completionDuedate =
-    caseData?.details?.workflow?.application?.completionduedate || "";
+  const completionDuedate = caseData?.details?.completions?.dueDate
+    ? moment(caseData?.details?.completions?.dueDate).format("YYYY-MM-DD")
+    : "";
 
   return (
     <CaseCard

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -43,6 +43,7 @@ export interface Completions {
   requested: RequestedCompletions[];
   randomCheck: boolean;
   completed: boolean;
+  dueDate: number;
 }
 
 export interface Period {

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -52,7 +52,6 @@ export interface Period {
 
 export interface Application {
   periodstartdate: string;
-  completionduedate: string;
 }
 
 export interface Workflow {


### PR DESCRIPTION
## Explain the changes you’ve made
A case card now shows the due date for both `komplettering` and `stickprov`.

## Explain why these changes are made
In order to prevent users from sending in their `komplettering` and/or `stickprov` too late, we want to start showing them when the last day of submitting the form is.

## Explain your solution
Utilised the completionDueDate property which exists in a case for `komplettering` and `stickprov`. This value is then displayed in the card.

Added a new property in the casecard component which then displays the due date. 

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a case for komplettering and/or stickprov.
4. Make sure the `dueDate` property is set in details.completions and to be a number in milliseconds

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

![simulator_screenshot_B938D4A2-E1D3-4A66-8C77-8A8080F89C68](https://user-images.githubusercontent.com/81250970/156342775-c48ff1ae-fbf7-490e-92e6-0a83c194f62c.png)

