### PR TITLE
Fix/pdf upload

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -262,7 +262,7 @@ PODS:
     - react-native-config/App (= 1.4.0)
   - react-native-config/App (1.4.0):
     - React-Core
-  - react-native-document-picker (5.3.0):
+  - react-native-document-picker (8.0.0):
     - React-Core
   - react-native-network-info (5.2.1):
     - React
@@ -380,7 +380,7 @@ PODS:
     - React-Core
   - RNVectorIcons (7.1.0):
     - React
-  - TOCropViewController (2.6.0)
+  - TOCropViewController (2.6.1)
   - toolbar-android (0.1.0-rc.2):
     - React
   - Yoga (1.14.0)
@@ -598,7 +598,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 51246358c40fe0d0c678a8ed1ba40fbd60f8fae3
+  FBReactNativeSpec: e684313f7bad785e52bef46967b2161b87fa64d7
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -624,7 +624,7 @@ SPEC CHECKSUMS:
   react-native-background-timer: 17ea5e06803401a379ebf1f20505b793ac44d0fe
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-config: f309b9ac19456dea12325699af51e0fa0217ce6a
-  react-native-document-picker: 226068006be4c52f8ef7f32d855ee025a12e9e64
+  react-native-document-picker: 429972f7ece4463aa5bcdd789622b3a674a3c5d1
   react-native-network-info: d1290ffc0bd0709e11436f5b8d7f605dcc5c4530
   react-native-pdf: ef641e79a6d550cfabe5d7ec1916799726514c43
   react-native-progress-bar-android: be43138ab7da30d51fc038bafa98e9ed594d0c40
@@ -658,7 +658,7 @@ SPEC CHECKSUMS:
   RNReanimated: 514a11da3a2bcc6c3dfd9de32b38e2b9bf101926
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
-  TOCropViewController: 3105367e808b7d3d886a74ff59bf4804e7d3ab38
+  TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   toolbar-android: 85f3ef4d691469f2d304e7dee4bca013aa1ba1ff
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -598,7 +598,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: e684313f7bad785e52bef46967b2161b87fa64d7
+  FBReactNativeSpec: 51246358c40fe0d0c678a8ed1ba40fbd60f8fae3
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -596,7 +596,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
   FBReactNativeSpec: 51246358c40fe0d0c678a8ed1ba40fbd60f8fae3
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-collapsible": "^1.6.0",
     "react-native-config": "1.4.0",
     "react-native-device-info": "^8.4.8",
-    "react-native-document-picker": "^5.0.0",
+    "react-native-document-picker": "^8.0.0",
     "react-native-elements": "^3.0.0-alpha.1",
     "react-native-exception-handler": "^2.10.10",
     "react-native-fs": "^2.16.6",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-native-storybook-loader": "^2.0.4",
     "react-native-swiper": "^1.6.0",
     "react-native-tab-view": "^2.15.2",
+    "react-native-uuid": "^2.0.1",
     "react-native-vector-icons": "^7.1.0",
     "react-native-web": "^0.14.10",
     "react-native-webview": "^11.0.2",

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import { NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
-import { Image as CropPickerImage } from 'react-native-image-crop-picker';
-import styled from 'styled-components/native';
-import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
-import ImageItem from './ImageItem';
-import { remove } from '../../../helpers/ApiRequest';
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { NativeSyntheticEvent, NativeScrollEvent } from "react-native";
+import { Image as CropPickerImage } from "react-native-image-crop-picker";
+import styled from "styled-components/native";
+import HorizontalScrollIndicator from "../../atoms/HorizontalScrollIndicator";
+import ImageItem from "./ImageItem";
+import { remove } from "../../../helpers/ApiRequest";
+import { AllowedFileTypes } from "../../../helpers/FileUpload";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -24,6 +25,7 @@ export interface Image extends CropPickerImage {
   url?: string;
   index?: number;
   questionId: string;
+  fileType: AllowedFileTypes;
 }
 
 interface Props {
@@ -33,7 +35,8 @@ interface Props {
 }
 
 const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
-  const [horizontalScrollPercentage, setHorizontalScrollPercentage] = useState(0);
+  const [horizontalScrollPercentage, setHorizontalScrollPercentage] =
+    useState(0);
 
   const deleteImageFromCloudStorage = async (image: Image) => {
     remove(`users/me/attachments/${image.uploadedFileName}`);
@@ -41,7 +44,9 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
   const removeImage = (image: Image) => {
     const answer: Image[] = answers[image.questionId];
     if (answer && Array.isArray(answer)) {
-      const answerWithImageRemoved = answer.filter((img) => img.path !== image.path);
+      const answerWithImageRemoved = answer.filter(
+        (img) => img.path !== image.path
+      );
       onChange(answerWithImageRemoved, image.questionId);
     }
     deleteImageFromCloudStorage(image);
@@ -49,7 +54,9 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
 
   const updateImage = (image: Image) => (newImage: Image) => {
     const answer: Image[] = answers[image.questionId];
-    const index = answer.findIndex((img) => img.uploadedFileName === image.uploadedFileName);
+    const index = answer.findIndex(
+      (img) => img.uploadedFileName === image.uploadedFileName
+    );
     answer[index] = newImage;
     onChange(answer, image.questionId);
   };
@@ -57,12 +64,17 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     setHorizontalScrollPercentage(
       event.nativeEvent.contentOffset.x /
-        (event.nativeEvent.contentSize.width - event.nativeEvent.layoutMeasurement.width)
+        (event.nativeEvent.contentSize.width -
+          event.nativeEvent.layoutMeasurement.width)
     );
   };
   return (
     <Wrapper>
-      <Container horizontal onScroll={handleScroll} showsHorizontalScrollIndicator={false}>
+      <Container
+        horizontal
+        onScroll={handleScroll}
+        showsHorizontalScrollIndicator={false}
+      >
         {images.length > 0 &&
           images.map((image, index) => (
             <ImageItem
@@ -75,7 +87,9 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
             />
           ))}
       </Container>
-      {images.length > 2 && <HorizontalScrollIndicator percentage={horizontalScrollPercentage} />}
+      {images.length > 2 && (
+        <HorizontalScrollIndicator percentage={horizontalScrollPercentage} />
+      )}
     </Wrapper>
   );
 };

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -26,6 +26,7 @@ export interface Image extends CropPickerImage {
   index?: number;
   questionId: string;
   fileType: AllowedFileTypes;
+  id: string;
 }
 
 interface Props {
@@ -76,9 +77,9 @@ const ImageDisplay: React.FC<Props> = ({ images, answers, onChange }) => {
         showsHorizontalScrollIndicator={false}
       >
         {images.length > 0 &&
-          images.map((image, index) => (
+          images.map((image) => (
             <ImageItem
-              key={`${image.path}-${index}`}
+              key={image.id}
               image={image}
               onRemove={() => {
                 removeImage(image);

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -69,7 +69,7 @@ interface Props {
   colorSchema?: PrimaryColor;
   maxImages?: number;
   id: string;
-  preferredImageName?: string;
+  preferredFileName?: string;
 }
 
 const MAX_IMAGE_SIZE_BYTES = 7 * 1000 * 1000;
@@ -82,7 +82,7 @@ const ImageUploader: React.FC<Props> = ({
   colorSchema,
   maxImages,
   id,
-  preferredImageName,
+  preferredFileName,
   ...rest
 }) => {
   const [choiceModalVisible, toggleModal] = useModal();
@@ -100,9 +100,9 @@ const ImageUploader: React.FC<Props> = ({
     let updatedImages =
       images === "" ? [...newImages] : [...images, ...newImages];
 
-    if (preferredImageName) {
+    if (preferredFileName) {
       updatedImages = updatedImages.map((image, index) =>
-        renameImageWithSuffix(image, preferredImageName, index.toString())
+        renameImageWithSuffix(image, preferredFileName, index.toString())
       );
     }
 

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Alert, TouchableOpacity } from "react-native";
 import ImagePicker, { ImageOrVideo } from "react-native-image-crop-picker";
+import uuid from "react-native-uuid";
 import styled from "styled-components/native";
 import { Text, Button, Icon, Label } from "../../atoms";
 import { BackgroundBlurWrapper } from "../../atoms/BackgroundBlur";
@@ -126,6 +127,7 @@ const ImageUploader: React.FC<Props> = ({
     height: rawImage.height,
     size: rawImage.size,
     fileType: (rawImage.path as string).split(".").pop() as AllowedFileTypes,
+    id: uuid.v4(),
     mime:
       rawImage?.filename?.split(".")?.pop() ??
       (rawImage.path?.split(".")?.pop() as string),

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -94,7 +94,7 @@ const ImageUploader: React.FC<Props> = ({
     suffix: string
   ) => ({
     ...image,
-    filename: `${baseName}_${suffix}.${ext}`,
+    filename: `${baseName}_${suffix}${ext}`,
   });
 
   const addImagesToState = (newImages: Image[]) => {

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -11,7 +11,7 @@ import {
   PrimaryColor,
 } from "../../../styles/themeHelpers";
 import ImageDisplay, { Image } from "../ImageDisplay/ImageDisplay";
-import { AllowedFileTypes } from "../../../helpers/FileUpload";
+import { AllowedFileTypes, splitFilePath } from "../../../helpers/FileUpload";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -90,10 +90,11 @@ const ImageUploader: React.FC<Props> = ({
   const renameImageWithSuffix = (
     image: Image,
     baseName: string,
+    ext: string,
     suffix: string
   ) => ({
     ...image,
-    filename: `${baseName}_${suffix}`,
+    filename: `${baseName}_${suffix}.${ext}`,
   });
 
   const addImagesToState = (newImages: Image[]) => {
@@ -102,7 +103,12 @@ const ImageUploader: React.FC<Props> = ({
 
     if (preferredFileName) {
       updatedImages = updatedImages.map((image, index) =>
-        renameImageWithSuffix(image, preferredFileName, index.toString())
+        renameImageWithSuffix(
+          image,
+          preferredFileName,
+          splitFilePath(image.filename).ext,
+          index.toString()
+        )
       );
     }
 

--- a/source/components/molecules/ImageUploader/ImageUploader.tsx
+++ b/source/components/molecules/ImageUploader/ImageUploader.tsx
@@ -6,12 +6,12 @@ import styled from "styled-components/native";
 import { Text, Button, Icon, Label } from "../../atoms";
 import { BackgroundBlurWrapper } from "../../atoms/BackgroundBlur";
 import { Modal, useModal } from "../Modal";
-import { getBlob, uploadFile } from "../../../helpers/FileUpload";
 import {
   getValidColorSchema,
   PrimaryColor,
 } from "../../../styles/themeHelpers";
 import ImageDisplay, { Image } from "../ImageDisplay/ImageDisplay";
+import { AllowedFileTypes } from "../../../helpers/FileUpload";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -60,34 +60,6 @@ const PopupButton = styled(Button)`
 `;
 
 export type ImageStatus = "loading" | "uploaded" | "error";
-
-export const uploadImage = async (image: Image) => {
-  const imageFileType = (image.path as string).split(".").pop();
-
-  if (!["jpg", "jpeg", "png"].includes(imageFileType)) {
-    console.error(
-      `Trying to upload a forbidden type of image, ${imageFileType}, allowed file types are [jpg, jpeg, png].`
-    );
-  }
-
-  const data: Blob = await getBlob(image.path);
-  const filename = image.filename ?? (image.path as string).split("/").pop();
-  const uploadResponse = await uploadFile({
-    endpoint: "users/me/attachments",
-    fileName: filename,
-    fileType: imageFileType as "jpg" | "jpeg" | "png",
-    data,
-  });
-
-  if (uploadResponse.error) {
-    throw uploadResponse?.message;
-  }
-
-  image.uploadedFileName = uploadResponse.uploadedFileName;
-  image.url = uploadResponse.url;
-
-  return image;
-};
 
 interface Props {
   buttonText: string;
@@ -147,8 +119,10 @@ const ImageUploader: React.FC<Props> = ({
     width: rawImage.width,
     height: rawImage.height,
     size: rawImage.size,
+    fileType: (rawImage.path as string).split(".").pop() as AllowedFileTypes,
     mime:
-      rawImage?.filename?.split(".")?.pop() ?? rawImage.path?.split(".")?.pop(),
+      rawImage?.filename?.split(".")?.pop() ??
+      (rawImage.path?.split(".")?.pop() as string),
   });
 
   const addImagesFromLibrary = async () => {

--- a/source/components/molecules/PdfDisplay/PdfDisplay.tsx
+++ b/source/components/molecules/PdfDisplay/PdfDisplay.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import { NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
-import styled from 'styled-components/native';
-import { DocumentPickerResponse } from 'react-native-document-picker';
-import HorizontalScrollIndicator from '../../atoms/HorizontalScrollIndicator';
-import PdfItem from './PdfItem';
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { NativeSyntheticEvent, NativeScrollEvent } from "react-native";
+import styled from "styled-components/native";
+import { DocumentPickerResponse } from "react-native-document-picker";
+import HorizontalScrollIndicator from "../../atoms/HorizontalScrollIndicator";
+import PdfItem from "./PdfItem";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -31,10 +31,15 @@ interface Props {
 }
 
 const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
-  const [horizontalScrollPercentage, setHorizontalScrollPercentage] = useState(0);
+  const [horizontalScrollPercentage, setHorizontalScrollPercentage] =
+    useState(0);
 
   const deletePdfFromCloudStorage = async (pdf: Pdf) => {
-    console.log('Placeholder: not implemented yet in API, want to delete pdf ', pdf.name, pdf.uri);
+    console.log(
+      "Placeholder: not implemented yet in API, want to delete pdf ",
+      pdf.name,
+      pdf.uri
+    );
   };
   const removePdf = (pdf: Pdf) => {
     const answer: Pdf[] = answers[pdf.questionId];
@@ -48,13 +53,18 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     setHorizontalScrollPercentage(
       event.nativeEvent.contentOffset.x /
-        (event.nativeEvent.contentSize.width - event.nativeEvent.layoutMeasurement.width)
+        (event.nativeEvent.contentSize.width -
+          event.nativeEvent.layoutMeasurement.width)
     );
   };
 
   return (
     <Wrapper>
-      <Container horizontal onScroll={handleScroll} showsHorizontalScrollIndicator={false}>
+      <Container
+        horizontal
+        onScroll={handleScroll}
+        showsHorizontalScrollIndicator={false}
+      >
         {pdfs.length > 0 &&
           pdfs.map((pdf, index) => (
             <PdfItem
@@ -66,7 +76,9 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
             />
           ))}
       </Container>
-      {pdfs.length > 2 && <HorizontalScrollIndicator percentage={horizontalScrollPercentage} />}
+      {pdfs.length > 2 && (
+        <HorizontalScrollIndicator percentage={horizontalScrollPercentage} />
+      )}
     </Wrapper>
   );
 };

--- a/source/components/molecules/PdfDisplay/PdfDisplay.tsx
+++ b/source/components/molecules/PdfDisplay/PdfDisplay.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components/native";
 import { DocumentPickerResponse } from "react-native-document-picker";
 import HorizontalScrollIndicator from "../../atoms/HorizontalScrollIndicator";
 import PdfItem from "./PdfItem";
+import { AllowedFileTypes } from "../../../helpers/FileUpload";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -21,6 +22,13 @@ export interface Pdf extends DocumentPickerResponse {
   uploadedFileName?: string;
   url?: string;
   questionId: string;
+  fileCopyUri: string;
+  name: string;
+  size: number;
+  type: string;
+  fileType: AllowedFileTypes;
+  path: string;
+  filename?: string;
 }
 
 export interface UploadedPdf extends Pdf {

--- a/source/components/molecules/PdfDisplay/PdfDisplay.tsx
+++ b/source/components/molecules/PdfDisplay/PdfDisplay.tsx
@@ -58,9 +58,7 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
     const answer = answers[pdf.questionId] as UploadedPdf[];
 
     if (answer && Array.isArray(answer)) {
-      const answerWithPdfRemoved = answer.filter(
-        (p) => pdf.uploadedFileName !== p.uploadedFileName
-      );
+      const answerWithPdfRemoved = answer.filter((p) => pdf.path !== p.path);
       onChange(answerWithPdfRemoved, pdf.questionId);
     }
 

--- a/source/components/molecules/PdfDisplay/PdfDisplay.tsx
+++ b/source/components/molecules/PdfDisplay/PdfDisplay.tsx
@@ -85,7 +85,7 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
         {pdfs.length > 0 &&
           pdfs.map((pdf) => (
             <PdfItem
-              key={pdf.uploadedFileName}
+              key={pdf.path}
               pdf={pdf}
               onRemove={() => {
                 removePdf(pdf);

--- a/source/components/molecules/PdfDisplay/PdfDisplay.tsx
+++ b/source/components/molecules/PdfDisplay/PdfDisplay.tsx
@@ -29,6 +29,7 @@ export interface Pdf extends DocumentPickerResponse {
   fileType: AllowedFileTypes;
   path: string;
   filename?: string;
+  id: string;
 }
 
 export interface UploadedPdf extends Pdf {
@@ -58,7 +59,7 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
     const answer = answers[pdf.questionId] as UploadedPdf[];
 
     if (answer && Array.isArray(answer)) {
-      const answerWithPdfRemoved = answer.filter((p) => pdf.path !== p.path);
+      const answerWithPdfRemoved = answer.filter((p) => pdf.id !== p.id);
       onChange(answerWithPdfRemoved, pdf.questionId);
     }
 
@@ -83,7 +84,7 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
         {pdfs.length > 0 &&
           pdfs.map((pdf) => (
             <PdfItem
-              key={pdf.path}
+              key={pdf.id}
               pdf={pdf}
               onRemove={() => {
                 removePdf(pdf);

--- a/source/components/molecules/PdfDisplay/PdfDisplay.tsx
+++ b/source/components/molecules/PdfDisplay/PdfDisplay.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import PropTypes from "prop-types";
 import { NativeSyntheticEvent, NativeScrollEvent } from "react-native";
 import styled from "styled-components/native";
 import { DocumentPickerResponse } from "react-native-document-picker";
@@ -24,30 +23,40 @@ export interface Pdf extends DocumentPickerResponse {
   questionId: string;
 }
 
+export interface UploadedPdf extends Pdf {
+  uploadedFileName: string;
+  url: string;
+}
+
 interface Props {
-  pdfs: Pdf[];
-  answers: Record<string, any>;
-  onChange: (value: Record<string, any>[], id?: string) => void;
+  pdfs: UploadedPdf[];
+  answers: Record<string, unknown>;
+  onChange: (value: UploadedPdf[], id?: string) => void;
 }
 
 const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
   const [horizontalScrollPercentage, setHorizontalScrollPercentage] =
     useState(0);
 
-  const deletePdfFromCloudStorage = async (pdf: Pdf) => {
+  const deletePdfFromCloudStorage = async (pdf: UploadedPdf) => {
     console.log(
       "Placeholder: not implemented yet in API, want to delete pdf ",
       pdf.name,
       pdf.uri
     );
   };
-  const removePdf = (pdf: Pdf) => {
-    const answer: Pdf[] = answers[pdf.questionId];
+
+  const removePdf = (pdf: UploadedPdf) => {
+    const answer = answers[pdf.questionId] as UploadedPdf[];
+
     if (answer && Array.isArray(answer)) {
-      const answerWithPdfRemoved = answer.filter((p) => pdf.uri !== p.uri);
+      const answerWithPdfRemoved = answer.filter(
+        (p) => pdf.uploadedFileName !== p.uploadedFileName
+      );
       onChange(answerWithPdfRemoved, pdf.questionId);
     }
-    deletePdfFromCloudStorage(pdf);
+
+    void deletePdfFromCloudStorage(pdf);
   };
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -66,9 +75,9 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
         showsHorizontalScrollIndicator={false}
       >
         {pdfs.length > 0 &&
-          pdfs.map((pdf, index) => (
+          pdfs.map((pdf) => (
             <PdfItem
-              key={`${pdf.uri}-${index}`}
+              key={pdf.uploadedFileName}
               pdf={pdf}
               onRemove={() => {
                 removePdf(pdf);
@@ -81,12 +90,6 @@ const PdfDisplay: React.FC<Props> = ({ pdfs, answers, onChange }) => {
       )}
     </Wrapper>
   );
-};
-
-PdfDisplay.propTypes = {
-  pdfs: PropTypes.arrayOf(PropTypes.object),
-  answers: PropTypes.object,
-  onChange: PropTypes.func,
 };
 
 export default PdfDisplay;

--- a/source/components/molecules/PdfDisplay/PdfItem.tsx
+++ b/source/components/molecules/PdfDisplay/PdfItem.tsx
@@ -70,7 +70,7 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
   };
 
   return (
-    <>
+    <React.Fragment key={pdf.path}>
       <Flex>
         <DeleteBackground>
           <TouchableOpacity onPress={handleRemove} activeOpacity={0.1}>
@@ -104,7 +104,7 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
           </Button>
         </ButtonWrapper>
       </Modal>
-    </>
+    </React.Fragment>
   );
 };
 

--- a/source/components/molecules/PdfDisplay/PdfItem.tsx
+++ b/source/components/molecules/PdfDisplay/PdfItem.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
-import styled from 'styled-components/native';
-import { TouchableOpacity, GestureResponderEvent, Dimensions, Pressable } from 'react-native';
-import PdfView from 'react-native-pdf';
-import { Icon, Button, Text } from '../../atoms';
-import { Modal, useModal } from '../Modal';
-import { Pdf } from './PdfDisplay';
+import React from "react";
+import styled from "styled-components/native";
+import {
+  TouchableOpacity,
+  GestureResponderEvent,
+  Dimensions,
+  Pressable,
+} from "react-native";
+import PdfView from "react-native-pdf";
+import { Icon, Button, Text } from "../../atoms";
+import { Modal, useModal } from "../Modal";
+import { Pdf } from "./PdfDisplay";
 
 const Flex = styled.View`
   flex-direction: column;
@@ -39,11 +44,11 @@ const Container = styled.View`
   shadow-radius: 5px;
   border: 1px solid transparent;
 `;
-const PdfInModal = styled(PdfView)<{width: number; height: number}>`
+const PdfInModal = styled(PdfView)<{ width: number; height: number }>`
   background-color: white;
   flex: 1;
-  width: ${({width}) => width}px;
-  height: ${({height}) => height}px;
+  width: ${({ width }) => width}px;
+  height: ${({ height }) => height}px;
 `;
 const ButtonWrapper = styled.View`
   padding: 5px;
@@ -76,7 +81,12 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
           <Pressable onPress={toggleModal}>
             <PdfView
               source={{ uri: pdf.uri }}
-              style={{ flex: 1, width: 120, height: 170, backgroundColor: 'white' }}
+              style={{
+                flex: 1,
+                width: 120,
+                height: 170,
+                backgroundColor: "white",
+              }}
               singlePage
             />
           </Pressable>
@@ -85,8 +95,8 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
       <Modal visible={modalVisible} hide={toggleModal}>
         <PdfInModal
           source={{ uri: pdf.uri }}
-          width={Dimensions.get('window').width}
-          height={Dimensions.get('window').height * 0.89}
+          width={Dimensions.get("window").width}
+          height={Dimensions.get("window").height * 0.89}
         />
         <ButtonWrapper>
           <Button colorSchema="red" onClick={toggleModal}>

--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import styled from "styled-components/native";
 import DocumentPicker from "react-native-document-picker";
 import uuid from "react-native-uuid";
@@ -59,7 +59,7 @@ const PdfUploader: React.FC<Props> = ({
 }) => {
   const addUniqueId = (pdfFile: Pdf) => ({ ...pdfFile, id: uuid.v4() });
 
-  const addPdfFromLibrary = useCallback(async () => {
+  const addPdfFromLibrary = async () => {
     try {
       let newFiles = await DocumentPicker.pick({
         type: DocumentPicker.types.pdf,
@@ -99,7 +99,7 @@ const PdfUploader: React.FC<Props> = ({
         console.error("Error while adding pdf from library:", error);
       }
     }
-  }, [id, onChange, preferredFileName, answers]);
+  };
 
   const validColorSchema = getValidColorSchema(colorSchema ?? "Blue");
   return (

--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
-import styled from 'styled-components/native';
-import DocumentPicker, { DocumentPickerOptions } from 'react-native-document-picker';
-import { Text, Button, Icon } from '../../atoms';
-import { getBlob, uploadFile } from '../../../helpers/FileUpload';
-import { getValidColorSchema, PrimaryColor } from '../../../styles/themeHelpers';
-import PdfDisplay, { Pdf } from '../PdfDisplay/PdfDisplay';
+import React from "react";
+import styled from "styled-components/native";
+import DocumentPicker, {
+  DocumentPickerOptions,
+} from "react-native-document-picker";
+import { Text, Button, Icon } from "../../atoms";
+import { getBlob, uploadFile } from "../../../helpers/FileUpload";
+import {
+  getValidColorSchema,
+  PrimaryColor,
+} from "../../../styles/themeHelpers";
+import PdfDisplay, { Pdf } from "../PdfDisplay/PdfDisplay";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -23,7 +28,7 @@ const ButtonContainer = styled.View`
 
 interface Props {
   buttonText: string;
-  value: Pdf[] | '';
+  value: Pdf[] | "";
   answers: Record<string, any>;
   onChange: (value: Record<string, any>[], id?: string) => void;
   colorSchema?: PrimaryColor;
@@ -41,7 +46,7 @@ const PdfUploader: React.FC<Props> = ({
   id,
 }) => {
   const addPdf = (newPdf: Pdf) => {
-    const updatedPdfs = pdfs === '' ? [newPdf] : [...pdfs, newPdf];
+    const updatedPdfs = pdfs === "" ? [newPdf] : [...pdfs, newPdf];
     onChange(updatedPdfs);
     return updatedPdfs;
   };
@@ -49,9 +54,9 @@ const PdfUploader: React.FC<Props> = ({
   const uploadPdf = async (pdf: Pdf, index: number, updatedPdfs: Pdf[]) => {
     const data: Blob = await getBlob(pdf.uri);
     const uploadResponse = await uploadFile({
-      endpoint: 'users/me/attachments',
+      endpoint: "users/me/attachments",
       fileName: pdf.name,
-      fileType: 'pdf',
+      fileType: "pdf",
       data,
     });
 
@@ -65,7 +70,7 @@ const PdfUploader: React.FC<Props> = ({
   };
 
   const addPdfFromLibrary = async () => {
-    const pickerOptions: DocumentPickerOptions<'android' | 'ios'> = {
+    const pickerOptions: DocumentPickerOptions<"android" | "ios"> = {
       /* @ts-ignore */
       type: DocumentPicker.types.pdf,
     };
@@ -79,14 +84,16 @@ const PdfUploader: React.FC<Props> = ({
       uploadPdf(pdf, originalLength, updatedPdfs);
     } catch (error) {
       if (!DocumentPicker.isCancel(error))
-        console.error('Error while adding pdf from library:', error);
+        console.error("Error while adding pdf from library:", error);
     }
   };
 
   const validColorSchema = getValidColorSchema(colorSchema);
   return (
     <Wrapper>
-      {pdfs !== '' && <PdfDisplay pdfs={pdfs} onChange={onChange} answers={answers} />}
+      {pdfs !== "" && (
+        <PdfDisplay pdfs={pdfs} onChange={onChange} answers={answers} />
+      )}
       <ButtonContainer>
         <Button
           colorSchema={validColorSchema}
@@ -94,7 +101,10 @@ const PdfUploader: React.FC<Props> = ({
           disabled={maxDocuments && pdfs.length >= maxDocuments}
         >
           <Icon name="add" />
-          <Text> {buttonText && buttonText !== '' ? buttonText : 'Ladda upp PDF'}</Text>
+          <Text>
+            {" "}
+            {buttonText && buttonText !== "" ? buttonText : "Ladda upp PDF"}
+          </Text>
         </Button>
       </ButtonContainer>
     </Wrapper>

--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useCallback } from "react";
 import styled from "styled-components/native";
 import DocumentPicker from "react-native-document-picker";
+import uuid from "react-native-uuid";
+
 import { Text, Button, Icon } from "../../atoms";
 import {
   getValidColorSchema,
@@ -42,7 +44,7 @@ const renamePdfWithSuffix = (
   suffix: string
 ) => ({
   ...pdf,
-  filename: `${baseName}_${suffix}.${ext}`,
+  filename: `${baseName}_${suffix}${ext}`,
 });
 
 const PdfUploader: React.FC<Props> = ({
@@ -55,12 +57,19 @@ const PdfUploader: React.FC<Props> = ({
   preferredFileName,
   onChange,
 }) => {
-  const addPdfFromLibrary = async () => {
+  const addUniqueId = (pdfFile: Pdf) => ({ ...pdfFile, id: uuid.v4() });
+
+  const addPdfFromLibrary = useCallback(async () => {
     try {
-      let files = await DocumentPicker.pick({
+      let newFiles = await DocumentPicker.pick({
         type: DocumentPicker.types.pdf,
         allowMultiSelection: true,
       });
+
+      newFiles = newFiles.map((pdf) => addUniqueId(pdf as Pdf));
+
+      const oldFiles = answers[id] || [];
+      let files = [...(oldFiles as Pdf[]), ...newFiles];
 
       if (preferredFileName) {
         files = files.map((pdf, index) =>
@@ -90,7 +99,7 @@ const PdfUploader: React.FC<Props> = ({
         console.error("Error while adding pdf from library:", error);
       }
     }
-  };
+  }, [id, onChange, preferredFileName, answers]);
 
   const validColorSchema = getValidColorSchema(colorSchema ?? "Blue");
   return (

--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import styled from "styled-components/native";
-import DocumentPicker, {
-  DocumentPickerOptions,
-} from "react-native-document-picker";
+import DocumentPicker from "react-native-document-picker";
 import { Text, Button, Icon } from "../../atoms";
-import { getBlob, uploadFile } from "../../../helpers/FileUpload";
 import {
   getValidColorSchema,
   PrimaryColor,
 } from "../../../styles/themeHelpers";
-import PdfDisplay, { Pdf } from "../PdfDisplay/PdfDisplay";
+import PdfDisplay, { Pdf, UploadedPdf } from "../PdfDisplay/PdfDisplay";
+import { getBlob, uploadFile } from "../../../helpers/FileUpload";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -28,12 +26,51 @@ const ButtonContainer = styled.View`
 
 interface Props {
   buttonText: string;
-  value: Pdf[] | "";
-  answers: Record<string, any>;
-  onChange: (value: Record<string, any>[], id?: string) => void;
+  value: UploadedPdf[] | "";
+  answers: Record<string, unknown>;
+  onChange: (value: UploadedPdf[], id?: string) => void;
   colorSchema?: PrimaryColor;
   maxDocuments?: number;
   id: string;
+}
+
+async function uploadPdf(pdf: Pdf): Promise<UploadedPdf> {
+  const data: Blob = await getBlob(pdf.uri);
+  const uploadResponse = await uploadFile({
+    endpoint: "users/me/attachments",
+    fileName: pdf.name,
+    fileType: "pdf",
+    data,
+  });
+
+  if (uploadResponse.message) {
+    throw new Error(uploadResponse.message);
+  }
+
+  return {
+    ...pdf,
+    uploadedFileName: uploadResponse.uploadedFileName,
+    url: uploadResponse.url,
+  };
+}
+
+function handlePdfFailedUpload(pdf: Pdf, error: Error) {
+  console.error("failed to upload pdf", pdf.name, error);
+}
+
+async function handleUploadPdfs(pdfs: Pdf[]): Promise<UploadedPdf[]> {
+  const uploadedPdfs = await Promise.all(
+    pdfs.map(async (pdf) => {
+      try {
+        return await uploadPdf(pdf);
+      } catch (error) {
+        handlePdfFailedUpload(pdf, error as Error);
+        return null;
+      }
+    })
+  );
+
+  return uploadedPdfs.filter((pdf) => pdf) as UploadedPdf[];
 }
 
 const PdfUploader: React.FC<Props> = ({
@@ -45,50 +82,29 @@ const PdfUploader: React.FC<Props> = ({
   maxDocuments,
   id,
 }) => {
-  const addPdf = (newPdf: Pdf) => {
-    const updatedPdfs = pdfs === "" ? [newPdf] : [...pdfs, newPdf];
-    onChange(updatedPdfs);
-    return updatedPdfs;
-  };
-
-  const uploadPdf = async (pdf: Pdf, index: number, updatedPdfs: Pdf[]) => {
-    const data: Blob = await getBlob(pdf.uri);
-    const uploadResponse = await uploadFile({
-      endpoint: "users/me/attachments",
-      fileName: pdf.name,
-      fileType: "pdf",
-      data,
-    });
-
-    if (uploadResponse.error) {
-      updatedPdfs[index].errorMessage = uploadResponse.message;
-    } else {
-      updatedPdfs[index].uploadedFileName = uploadResponse.uploadedFilename;
-      updatedPdfs[index].url = uploadResponse.url;
-    }
-    onChange(updatedPdfs);
-  };
-
   const addPdfFromLibrary = async () => {
-    const pickerOptions: DocumentPickerOptions<"android" | "ios"> = {
-      /* @ts-ignore */
-      type: DocumentPicker.types.pdf,
-    };
-
     try {
-      const fileInfo = await DocumentPicker.pick(pickerOptions);
+      const files = await DocumentPicker.pick({
+        type: DocumentPicker.types.pdf,
+      });
 
-      const pdf: Pdf = { questionId: id, ...fileInfo };
-      const originalLength = pdfs.length;
-      const updatedPdfs = addPdf(pdf);
-      uploadPdf(pdf, originalLength, updatedPdfs);
+      const filesWithQuestionId: Pdf[] = files.map((file) => ({
+        ...file,
+        questionId: id,
+      }));
+
+      const uploadedPdfs = await handleUploadPdfs(filesWithQuestionId);
+
+      const newPdfs = [...(pdfs === "" ? [] : pdfs), ...uploadedPdfs];
+      onChange(newPdfs);
     } catch (error) {
-      if (!DocumentPicker.isCancel(error))
+      if (!DocumentPicker.isCancel(error as Error)) {
         console.error("Error while adding pdf from library:", error);
+      }
     }
   };
 
-  const validColorSchema = getValidColorSchema(colorSchema);
+  const validColorSchema = getValidColorSchema(colorSchema ?? "Blue");
   return (
     <Wrapper>
       {pdfs !== "" && (
@@ -98,7 +114,7 @@ const PdfUploader: React.FC<Props> = ({
         <Button
           colorSchema={validColorSchema}
           onClick={addPdfFromLibrary}
-          disabled={maxDocuments && pdfs.length >= maxDocuments}
+          disabled={!!maxDocuments && pdfs.length >= maxDocuments}
         >
           <Icon name="add" />
           <Text>

--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -59,6 +59,7 @@ const PdfUploader: React.FC<Props> = ({
     try {
       let files = await DocumentPicker.pick({
         type: DocumentPicker.types.pdf,
+        allowMultiSelection: true,
       });
 
       if (preferredFileName) {

--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -31,7 +31,7 @@ interface Props {
   colorSchema?: PrimaryColor;
   maxDocuments?: number;
   id: string;
-  preferredImageName?: string;
+  preferredFileName?: string;
   onChange: (value: Pdf[], id?: string) => void;
 }
 
@@ -47,7 +47,7 @@ const PdfUploader: React.FC<Props> = ({
   colorSchema,
   maxDocuments,
   id,
-  preferredImageName: preferredFileName,
+  preferredFileName,
   onChange,
 }) => {
   const addPdfFromLibrary = async () => {

--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -7,7 +7,7 @@ import {
   PrimaryColor,
 } from "../../../styles/themeHelpers";
 import PdfDisplay, { Pdf, UploadedPdf } from "../PdfDisplay/PdfDisplay";
-import { AllowedFileTypes } from "../../../helpers/FileUpload";
+import { AllowedFileTypes, splitFilePath } from "../../../helpers/FileUpload";
 
 const Wrapper = styled.View`
   padding-left: 0;
@@ -35,9 +35,14 @@ interface Props {
   onChange: (value: Pdf[], id?: string) => void;
 }
 
-const renameImageWithSuffix = (pdf: Pdf, baseName: string, suffix: string) => ({
+const renamePdfWithSuffix = (
+  pdf: Pdf,
+  baseName: string,
+  ext: string,
+  suffix: string
+) => ({
   ...pdf,
-  filename: `${baseName}_${suffix}`,
+  filename: `${baseName}_${suffix}.${ext}`,
 });
 
 const PdfUploader: React.FC<Props> = ({
@@ -58,17 +63,25 @@ const PdfUploader: React.FC<Props> = ({
 
       if (preferredFileName) {
         files = files.map((pdf, index) =>
-          renameImageWithSuffix(pdf as Pdf, preferredFileName, index.toString())
+          renamePdfWithSuffix(
+            pdf as Pdf,
+            preferredFileName,
+            splitFilePath(pdf?.name).ext,
+            index.toString()
+          )
         );
       }
 
-      const filesWithQuestionId = files.map((pdf) => ({
-        ...pdf,
-        questionId: id,
-        filename: pdf?.filename ?? "",
-        fileType: "pdf" as AllowedFileTypes,
-        path: pdf.uri,
-      }));
+      const filesWithQuestionId = files.map((pdf) => {
+        const split = splitFilePath(pdf?.name);
+        return {
+          ...pdf,
+          questionId: id,
+          filename: pdf?.filename ?? `${split.name}${split.ext}`,
+          fileType: "pdf" as AllowedFileTypes,
+          path: pdf.uri,
+        };
+      });
 
       onChange(filesWithQuestionId);
     } catch (error) {

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -355,7 +355,6 @@ const Form: React.FC<Props> = ({
       </Modal>
       {hasSigned && !hasUploaded && attachments.length > 0 && (
         <FormUploader
-          allQuestions={formState.allQuestions}
           caseStatus={status}
           answers={formState.formAnswers}
           onChange={handleInputChange}

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -290,7 +290,7 @@ const FormField = (props: FormFieldProps): JSX.Element => {
   if (inputType === "repeaterField" && !!input?.addAnswerEvent)
     inputCompProps[input.addAnswerEvent] = onInputAddAnswer;
 
-  if (inputType === "imageUploader") {
+  if (["pdfUploader", "imageUploader"].includes(inputType)) {
     inputCompProps.preferredImageName = label;
   }
 

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -291,7 +291,7 @@ const FormField = (props: FormFieldProps): JSX.Element => {
     inputCompProps[input.addAnswerEvent] = onInputAddAnswer;
 
   if (["pdfUploader", "imageUploader"].includes(inputType)) {
-    inputCompProps.preferredImageName = label;
+    inputCompProps.preferredFileName = label;
   }
 
   if (inputType === "bulletList") {

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -129,3 +129,21 @@ export const downloadFile = async ({
     return { error: true, message: error.message, ...error.response };
   }
 };
+
+export function splitFilePath(inPath: string | undefined | null): {
+  dir: string;
+  name: string;
+  ext: string;
+} {
+  if (!inPath) return { dir: "", name: "", ext: "" };
+
+  const lastSlash = inPath.lastIndexOf("/");
+
+  const dir = lastSlash >= 0 ? inPath.substring(0, lastSlash) : "";
+  const basename = lastSlash >= 0 ? inPath.substring(lastSlash + 1) : inPath;
+  const firstDot = basename.indexOf(".");
+  const name = firstDot >= 0 ? basename.substring(0, firstDot) : basename;
+  const ext = firstDot >= 0 ? basename.substring(firstDot) : "";
+
+  return { dir, name, ext };
+}

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -26,6 +26,12 @@ interface FileUploadParams {
   headers?: Record<string, string>;
 }
 
+interface UploadFileResponse {
+  url: string;
+  uploadedFileName: string;
+  message?: string;
+}
+
 /**
  * Helper for uploading a file to S3
  */
@@ -35,7 +41,7 @@ export const uploadFile = async ({
   fileType,
   data,
   headers,
-}: FileUploadParams): Promise<unknown> => {
+}: FileUploadParams): Promise<UploadFileResponse> => {
   const requestUrl = await buildServiceUrl(endpoint);
   const token = await StorageService.getData(ACCESS_TOKEN_KEY);
   const { apiKey } =

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -10,7 +10,7 @@ export const getBlob = async (fileUri: string): Promise<Blob> => {
   return fileBlob;
 };
 
-type AllowedFileTypes = "jpg" | "jpeg" | "png" | "pdf";
+export type AllowedFileTypes = "jpg" | "jpeg" | "png" | "pdf";
 const MIMEs: Record<AllowedFileTypes, string> = {
   jpg: "image/jpg",
   jpeg: "image/jpg",

--- a/source/helpers/test/fileUpload.test.ts
+++ b/source/helpers/test/fileUpload.test.ts
@@ -1,0 +1,62 @@
+import { splitFilePath } from "../FileUpload";
+
+describe("fileUpload", () => {
+  describe("splitFilePath", () => {
+    const TEST_DEEP_DIR = "/somedir/subdir/subdir2";
+    const TEST_NAME = "filename";
+    const TEST_EXT = ".jpg";
+    const TEST_FILEPATH_FULL = `${TEST_DEEP_DIR}/${TEST_NAME}${TEST_EXT}`;
+
+    it("gets dir", () => {
+      const { dir } = splitFilePath(TEST_FILEPATH_FULL);
+
+      expect(dir).toBe(TEST_DEEP_DIR);
+    });
+
+    it("gets name", () => {
+      const { name } = splitFilePath(TEST_FILEPATH_FULL);
+
+      expect(name).toBe(TEST_NAME);
+    });
+
+    it("gets ext", () => {
+      const { ext } = splitFilePath(TEST_FILEPATH_FULL);
+
+      expect(ext).toBe(TEST_EXT);
+    });
+
+    it("handles path without dirs", () => {
+      const { dir, name, ext } = splitFilePath(`${TEST_NAME}${TEST_EXT}`);
+
+      expect(dir).toBeFalsy();
+      expect(name).toBe(TEST_NAME);
+      expect(ext).toBe(TEST_EXT);
+    });
+
+    it("handles path without ext", () => {
+      const { dir, name, ext } = splitFilePath(`${TEST_DEEP_DIR}/${TEST_NAME}`);
+
+      expect(dir).toBe(TEST_DEEP_DIR);
+      expect(name).toBe(TEST_NAME);
+      expect(ext).toBeFalsy();
+    });
+
+    it("handles path with multiple ext", () => {
+      const { dir, name, ext } = splitFilePath(
+        `${TEST_DEEP_DIR}/${TEST_NAME}.err.log`
+      );
+
+      expect(dir).toBe(TEST_DEEP_DIR);
+      expect(name).toBe(TEST_NAME);
+      expect(ext).toBe(".err.log");
+    });
+
+    it("handles empty path", () => {
+      const { dir, name, ext } = splitFilePath("");
+
+      expect(dir).toBeFalsy();
+      expect(name).toBeFalsy();
+      expect(ext).toBeFalsy();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8409,6 +8409,11 @@ react-native-tab-view@^2.15.2:
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-2.16.0.tgz#cae72c7084394bd328fac5fefb86cd966df37a86"
   integrity sha512-ac2DmT7+l13wzIFqtbfXn4wwfgtPoKzWjjZyrK1t+T8sdemuUvD4zIt+UImg03fu3s3VD8Wh/fBrIdcqQyZJWg==
 
+react-native-uuid@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.1.tgz#ed4e2dfb1683eddb66967eb5dca140dfe1abddb9"
+  integrity sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==
+
 react-native-vector-icons@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-7.1.0.tgz#145487d617b2a81d395d2cf64e6e065fcab3a454"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8222,10 +8222,10 @@ react-native-device-info@^8.4.8:
   resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.4.8.tgz#fc92ae423e47db6cfbf30c30012e09cee63727fa"
   integrity sha512-92676ZWHZHsPM/EW1ulgb2MuVfjYfMWRTWMbLcrCsipkcMaZ9Traz5mpsnCS7KZpsOksnvUinzDIjsct2XGc6Q==
 
-react-native-document-picker@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-document-picker/-/react-native-document-picker-5.3.0.tgz#90f53def42d87a316b76311c729ba401c2823ffa"
-  integrity sha512-vFw9pHJywEY+xeMGM8LgfZYMw12bXQNi8vf2DblFLh11lSLf6J99nZweAGVDB8Va+Fg6CP+nLfWG2bWgL4XmMw==
+react-native-document-picker@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-document-picker/-/react-native-document-picker-8.0.0.tgz#f760f89049cda668be8b1cfb31a484af19716f35"
+  integrity sha512-4O1FNOJHzfZ7BBFOJhNoeCKHSjthFtZyMEWJsAxX1ORdShGSa6miLvTHtQjpCDMNWSoPU1C7fXLNNPrv8GAarQ==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
## Explain the changes you’ve made
Make it possible to upload PDF together with other files like images.

Also did smaller refactoring.

## Explain why these changes are made
A user needs to be able to upload PDF when answering the form, hence adding the ability to do so.

## Explain your solution
Added new properties to the pdfUpload component to make it more alike the imageUploader component. This to make it easier in the future to refactor the file selector components to only one. 
Also by doing so we can remove the uploading logic from both pdfUploader and imageUploader components to fileUploader components instead.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a form that supports both imageUploader and PdfUploader
4. Add files and images (or only one of them)
5. When uploading the files, check the number of files uploaded in the uploading info modal

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
![simulator_screenshot_C76E233A-4538-4083-9AE0-3F3246DF764E](https://user-images.githubusercontent.com/81250970/159956068-3690adf4-bab4-4353-bb76-6c6113386a65.png)

