### PR TITLE
Feat/update textreplacement

### DIFF
--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -62,6 +62,7 @@ interface Props {
   editable: boolean;
   completions: RequestedCompletions[];
   persons: Person[];
+  encryptionPin: string;
 }
 
 export const defaultInitialPosition: FormPosition = {
@@ -98,6 +99,7 @@ const Form: React.FC<Props> = ({
   editable,
   completions,
   persons,
+  encryptionPin,
 }) => {
   const initialState: FormReducerState = {
     submitted: false,
@@ -113,6 +115,7 @@ const Form: React.FC<Props> = ({
     period,
     editable,
     persons,
+    encryptionPin,
   };
 
   const {

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -1,11 +1,11 @@
+import { PartnerInfo, User } from "app/types/UserTypes";
+import { Person, PersonRole } from "app/types/Case";
 import { Question, StepperActions } from "../../../types/FormTypes";
 import { replaceMarkdownTextInSteps } from "./textReplacement";
 import { FormReducerState } from "./useForm";
 import { validateInput } from "../../../helpers/ValidationHelper";
 import { evaluateConditionalExpression } from "../../../helpers/conditionParser";
 import { deepCopy } from "../../../helpers/Objects";
-import { PartnerInfo, User } from "app/types/UserTypes";
-import { Person, PersonRole } from "app/types/Case";
 
 function computePartnerPersonInfo(person: Person): PartnerInfo {
   return {
@@ -30,6 +30,7 @@ export function replaceMarkdownText(state: FormReducerState) {
     period,
     formAnswers: { partnerInfo },
     persons,
+    encryptionPin,
   } = state;
 
   const partnerPerson = findPersonByRole(persons, "coApplicant");
@@ -50,7 +51,8 @@ export function replaceMarkdownText(state: FormReducerState) {
     steps,
     computedApplicant,
     period,
-    computedPartnerInfo
+    computedPartnerInfo,
+    encryptionPin
   );
   return {
     ...state,

--- a/source/containers/Form/hooks/test/textReplacement.test.ts
+++ b/source/containers/Form/hooks/test/textReplacement.test.ts
@@ -47,7 +47,8 @@ const doTest = (
   placeholder: string,
   expected: string,
   partner: PartnerInfo | undefined = undefined,
-  period: Period = basePeriod
+  period: Period = basePeriod,
+  encryptionPin = "1234"
 ): void => {
   const res = replaceMarkdownTextInSteps(
     [
@@ -103,12 +104,14 @@ const doTest = (
               },
             ],
           },
+          { ...baseQuestion, label: placeholder },
         ],
       },
     ],
     mockedUserData,
     period,
-    partner
+    partner,
+    encryptionPin
   );
 
   expect(res[0].title).toBe(expected);
@@ -125,6 +128,8 @@ const doTest = (
   expect(res[0]?.questions?.[2].text).toBe(expected);
   expect(res[0]?.questions?.[2].heading).toBe(expected);
   expect(res[0]?.questions?.[2].title).toBe(expected);
+
+  expect(res[0]?.questions?.[3].label).toBe(expected);
 };
 
 jest.useFakeTimers().setSystemTime(new Date("2021-01-01").getTime());
@@ -190,6 +195,13 @@ describe("replaceMarkdownTextInSteps", () => {
     describe("Doesn't have a partner", () => {
       it.each([["#partnerName", ""]])("Replaces %s with %s", doTest);
     });
+  });
+  describe("Encryption pin", () => {
+    it.each([["#encryptionPin", "1111"]])(
+      "Replaces %s with %s",
+      (placeholder, expected) =>
+        doTest(placeholder, expected, undefined, undefined, expected)
+    );
   });
 });
 

--- a/source/containers/Form/hooks/test/textReplacement.test.ts
+++ b/source/containers/Form/hooks/test/textReplacement.test.ts
@@ -196,6 +196,7 @@ describe("replaceMarkdownTextInSteps", () => {
       it.each([["#partnerName", ""]])("Replaces %s with %s", doTest);
     });
   });
+
   describe("Encryption pin", () => {
     it.each([["#encryptionPin", "1111"]])(
       "Replaces %s with %s",

--- a/source/containers/Form/hooks/test/textReplacement.test.ts
+++ b/source/containers/Form/hooks/test/textReplacement.test.ts
@@ -80,6 +80,13 @@ const doTest = (
                 inputSelectValue: "checkbox",
               },
             ],
+            components: [
+              {
+                text: placeholder,
+                type: "text",
+                heading: "some sort of heading",
+              },
+            ],
           },
           {
             ...baseQuestion,
@@ -112,6 +119,7 @@ const doTest = (
   expect(res[0]?.questions?.[1].categories?.[1].description).toBe(expected);
 
   expect(res[0]?.questions?.[1].items?.[0].title).toBe(expected);
+  expect(res[0]?.questions?.[1].components?.[0].text).toBe(expected);
   expect(res[0]?.questions?.[2].inputs?.[0].label).toBe(expected);
   expect(res[0]?.questions?.[2].inputs?.[0].title).toBe(expected);
   expect(res[0]?.questions?.[2].text).toBe(expected);

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -72,6 +72,7 @@ const replacementRules = [
   ["#year", "date.currentYear"], // this is the current year of next month
   ["#today", "date.currentDate"], // this is the current year of next month
   ["#partnerName", "partner.partnerName"],
+  ["#encryptionPin", "encryptionPin"],
 ];
 
 const swedishMonthTable = [
@@ -148,7 +149,8 @@ const computeText = (
   descriptor: string,
   user: User,
   period?: FormPeriod,
-  partner?: PartnerInfo
+  partner?: PartnerInfo,
+  encryptionPin?: string
 ): string => {
   const strArr = descriptor.split(".");
   if (strArr[0] === "user") {
@@ -160,6 +162,9 @@ const computeText = (
   if (strArr[0] === "date") {
     return replaceDates(strArr, period);
   }
+  if (strArr[0] === "encryptionPin" && encryptionPin) {
+    return encryptionPin;
+  }
   return "";
 };
 
@@ -167,13 +172,17 @@ export const replaceText = (
   text: string,
   user: User,
   period?: FormPeriod,
-  partner?: PartnerInfo
+  partner?: PartnerInfo,
+  encryptionPin?: string
 ) => {
   // This way of doing it might be a bit overkill, but the idea is that this in principle
   // allows for nesting replacement rules and then applying them in order one after the other.
   let res = text;
   replacementRules.forEach(([template, descriptor]) => {
-    res = res.replace(template, computeText(descriptor, user, period, partner));
+    res = res.replace(
+      template,
+      computeText(descriptor, user, period, partner, encryptionPin)
+    );
   });
   return res;
 };
@@ -188,31 +197,56 @@ export const replaceMarkdownTextInSteps = (
   steps: Step[],
   user: User,
   period?: FormPeriod,
-  partner?: PartnerInfo
+  partner?: PartnerInfo,
+  encryptionPin?: string
 ): Step[] => {
   const newSteps = steps.map((step) => {
     if (step.questions) {
       step.questions = step.questions.map((qs) => {
         if (qs.text && qs.text !== "") {
-          qs.text = replaceText(qs.text, user, period, partner);
+          qs.text = replaceText(qs.text, user, period, partner, encryptionPin);
         }
 
         if (qs.label && qs.label !== "") {
-          qs.label = replaceText(qs.label, user, period, partner);
+          qs.label = replaceText(
+            qs.label,
+            user,
+            period,
+            partner,
+            encryptionPin
+          );
         }
 
         if (qs.title && qs.title !== "") {
-          qs.title = replaceText(qs.title, user, period, partner);
+          qs.title = replaceText(
+            qs.title,
+            user,
+            period,
+            partner,
+            encryptionPin
+          );
         }
 
         if (qs.heading && qs.heading !== "") {
-          qs.heading = replaceText(qs.heading, user, period, partner);
+          qs.heading = replaceText(
+            qs.heading,
+            user,
+            period,
+            partner,
+            encryptionPin
+          );
         }
 
         if (qs.items) {
           qs.items = qs.items.map((item) => ({
             ...item,
-            title: replaceText(item.title, user, period, partner),
+            title: replaceText(
+              item.title,
+              user,
+              period,
+              partner,
+              encryptionPin
+            ),
           }));
         }
 
@@ -223,7 +257,8 @@ export const replaceMarkdownTextInSteps = (
               category.description,
               user,
               period,
-              partner
+              partner,
+              encryptionPin
             ),
           }));
         }
@@ -232,25 +267,40 @@ export const replaceMarkdownTextInSteps = (
           qs.inputs = qs.inputs.map((input) => ({
             ...input,
             label:
-              input.label && replaceText(input.label, user, period, partner),
+              input.label &&
+              replaceText(input.label, user, period, partner, encryptionPin),
             title:
-              input.title && replaceText(input.title, user, period, partner),
+              input.title &&
+              replaceText(input.title, user, period, partner, encryptionPin),
           }));
         }
 
         if (qs.components) {
           qs.components = qs.components.map((input) => ({
             ...input,
-            text: replaceText(input.text, user, period, partner),
+            text: replaceText(input.text, user, period, partner, encryptionPin),
           }));
         }
 
         return qs;
       });
     }
-    if (step.title) step.title = replaceText(step.title, user, period, partner);
+    if (step.title)
+      step.title = replaceText(
+        step.title,
+        user,
+        period,
+        partner,
+        encryptionPin
+      );
     if (step.description)
-      step.description = replaceText(step.description, user, period, partner);
+      step.description = replaceText(
+        step.description,
+        user,
+        period,
+        partner,
+        encryptionPin
+      );
     return step;
   });
 

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -238,6 +238,13 @@ export const replaceMarkdownTextInSteps = (
           }));
         }
 
+        if (qs.components) {
+          qs.components = qs.components.map((input) => ({
+            ...input,
+            text: replaceText(input.text, user, period, partner),
+          }));
+        }
+
         return qs;
       });
     }

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -30,6 +30,7 @@ export interface FormReducerState {
   period?: FormPeriod;
   editable?: boolean;
   persons: Person[];
+  encryptionPin: string;
 }
 
 function useForm(initialState: FormReducerState) {

--- a/source/screens/FormCaseScreen.tsx
+++ b/source/screens/FormCaseScreen.tsx
@@ -16,6 +16,7 @@ import {
   convertAnswerArrayToObject,
 } from "../helpers/CaseDataConverter";
 import { getPasswordForForm } from "../services/encryption/CaseEncryptionHelper";
+import { to } from "../helpers/Misc";
 
 import {
   Case,
@@ -90,13 +91,13 @@ const FormCaseScreen = ({
           const encryption =
             initCase?.forms?.[initCase.currentFormId].encryption ?? {};
 
-          const pinCode =
-            ((await getPasswordForForm(
-              { encryption } as AnsweredForm,
-              user
-            )) as string) ?? "";
+          const [, pinCode] = await to(
+            getPasswordForForm({ encryption } as AnsweredForm, user)
+          );
 
-          setEncryptionPin(pinCode);
+          const pinCodeToUse = (pinCode ?? "") as string;
+
+          setEncryptionPin(pinCodeToUse);
           void getForm(initCase.currentFormId);
           setCurrentFormId(initCase.currentFormId);
         }

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -81,6 +81,7 @@ export interface Question {
   text?: string;
   labelLine?: boolean;
   categories?: { category: string; description: string }[];
+  components?: Components[];
 }
 
 export type ActionType =
@@ -98,6 +99,15 @@ export interface Action {
   hasCondition?: boolean;
   conditionalOn?: string;
   signMessage?: string;
+}
+
+export interface Components {
+  type: string;
+  text: string;
+  italic?: boolean;
+  closeButtonText?: string;
+  heading: string;
+  markdownText?: string;
 }
 
 export interface Banner {


### PR DESCRIPTION
## Explain the changes you’ve made
Update text replacement to include `#partnerName` and `#encryptionPin`. Also added the ability to do text replacement in the `components` property in a quetion.

## Explain why these changes are made
Since the `Card` component in form-builder needs to be able to show encryption pin and partner name, the textreplacement logic needed to be updated.

## Explain your solution
* Included the `components` property in textReplacement
* Added new rule to replacing encryption code
* Provide encryptionPin to the `Form` component to be able to do text replacement on that
* Update tests

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a form with the `Card` component
4. include `#encryptionPin` and/or `#partnerName` in the text in the component
5. Run the form in a simulator and make sure that the encryption pin is shown 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

![image](https://user-images.githubusercontent.com/81250970/158785992-db73307a-99f1-430a-b56e-3a5bb02cad1b.png)

