### PR TITLE
fix(step, stepfooter,form): remove unnecessary calls to onupdatecase

### DIFF
--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -123,7 +123,6 @@ function Step({
   onFieldMount,
   onAddAnswer,
   isBackBtnVisible,
-  onUpdateCase,
   currentPosition,
   totalStepNumber,
   answerSnapshot,
@@ -334,7 +333,6 @@ function Step({
                 formNavigation={formNavigation}
                 currentPosition={currentPosition}
                 onUpdate={onFieldChange}
-                onUpdateCase={onUpdateCase}
                 validateStepAnswers={validateStepAnswers}
                 attachments={attachments}
               />
@@ -423,10 +421,6 @@ Step.propTypes = {
     restoreSnapshot: PropTypes.func,
     deleteSnapshot: PropTypes.func,
   }),
-  /**
-   * The function to update values in context (and thus the backend)
-   */
-  onUpdateCase: PropTypes.func,
   /**
    * Properties to adjust the banner at the top of a step
    */

--- a/source/components/organisms/Step/StepFooter/StepFooter.tsx
+++ b/source/components/organisms/Step/StepFooter/StepFooter.tsx
@@ -43,11 +43,6 @@ interface Props {
   };
   onUpdate: (answers: Record<string, any>) => void;
   onSubmit: () => void;
-  onUpdateCase: (
-    answers: Record<string, any>,
-    signature: { success: boolean },
-    currentPosition: FormPosition
-  ) => void;
   currentPosition: FormPosition;
   validateStepAnswers: (
     errorCallback: () => void,
@@ -63,7 +58,6 @@ const StepFooter: React.FC<Props> = ({
   formNavigation,
   onUpdate,
   onSubmit,
-  onUpdateCase,
   currentPosition,
   children,
   validateStepAnswers,
@@ -79,9 +73,13 @@ const StepFooter: React.FC<Props> = ({
       }
       case "close": {
         return () => {
-          if (onUpdate && caseStatus.type.includes("ongoing"))
+          if (onUpdate && caseStatus.type.includes("ongoing")) {
             onUpdate(answers);
-          if (formNavigation.close) formNavigation.close();
+          }
+
+          if (formNavigation.close) {
+            formNavigation.close();
+          }
         };
       }
       case "submit": {
@@ -132,12 +130,6 @@ const StepFooter: React.FC<Props> = ({
               caseStatus.type.includes("notStarted"))
           )
             onUpdate(answers);
-          if (
-            onUpdateCase &&
-            (caseStatus.type.includes("ongoing") ||
-              caseStatus.type.includes("notStarted"))
-          )
-            onUpdateCase(answers, undefined, currentPosition);
 
           validateStepAnswers(errorCallback, onValidCallback);
         };
@@ -221,7 +213,6 @@ StepFooter.propTypes = {
   onUpdate: PropTypes.func,
   onSubmit: PropTypes.func,
   /** Behaviour for updating case in context and backend */
-  onUpdateCase: PropTypes.func,
   currentPosition: PropTypes.shape({
     index: PropTypes.number,
     level: PropTypes.number,

--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -323,7 +323,6 @@ const Form: React.FC<Props> = ({
           onFieldChange={handleInputChange}
           onFieldBlur={handleBlur}
           onAddAnswer={handleAddAnswer}
-          onUpdateCase={onUpdateCase}
           onFieldMount={handleInputChange}
           currentPosition={formState.currentPosition}
           totalStepNumber={formState.numberOfMainSteps || 0}


### PR DESCRIPTION
## Explain the changes you’ve made
Remove unnecessary calls for updating a case every time a user goes to the next step in the form. 
For example, a `grundansökan` form has about 30 steps, which means at least 30 calls to the update case lambda. This is unnecessary and we only need to update the case when closing the form or when singing it.

## Explain why these changes are made
In order to not spam our backend and VIVA with unnecessary requests, this changes are made.

## Explain your solution
Remove logic where we run the onUpdateCase in `StepFooter` component in the application.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Example: Place a console log in the FormCaseScreen component and in the `handleUpdateCase` function and see how many times the onUpdateCase function is run. 
4. Switch back to development branch and place a console log as you did in step 3 and watch the difference
5. The form handling in the application should function as before

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
