### PR TITLE
fix/hide form close button 

### DIFF
--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -225,6 +225,10 @@ function Step({
     });
   };
 
+  const showCloseFormButton = !actions.some(
+    ({ type = "" }) => type === "close"
+  );
+
   return (
     <StepContainer>
       <KeyboardAwareScrollView
@@ -323,6 +327,7 @@ function Step({
 
       <StepBackNavigation
         showBackButton={isBackBtnVisible && isFormEditable}
+        showCloseButton={showCloseFormButton}
         primary={!isSubstep}
         isSubstep={isSubstep}
         onBack={backButtonBehavior}


### PR DESCRIPTION
## Explain the changes you’ve made
Hide close form button (see picture below) if there also is a form action for closing the form.

![image](https://user-images.githubusercontent.com/81250970/156357707-ddca89f2-ec4a-4015-ac97-51e726031d3b.png)

## Explain why these changes are made
When closing the modal with the close form button, we are updating the case in our backend with the current position in the form. So if a user has signed a form and then continue to the next step and closes the form, that step is then saved.
This will cause an error for the "medsökande" since that person will then only be redirected to the latest step where the current user were in, preventing the "medsökande" to sign the form.

So by removing the close for button if there is an step action which do the same, we are preventing this to occur. 

## Explain your solution
Checking the actions array if there is an action with the type of "close", if it is, then hide the button.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a form with a step action with type `close`. Preferably two actions with types `close` and/or `next`
4. The close form button should not be visible if an action of type `close` exists.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
