### PR TITLE
feat: (caseoverview, casesummary): show completion due date when available

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -132,7 +132,10 @@ const computeCaseCardComponent = (
   );
 
   const completions = caseData?.details?.completions?.requested || [];
-  const completionDuedate = caseData?.details?.completions?.dueDate
+  const canShowCompletionDueDate =
+    caseData?.details?.completions?.dueDate &&
+    !caseData?.details?.completions?.isDueDateExpired;
+  const completionDuedate = canShowCompletionDueDate
     ? moment(caseData?.details?.completions?.dueDate).format("YYYY-MM-DD")
     : "";
 

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -242,7 +242,10 @@ const computeCaseCardComponent = (
       ? getUnapprovedCompletionDescriptions(completions)
       : [];
 
-  const completionDuedate = caseData?.details?.completions?.dueDate
+  const canShowCompletionDueDate =
+    caseData?.details?.completions?.dueDate &&
+    !caseData?.details?.completions?.isDueDateExpired;
+  const completionDuedate = canShowCompletionDueDate
     ? moment(caseData?.details?.completions?.dueDate).format("YYYY-MM-DD")
     : "";
 


### PR DESCRIPTION
## Explain the changes you’ve made
Only show completion due date when it can be shown in the application.

## Explain why these changes are made
In order to not make the UI switching from showing and hiding completion due date because of synchronizing the case in the backend, we check the `isDueDateExpired` flag together with `dueDate`.

## Explain your solution
Added the `isDueDateExpired` boolean when creating the `completionDueDate` value.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a case with completions and that dueDate and isDueDateExpired are set
4. Switch isDueDateExpired from true to false and check the result in caseoverview and casesummary. 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
