### PR TITLE
bug: fix reset of navigation state

### DIFF
--- a/source/screens/FormCaseScreen.tsx
+++ b/source/screens/FormCaseScreen.tsx
@@ -108,7 +108,10 @@ const FormCaseScreen = ({
   }, [getForm, caseId, cases, user]);
 
   const handleCloseForm = () => {
-    navigation.popToTop();
+    navigation.reset({
+      index: 0,
+      routes: [{ name: "App" }],
+    });
   };
 
   const handleUpdateCase = async (
@@ -152,7 +155,7 @@ const FormCaseScreen = ({
 
   // TODO: Update case on form submit.
   const handleSubmitForm = () => {
-    navigation.popToTop();
+    handleCloseForm();
   };
 
   if (!form?.steps) {


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed the issue when the closing a form ended up with strange animation behavior when navigating between `CaseOverview` and `CaseSummary`. This fix will navigate the user to `CaseOverview` needles if the form were open from `CaseOverview` or `CaseSummary`.

## Explain why these changes are made
The old (buggy) behavior were disturbing, hence fixing the issue.

## Explain your solution
Resetting the navigation state to App navigator when closing the form. 

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Start a whichever form and navigate in and out, from and to casesummar and caseoverview. The navigation animation should not feel strange.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
- 