### PR TITLE
feat: add fileviewer component

### DIFF
--- a/source/components/molecules/FileViewer/FileViewer.tsx
+++ b/source/components/molecules/FileViewer/FileViewer.tsx
@@ -13,13 +13,9 @@ const FileViewer: React.FC<Props> = ({
   answers,
   onChange,
 }) => {
-  const files: File[] = [];
-
-  questionIds.forEach((id) => {
-    if (Array.isArray(answers[id])) {
-      files.push(...answers[id].map((file) => file));
-    }
-  });
+  const files = questionIds
+    .filter((id) => Array.isArray(answers[id]))
+    .flatMap((id) => answers[id]);
 
   return <FileDisplay files={files} onChange={onChange} answers={answers} />;
 };

--- a/source/components/molecules/FileViewer/FileViewer.tsx
+++ b/source/components/molecules/FileViewer/FileViewer.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import FileDisplay from "../FileDisplay/FileDisplay";
+import { File } from "../FilePicker/FilePicker";
+
+interface Props {
+  questionIds: string[];
+  answers: Record<string, File[]>;
+  onChange: (value: File[], id: string) => void;
+}
+const FileViewer: React.FC<Props> = ({
+  questionIds = [],
+  answers,
+  onChange,
+}) => {
+  const files: File[] = [];
+
+  questionIds.forEach((id) => {
+    if (Array.isArray(answers[id])) {
+      files.push(...answers[id].map((file) => file));
+    }
+  });
+
+  return <FileDisplay files={files} onChange={onChange} answers={answers} />;
+};
+
+export default FileViewer;

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -22,6 +22,7 @@ import PdfUploader from "../../components/molecules/PdfUploader/PdfUploader";
 import PdfViewer from "../../components/molecules/PdfViewer/PdfViewer";
 import BulletList from "../../components/organisms/BulletList";
 import FilePicker from "../../components/molecules/FilePicker/FilePicker";
+import FileViewer from "../../components/molecules/FileViewer/FileViewer";
 
 import getUnApprovedCompletionsDescriptions from "../../helpers/FormatCompletions";
 import { FormInputType, InputFieldType } from "../../types/FormTypes";
@@ -187,6 +188,11 @@ const inputTypes: Record<inputKeyType, InputTypeProperties> = {
   checkboxList: {
     component: CheckboxList,
     changeEvent: "onChange",
+  },
+  fileViewer: {
+    component: FileViewer,
+    changeEvent: "onChange",
+    props: { answers: true },
   },
 };
 

--- a/source/types/FormTypes.ts
+++ b/source/types/FormTypes.ts
@@ -52,7 +52,8 @@ export type InputFieldType =
   | "imageViewer"
   | "pdfUploader"
   | "pdfViewer"
-  | "filePicker";
+  | "filePicker"
+  | "fileViewer";
 
 export type FormInputType =
   | "text"


### PR DESCRIPTION
## Explain the changes you’ve made
Added new FileViewer component for displaying added files (images and pdfs).

## Explain why these changes are made
The new FilePicker component were missing the FileViewer component, hence adding it.

## Explain your solution
Created the FileViewer component which uses the FileDisplay component for rendering PDfItem and ImageItem component

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a form with PdfUploader, ImageUploader or FilePicker component
4. Add the new FileViewer component in the form with ids from previous questions
5. Start the form in the app

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
