### PR TITLE
Bugg/handle null details

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -71,6 +71,18 @@ const StyledIcon = styled(Icon)`
   color: ${(props) => props.theme.colors.primary[colorSchema][0]};
 `;
 
+interface InternalCardProps {
+  subtitle: string;
+  description?: string;
+  onClick?: () => void;
+}
+
+interface InternalButtonProps {
+  text: string;
+  colorSchema: string | null;
+  onClick: () => void;
+}
+
 /**
  * Returns a case card component depending on it's status
  * @param {obj} caseData
@@ -84,31 +96,18 @@ const computeCaseCardComponent = (
   authContext,
   onShowPinInput
 ) => {
-  interface InternalCardProps {
-    subtitle: string;
-    description?: string;
-    onClick?: () => void;
-  }
-
-  interface InternalButtonProps {
-    text: string;
-    colorSchema: string | null;
-    onClick: () => void;
-  }
-
   const currentStep =
     caseData?.forms?.[caseData.currentFormId]?.currentPosition
       ?.currentMainStep || 0;
   const totalSteps = caseData.form?.stepStructure
     ? caseData.form.stepStructure.length
     : 0;
-  const {
-    details: {
-      period = {},
-      workflow: { decision = {}, payments = {}, application = {} } = {},
-    } = {},
-    persons = [],
-  } = caseData;
+
+  const persons = caseData?.persons ?? [];
+
+  const details = caseData?.details ?? {};
+  const { workflow = {}, period = {} } = details;
+  const { decision = {}, payments = {}, application = {} } = workflow;
 
   const applicationPeriodTimestamp =
     application?.periodenddate ?? period?.endDate;
@@ -121,10 +120,10 @@ const computeCaseCardComponent = (
     : [];
 
   const paymentsArray = decisions.filter(
-    (decision) => decision.typecode === "01"
+    (caseDecision) => caseDecision?.typecode === "01"
   );
-  const partiallyApprovedDecisionsAndRejected = decisions.filter((decision) =>
-    ["03", "02"].includes(decision.typecode)
+  const partiallyApprovedDecisionsAndRejected = decisions.filter(
+    (caseDecision) => ["03", "02"].includes(caseDecision.typecode)
   );
 
   const casePersonData = persons.find(

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useRef,
   useCallback,
+  useMemo,
 } from "react";
 import { View, Animated, Easing, ScrollView } from "react-native";
 import PropTypes from "prop-types";
@@ -33,7 +34,14 @@ import {
 } from "../../helpers/FormatVivaData";
 import AuthContext from "../../store/AuthContext";
 import { put } from "../../helpers/ApiRequest";
-import { ApplicationStatusType } from "../../types/Case";
+import {
+  ApplicationStatusType,
+  Case,
+  VIVACaseDetails,
+  Workflow,
+  Journal,
+  Decision,
+} from "../../types/Case";
 
 const {
   NOT_STARTED,
@@ -128,20 +136,13 @@ const computeCaseCardComponent = (
 ) => {
   const {
     currentPosition: { currentMainStep: currentStep },
-  } = caseData.forms[caseData.currentFormId];
-  const {
-    status,
-    details: {
-      period = {},
-      workflow: {
-        decision = {},
-        payments = {},
-        application = {},
-        journals = {},
-      } = {},
-    } = {},
-    persons = [],
-  } = caseData;
+  } = caseData?.forms[caseData?.currentFormId];
+
+  const status = caseData?.status;
+  const persons = caseData.persons ?? [];
+  const details = caseData?.details ?? {};
+  const { workflow = {}, period = {} } = details;
+  const { decision = {}, payments = {}, application = {} } = workflow;
 
   const totalSteps = form?.stepStructure?.length || 0;
 
@@ -181,10 +182,10 @@ const computeCaseCardComponent = (
     : [];
 
   const paymentsArray = decisions.filter(
-    (decision) => decision.typecode === "01"
+    (caseDecision) => caseDecision.typecode === "01"
   );
-  const partiallyApprovedDecisionsAndRejected = decisions.filter((decision) =>
-    ["03", "02"].includes(decision.typecode)
+  const partiallyApprovedDecisionsAndRejected = decisions.filter(
+    (caseDecision) => ["03", "02"].includes(caseDecision.typecode)
   );
 
   const shouldShowCTAButton = isCoApplicant
@@ -282,9 +283,7 @@ const computeCaseCardComponent = (
 const CaseSummary = (props) => {
   const authContext = useContext(AuthContext);
   const { cases, getCase } = useContext(CaseState);
-  const { getForm } = useContext(FormContext);
-  const [caseData, setCaseData] = useState({});
-  const [form, setForm] = useState({});
+  const { getForm, forms } = useContext(FormContext);
 
   const {
     colorSchema,
@@ -294,12 +293,19 @@ const CaseSummary = (props) => {
     },
   } = props;
 
+  const caseData: Case = useMemo(() => cases[caseId] ?? {}, [cases, caseId]);
+  const form = useMemo(
+    () => forms[caseData?.currentFormId] ?? {},
+    [caseData?.currentFormId, forms]
+  );
+
+  const details = caseData?.details ?? ({} as VIVACaseDetails);
+  const { workflow = {}, administrators } = details;
   const {
-    details: {
-      administrators,
-      workflow: { decision = {}, calculations = {}, journals = {} } = {},
-    } = {},
-  } = caseData;
+    decision = {} as Decision,
+    calculations = {},
+    journals = {} as Journal,
+  } = workflow as Workflow;
 
   const isFocused = useIsFocused();
   const [isModalVisible, toggleModal] = useModal();
@@ -310,16 +316,14 @@ const CaseSummary = (props) => {
     : [];
 
   useEffect(() => {
-    const caseData = getCase(caseId);
-    setCaseData(caseData);
-
-    const getFormObject = async (id) => {
-      setForm(await getForm(id));
+    const getFormObject = async (id: string) => {
+      await getForm(id);
     };
 
-    getFormObject(caseData.currentFormId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFocused, cases]);
+    if (caseData?.currentFormId) {
+      void getFormObject(caseData?.currentFormId);
+    }
+  }, [isFocused, cases, caseData, getForm]);
 
   const updateCaseSignature = useCallback(
     async (caseItem, signatureSuccessful) => {

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -9,7 +9,6 @@ import React, {
 import { View, Animated, Easing, ScrollView } from "react-native";
 import PropTypes from "prop-types";
 import styled from "styled-components/native";
-import { useIsFocused } from "@react-navigation/native";
 import moment from "moment";
 import { CaseState } from "../../store/CaseContext";
 import FormContext from "../../store/FormContext";
@@ -307,7 +306,6 @@ const CaseSummary = (props) => {
     journals = {} as Journal,
   } = workflow as Workflow;
 
-  const isFocused = useIsFocused();
   const [isModalVisible, toggleModal] = useModal();
   const [isCalculationDetailsVisible, setCalculationDetailsVisibility] =
     useState(false);
@@ -323,7 +321,7 @@ const CaseSummary = (props) => {
     if (caseData?.currentFormId) {
       void getFormObject(caseData?.currentFormId);
     }
-  }, [isFocused, cases, caseData, getForm]);
+  }, [cases, caseData, getForm]);
 
   const updateCaseSignature = useCallback(
     async (caseItem, signatureSuccessful) => {

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -56,8 +56,39 @@ export interface Application {
   periodstartdate: string;
 }
 
+export interface Calculation {
+  periodstartdate: string;
+  periodenddate: string;
+  incomesum: string;
+  costsum: string;
+  normsubtotal: string;
+  reductionsum: string;
+  calculationsum: string;
+}
+
+export interface Note {
+  label: string;
+  text: string;
+}
+export interface Journal {
+  journal: {
+    notes: {
+      note: Note[];
+    };
+  };
+}
+
+export interface Decision {
+  decisions: {
+    decision: Record<string, string>;
+  };
+}
+
 export interface Workflow {
   application: Application;
+  calculations: Record<string, Calculation>;
+  journals: Journal;
+  decision: Decision;
 }
 
 export interface VIVACaseDetails {


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed a bugg where the application crashed because of details property in a case being set to null.

Also did a smaller change regarding double scoped constants and double states for case and forms

## Explain why these changes are made
In order to not crash the application, these changes are made.

## Explain your solution
Destruct the case (caseData) more "correct" by assigning the details property to an empty object when its falsy. Did add new property types for Workflow.

## How to test


1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Make sure you have a case with the `details` property set to `null`
4. Start whichever form you like
5. Close the form, **the application should not crash** as it did before.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
