### PR TITLE
Fix/pdf-upload-caches-directory

### DIFF
--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -64,6 +64,7 @@ const PdfUploader: React.FC<Props> = ({
       let newFiles = await DocumentPicker.pick({
         type: DocumentPicker.types.pdf,
         allowMultiSelection: true,
+        copyTo: "cachesDirectory",
       });
 
       newFiles = newFiles.map((pdf) => addUniqueId(pdf as Pdf));

--- a/source/helpers/filePicker.stories.tsx
+++ b/source/helpers/filePicker.stories.tsx
@@ -1,0 +1,175 @@
+import { storiesOf } from "@storybook/react-native";
+import React, { useState } from "react";
+import styled from "styled-components/native";
+import DocumentPicker, {
+  DocumentPickerResponse,
+} from "react-native-document-picker";
+import PdfView from "react-native-pdf";
+import { Button, Text } from "../components/atoms";
+import StoryWrapper from "../components/molecules/StoryWrapper";
+import { wrappedDefaultStorage } from "../services/StorageService";
+
+const ButtonRow = styled.View`
+  display: flex;
+  flex-direction: row;
+`;
+
+const FlexContainer = styled.ScrollView`
+  background-color: #fff;
+  flex: 1;
+  margin-left: 30px;
+`;
+
+const PdfContainer = styled.View`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const PdfEntry = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-right: 10px;
+  padding-right: 5px;
+  padding-left: 5px;
+  background-color: #9f9;
+`;
+
+function FilePickerStory(): JSX.Element {
+  const [docs, setDocs] = useState<DocumentPickerResponse[]>([]);
+  const [latestLoadLog, setLatestLoadLog] = useState("");
+
+  const pickFile = async () => {
+    const newDocs = await DocumentPicker.pickMultiple({
+      type: DocumentPicker.types.pdf,
+      allowMultiSelection: true,
+      // copyTo: "cachesDirectory",
+    });
+
+    console.log("newDocs", newDocs);
+    setDocs((old) => [...old, ...newDocs]);
+  };
+
+  const pickFileCached = async () => {
+    const newDocs = await DocumentPicker.pickMultiple({
+      type: DocumentPicker.types.pdf,
+      allowMultiSelection: true,
+      copyTo: "cachesDirectory",
+    });
+
+    console.log("newDocs", newDocs);
+    setDocs((old) => [...old, ...newDocs]);
+  };
+
+  const tryLoad = async (uri: string) => {
+    try {
+      setLatestLoadLog("loading...");
+      console.log("tryLoad", uri);
+      const response = await fetch(uri);
+      console.log("fetch response: ", response);
+      const blob = await response.blob();
+      console.log("blob:", blob);
+      setLatestLoadLog(`loaded! ${blob.size} bytes`);
+    } catch (error) {
+      setLatestLoadLog(`error: ${error}`);
+    }
+  };
+
+  const saveData = async () => {
+    console.log("saving docs", docs.length);
+    await wrappedDefaultStorage.saveData(
+      "___filePicker_TEST_docs",
+      JSON.stringify(docs)
+    );
+  };
+
+  const loadData = async () => {
+    console.log("loading docs");
+    const newDocs = await wrappedDefaultStorage.getData(
+      "___filePicker_TEST_docs"
+    );
+    if (newDocs) {
+      const finalDocs = JSON.parse(newDocs) ?? [];
+      console.log("finalDocs", finalDocs.length);
+      setDocs(finalDocs);
+    }
+  };
+
+  const clearDocs = () => {
+    setDocs([]);
+  };
+
+  return (
+    <FlexContainer>
+      <ButtonRow>
+        <Button
+          onClick={pickFile}
+          colorSchema="neutral"
+          style={{ marginRight: 5 }}
+        >
+          <Text>Pick</Text>
+        </Button>
+        <Button
+          onClick={pickFileCached}
+          colorSchema="neutral"
+          style={{ marginRight: 5 }}
+        >
+          <Text>Pick Cached</Text>
+        </Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button onClick={loadData} colorSchema="red" style={{ marginRight: 5 }}>
+          <Text>Load</Text>
+        </Button>
+        <Button
+          onClick={saveData}
+          colorSchema="green"
+          style={{ marginRight: 5 }}
+        >
+          <Text>Save</Text>
+        </Button>
+        <Button
+          onClick={clearDocs}
+          colorSchema="purple"
+          style={{ marginRight: 5 }}
+        >
+          <Text>Clear</Text>
+        </Button>
+      </ButtonRow>
+      <Text>{latestLoadLog}</Text>
+      <Text>docs: {docs.length}</Text>
+      <PdfContainer>
+        {docs.map((doc, index) => (
+          <PdfEntry key={doc.fileCopyUri ?? doc.uri}>
+            <Text style={{ margin: 5, fontSize: 9 }}>
+              {index}: {doc.fileCopyUri ?? doc.uri}
+            </Text>
+            <Button
+              colorSchema="blue"
+              onClick={() => tryLoad(doc.fileCopyUri ?? doc.uri ?? "")}
+            >
+              <Text>Try Load</Text>
+            </Button>
+            <PdfView
+              source={{ uri: doc.fileCopyUri }}
+              style={{
+                flex: 1,
+                width: 120,
+                height: 170,
+                backgroundColor: "red",
+              }}
+            />
+          </PdfEntry>
+        ))}
+      </PdfContainer>
+    </FlexContainer>
+  );
+}
+
+storiesOf("File Picker", module).add("Overview", () => (
+  <StoryWrapper>
+    <FilePickerStory />
+  </StoryWrapper>
+));

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -51,6 +51,7 @@ function loadStories() {
   require("../source/containers/Form/Form.stories");
   require("../source/containers/FormField/FormField.stories");
   require("../source/helpers/error-handler/ErrorHandler.stories");
+  require("../source/helpers/filePicker.stories");
 }
 
 const stories = [
@@ -101,6 +102,7 @@ const stories = [
   "../source/containers/Form/Form.stories",
   "../source/containers/FormField/FormField.stories",
   "../source/helpers/error-handler/ErrorHandler.stories",
+  "../source/helpers/filePicker.stories",
 ];
 
 module.exports = {


### PR DESCRIPTION
## Explain the changes you’ve made

Changed files picked by pdf uploader to be copied to the app's "caches" directory.

## Explain why these changes are made

Without this change files were copied to tmp storage, which could be cleared at any time before upload, causing the upload to fail since the app couldn't find the file anymore.