### PR TITLE
bug(pdfuploader): fix correct path to file

### DIFF
--- a/source/components/molecules/PdfUploader/PdfUploader.tsx
+++ b/source/components/molecules/PdfUploader/PdfUploader.tsx
@@ -11,6 +11,10 @@ import {
 import PdfDisplay, { Pdf, UploadedPdf } from "../PdfDisplay/PdfDisplay";
 import { AllowedFileTypes, splitFilePath } from "../../../helpers/FileUpload";
 
+const uriScheme = {
+  file: "file://",
+};
+
 const Wrapper = styled.View`
   padding-left: 0;
   padding-right: 0;
@@ -59,6 +63,9 @@ const PdfUploader: React.FC<Props> = ({
 }) => {
   const addUniqueId = (pdfFile: Pdf) => ({ ...pdfFile, id: uuid.v4() });
 
+  const removeUriScheme = (path: string): string =>
+    path.startsWith(uriScheme.file) ? path.replace(uriScheme.file, "") : path;
+
   const addPdfFromLibrary = async () => {
     try {
       let newFiles = await DocumentPicker.pick({
@@ -85,12 +92,14 @@ const PdfUploader: React.FC<Props> = ({
 
       const filesWithQuestionId = files.map((pdf) => {
         const split = splitFilePath(pdf?.name);
+        const filePath = removeUriScheme(pdf.fileCopyUri ?? pdf.uri);
+
         return {
           ...pdf,
           questionId: id,
           filename: pdf?.filename ?? `${split.name}${split.ext}`,
           fileType: "pdf" as AllowedFileTypes,
-          path: pdf.uri,
+          path: filePath,
         };
       });
 


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed correct path to file location when uploading pdf:s

## Explain why these changes are made
Files that were in the old location could be deleted by the device itself, which means that the files could already have been deleted once they should be uploaded to s3, hence changing the location. 

## Explain your solution
Use the `fileCopyUri` instead of the uri property.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a form with a pdfuploader question
4. Try uploading some files in the form  

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
