### PR TITLE
fix: remove unused code

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -23,7 +23,6 @@ import { CaseState, caseTypes, CaseDispatch } from "../../store/CaseContext";
 import FormContext from "../../store/FormContext";
 import { convertDataToArray, calculateSum } from "../../helpers/FormatVivaData";
 import AuthContext from "../../store/AuthContext";
-import { put } from "../../helpers/ApiRequest";
 import {
   State as CaseContextState,
   Dispatch as CaseContextDispatch,
@@ -294,7 +293,6 @@ function CaseOverview(props): JSX.Element {
   const [caseItems, setCaseItems] = useState<CaseWithExtra[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [pendingCaseSign, setPendingCaseSign] = useState<Case | null>(null);
   const [pinModalCase, setPinModalCase] = useState<Case | null>(null);
   const [pinModalError, setPinModalError] = useState<string | null>(null);
   const [pinModalName, setPinModalName] = useState<string | null>(null);
@@ -394,50 +392,6 @@ function CaseOverview(props): JSX.Element {
 
     void updateItems();
   }, [authContext.user, getCasesByFormIds, getForm, getFormIdsByFormTypes]);
-
-  useEffect(() => {
-    if (pendingCaseSign && authContext.status === "signResolved") {
-      void (async () => {
-        const currentForm =
-          pendingCaseSign.forms[pendingCaseSign.currentFormId];
-
-        const updateCaseRequestBody = {
-          currentFormId: pendingCaseSign.currentFormId,
-          ...currentForm,
-          signature: { success: true },
-        };
-
-        try {
-          const updateCaseResponse = await put(
-            `/cases/${pendingCaseSign.id}`,
-            JSON.stringify(updateCaseRequestBody)
-          );
-
-          if (updateCaseResponse.status !== 200) {
-            throw new Error(
-              `${updateCaseResponse.status} ${updateCaseResponse?.data?.data?.message}`
-            );
-          }
-
-          setPendingCaseSign(null);
-          onRefresh();
-
-          // Show last screen of form
-          navigation.navigate("Form", {
-            caseId: pendingCaseSign.id,
-          });
-        } catch (error) {
-          console.log(`Could not update case with new signature: ${error}`);
-        }
-      })();
-    }
-  }, [
-    pendingCaseSign,
-    authContext.status,
-    setPendingCaseSign,
-    onRefresh,
-    navigation,
-  ]);
 
   const showPinInput = (caseData: Case) => {
     const mainPerson = caseData.persons?.find(


### PR DESCRIPTION
## Explain the changes you’ve made
Removed unused code in caseoverview

## Explain why these changes are made
A state was not used, which meant that an useEffect wasn't run, hence removing it.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Fire up any form and check that nothing breaks when filling and sining a form

## Tested environments

- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
