### PR TITLE
feat: enable hermes engine on android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,7 +84,8 @@ keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    entryFile: "index.js",
+    enableHermes: true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
## Explain the changes you’ve made
Enable [Hermes engine ](https://reactnative.dev/docs/hermes)on Ios.

## Explain why these changes are made
Hermes is an optimized javascript engine for react-native. By enabling Hermes we also enable the usage of [Flipper](https://fbflipper.com/).

## Explain your solution
Set the use hermes flag to true in Ios PodFile, which enables hermes.

## How to test

1. Checkout this branch
2. run `cd android && ./gradlew clean`
3. run `yarn android`
4. The application should run as usual

## Tested environments

- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
