### PR TITLE
bug: Wrong month showed in case card

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -98,7 +98,7 @@ const computeCaseCardComponent = (
   const { decision = {}, payments = {}, application = {} } = workflow;
 
   const applicationPeriodTimestamp =
-    application?.periodenddate ?? period?.endDate;
+    period?.endDate ?? application?.periodenddate;
   const applicationPeriodMonth = applicationPeriodTimestamp
     ? getSwedishMonthNameByTimeStamp(applicationPeriodTimestamp, true)
     : "";

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -95,12 +95,10 @@ const computeCaseCardComponent = (
 
   const details = caseData?.details ?? {};
   const { workflow = {}, period = {} } = details;
-  const { decision = {}, payments = {}, application = {} } = workflow;
+  const { decision = {}, payments = {} } = workflow;
 
-  const applicationPeriodTimestamp =
-    period?.endDate ?? application?.periodenddate;
-  const applicationPeriodMonth = applicationPeriodTimestamp
-    ? getSwedishMonthNameByTimeStamp(applicationPeriodTimestamp, true)
+  const applicationPeriodMonth = period?.endDate
+    ? getSwedishMonthNameByTimeStamp(period?.endDate, true)
     : "";
 
   const decisions = decision?.decisions?.decision

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -139,7 +139,7 @@ const computeCaseCardComponent = (
   const completions = caseData?.details?.completions?.requested || [];
 
   const applicationPeriodTimestamp =
-    application?.periodenddate ?? period?.endDate;
+    period?.endDate ?? application?.periodenddate;
   const applicationPeriodMonth = applicationPeriodTimestamp
     ? getSwedishMonthNameByTimeStamp(applicationPeriodTimestamp, true)
     : "";

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -132,16 +132,14 @@ const computeCaseCardComponent = (
   const persons = caseData.persons ?? [];
   const details = caseData?.details ?? {};
   const { workflow = {}, period = {} } = details;
-  const { decision = {}, payments = {}, application = {} } = workflow;
+  const { decision = {}, payments = {} } = workflow;
 
   const totalSteps = form?.stepStructure?.length || 0;
 
   const completions = caseData?.details?.completions?.requested || [];
 
-  const applicationPeriodTimestamp =
-    period?.endDate ?? application?.periodenddate;
-  const applicationPeriodMonth = applicationPeriodTimestamp
-    ? getSwedishMonthNameByTimeStamp(applicationPeriodTimestamp, true)
+  const applicationPeriodMonth = period?.endDate
+    ? getSwedishMonthNameByTimeStamp(period?.endDate, true)
     : "";
 
   const casePersonData = persons.find(


### PR DESCRIPTION
## Explain the changes you’ve made
The end date (month) for when a period were ending were taken from the wrong property, resulting in wrong month were showed in a case card.

## Explain why these changes are made
The old period end date property did specify an end date on the wrong month. Example:

Lets say that the period did end at the end of march, the old property value would then say that the end date is 1 of april, which is kinda true. But then the period in the case card would say the wrong month.
The new end date property does instead end the period of 31 of march, resulting in correct month is showed to the user.

## Explain your solution
Changing the preferred property to take date from 

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Have a recurring case and check that the period is showed correct in the case card

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
