### PR TITLE
Feat/refactor done button ios keyboard

### DIFF
--- a/source/components/atoms/Input/Input.styled.ts
+++ b/source/components/atoms/Input/Input.styled.ts
@@ -1,7 +1,7 @@
 import { Dimensions } from "react-native";
 import styled from "styled-components/native";
 
-import { Text } from "..";
+import Text from "../Text";
 
 import { ErrorValidation } from "./Input.types";
 

--- a/source/components/atoms/Input/Input.styled.ts
+++ b/source/components/atoms/Input/Input.styled.ts
@@ -1,0 +1,43 @@
+import { Dimensions } from "react-native";
+import styled from "styled-components/native";
+
+import { Text } from "..";
+
+import { Props } from "./Input.types";
+
+const StyledTextInput = styled.TextInput<Props>`
+  width: 100%;
+  font-weight: ${({ theme }) => theme.fontWeights[0]};
+  background-color: ${({ theme, colorSchema }) =>
+    theme.colors.complementary[colorSchema][2]};
+  ${({ transparent }) => transparent && `background-color: transparent;`}
+  border-radius: 4.5px;
+  border: solid 1px
+    ${({ theme, error }) =>
+      error?.isValid || error === undefined
+        ? "transparent"
+        : theme.colors.primary.red[0]};
+  padding: 16px;
+  color: ${({ theme }) => theme.colors.neutrals[0]};
+  ${({ center }) => (center ? "text-align: center;" : null)}
+  ${({ hidden }) => (hidden ? "display: none;" : null)}
+`;
+
+const StyledErrorText = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSizes[3]}px;
+  color: ${({ theme }) => theme.textInput.errorTextColor};
+  font-weight: ${({ theme }) => theme.fontWeights[0]};
+  padding-top: 8px;
+`;
+
+const AccesoryViewChild = styled.View`
+  width: ${Dimensions.get("window").width}px;
+  height: 48px;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  background-color: #f8f8f8;
+  padding-right: 16px;
+`;
+
+export { StyledTextInput, StyledErrorText, AccesoryViewChild };

--- a/source/components/atoms/Input/Input.styled.ts
+++ b/source/components/atoms/Input/Input.styled.ts
@@ -3,9 +3,19 @@ import styled from "styled-components/native";
 
 import { Text } from "..";
 
-import { Props } from "./Input.types";
+import { ErrorValidation } from "./Input.types";
 
-const StyledTextInput = styled.TextInput<Props>`
+import { PrimaryColor, ThemeType } from "../../../styles/themeHelpers";
+
+interface StyledInputprops {
+  theme: ThemeType;
+  colorSchema: PrimaryColor;
+  center: boolean;
+  hidden: boolean;
+  transparent: boolean;
+  error: ErrorValidation;
+}
+const StyledTextInput = styled.TextInput<StyledInputprops>`
   width: 100%;
   font-weight: ${({ theme }) => theme.fontWeights[0]};
   background-color: ${({ theme, colorSchema }) =>

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useEffect, forwardRef } from "react";
 import {
   Keyboard,
   Button,
   Platform,
   View,
   InputAccessoryView,
+  TextInput,
 } from "react-native";
 import { useTheme } from "styled-components/native";
 
@@ -48,16 +49,19 @@ const replaceSpace = (str?: string) => {
   return str;
 };
 
-export default function Input({
-  onBlur,
-  onMount,
-  showErrorMessage,
-  value,
-  error,
-  inputType,
-  keyboardType,
-  ...props
-}: Props): JSX.Element {
+function Input(
+  {
+    onBlur,
+    onMount,
+    showErrorMessage,
+    value,
+    error,
+    inputType,
+    keyboardType,
+    ...props
+  }: Props,
+  ref: React.Ref<TextInput>
+): JSX.Element {
   const handleBlur = () => {
     if (onBlur) onBlur(value);
   };
@@ -93,9 +97,9 @@ export default function Input({
         }}
         inputAccessoryViewID="klar-accessory"
         keyboardType={smartKeyboardType}
-        // ref={ref as React.Ref<TextInput>}
         {...smartKeyboardExtraProps}
         {...props}
+        ref={ref}
       />
 
       {showErrorMessage && !!error?.message && (
@@ -114,3 +118,5 @@ export default function Input({
     </>
   );
 }
+
+export default forwardRef(Input);

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -58,6 +58,7 @@ function Input(
     error,
     inputType,
     keyboardType,
+    colorSchema = "blue",
     ...props
   }: Props,
   ref: React.Ref<TextInput>
@@ -97,6 +98,7 @@ function Input(
         }}
         inputAccessoryViewID="klar-accessory"
         keyboardType={smartKeyboardType}
+        colorSchema={colorSchema}
         {...smartKeyboardExtraProps}
         {...props}
         ref={ref}

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -1,34 +1,22 @@
 import React, { useEffect } from "react";
-import PropTypes from "prop-types";
 import {
-  TextInputProps,
   Keyboard,
-  TextInput,
-  KeyboardTypeOptions,
-  InputAccessoryView,
-  View,
   Button,
-  Dimensions,
   Platform,
+  View,
+  InputAccessoryView,
 } from "react-native";
-import styled, { useTheme } from "styled-components/native";
-import Text from "../Text";
-import { InputFieldType } from "../../../types/FormTypes";
+import { useTheme } from "styled-components/native";
 
-type InputProps = Omit<TextInputProps, "onBlur"> & {
-  onBlur: (value: string) => void;
-  onMount: (value: string) => void;
-  center?: boolean;
-  transparent?: boolean;
-  colorSchema?: "neutral" | "blue" | "green" | "red" | "purple";
-  showErrorMessage?: boolean;
-  hidden?: boolean;
-  error?: { isValid: boolean; message: string };
-  textAlign?: "left" | "center" | "right";
-  inputType?: InputFieldType;
-};
+import {
+  StyledTextInput,
+  StyledErrorText,
+  AccesoryViewChild,
+} from "./Input.styled";
 
-const keyboardTypes: Record<InputFieldType, KeyboardTypeOptions> = {
+import { Props, KeyboardTypeExtraPropType } from "./Input.types";
+
+const keyboardTypes = {
   text: "default",
   number: "number-pad",
   email: "email-address",
@@ -38,7 +26,7 @@ const keyboardTypes: Record<InputFieldType, KeyboardTypeOptions> = {
   personalNumber: "number-pad",
 };
 
-const keyboardTypeExtraProp: Record<InputFieldType, Partial<InputProps>> = {
+const keyboardTypeExtraProp: KeyboardTypeExtraPropType = {
   text: {},
   number: {},
   email: {
@@ -51,44 +39,6 @@ const keyboardTypeExtraProp: Record<InputFieldType, Partial<InputProps>> = {
   personalNumber: {},
 };
 
-const StyledTextInput = styled.TextInput<InputProps>`
-  width: 100%;
-  font-weight: ${({ theme }) => theme.fontWeights[0]};
-  background-color: ${(props) =>
-    props.theme.colors.complementary[props.colorSchema][2]};
-  ${({ transparent }) => transparent && `background-color: transparent;`}
-  border-radius: 4.5px;
-  border: solid 1px
-    ${({ theme, error }) =>
-      error?.isValid || error === undefined
-        ? "transparent"
-        : theme.colors.primary.red[0]};
-  padding-top: 16px;
-  padding-bottom: 16px;
-  padding-left: 16px;
-  padding-right: 16px;
-  color: ${({ theme }) => theme.colors.neutrals[0]};
-  ${(props) => (props.center ? "text-align: center;" : null)}
-  ${(props) => (props.hidden ? "display: none;" : null)}
-`;
-
-const StyledErrorText = styled(Text)`
-  font-size: ${({ theme }) => theme.fontSizes[3]}px;
-  color: ${(props) => props.theme.textInput.errorTextColor};
-  font-weight: ${({ theme }) => theme.fontWeights[0]};
-  padding-top: 8px;
-`;
-
-const StyledAccessoryViewChild = styled(View)`
-  width: ${Dimensions.get("window").width}px;
-  height: 48px;
-  flexdirection: row;
-  justifycontent: flex-end;
-  alignitems: center;
-  backgroundcolor: #f8f8f8;
-  paddinghorizontal: 8px;
-`;
-
 const replaceSpace = (str?: string) => {
   if (typeof str === "string") {
     return str?.replace(/\u00A0/g, "\u0020");
@@ -98,95 +48,69 @@ const replaceSpace = (str?: string) => {
   return str;
 };
 
-const Input: React.FC<InputProps> = React.forwardRef(
-  (
-    {
-      onBlur,
-      onMount,
-      showErrorMessage,
-      value,
-      error,
-      inputType,
-      keyboardType,
-      ...props
-    },
-    ref
-  ) => {
-    const handleBlur = () => {
-      if (onBlur) onBlur(value);
-    };
-    const handleMount = () => {
-      if (onMount) onMount(value);
-    };
-    const theme = useTheme();
-    const smartKeyboardType = inputType
-      ? keyboardTypes[inputType]
-      : keyboardType;
-    const smartKeyboardExtraProps = inputType
-      ? keyboardTypeExtraProp[inputType]
-      : {};
+export default function Input({
+  onBlur,
+  onMount,
+  showErrorMessage,
+  value,
+  error,
+  inputType,
+  keyboardType,
+  ...props
+}: Props): JSX.Element {
+  const handleBlur = () => {
+    if (onBlur) onBlur(value);
+  };
+  const handleMount = () => {
+    if (onMount) onMount(value);
+  };
+  const theme = useTheme();
+  const smartKeyboardType = inputType ? keyboardTypes[inputType] : keyboardType;
+  const smartKeyboardExtraProps = inputType
+    ? keyboardTypeExtraProp[inputType]
+    : {};
 
-    useEffect(handleMount, []);
+  useEffect(handleMount, []);
 
-    return (
-      <>
-        <StyledTextInput
-          value={replaceSpace(value)}
-          multiline /** Temporary fix to make field scrollable inside scrollview */
-          numberOfLines={
-            1
-          } /** Temporary fix to make field scrollable inside scrollview */
-          onBlur={handleBlur}
-          placeholderTextColor={theme.colors.neutrals[1]}
-          returnKeyType="done"
-          returnKeyLabel="Klar" // Only works on Android
-          blurOnSubmit
-          onSubmitEditing={() => {
-            Keyboard.dismiss();
-          }}
-          inputAccessoryViewID="klar-accessory"
-          keyboardType={smartKeyboardType}
-          ref={ref as React.Ref<TextInput>}
-          {...smartKeyboardExtraProps}
-          {...props}
-        />
-        {showErrorMessage && error ? (
-          <StyledErrorText>{error?.message}</StyledErrorText>
-        ) : (
-          <></>
-        )}
+  const showAccessoryDoneButton =
+    Platform.OS === "ios" && inputType !== "email" && inputType !== "text";
 
-        {Platform.OS === "ios" &&
-        inputType !== "email" &&
-        inputType !== "text" ? (
-          <InputAccessoryView nativeID="klar-accessory">
-            <StyledAccessoryViewChild>
+  return (
+    <>
+      <StyledTextInput
+        value={replaceSpace(value)}
+        multiline /** Temporary fix to make field scrollable inside scrollview */
+        numberOfLines={
+          1
+        } /** Temporary fix to make field scrollable inside scrollview */
+        onBlur={handleBlur}
+        placeholderTextColor={theme.colors.neutrals[1]}
+        returnKeyType="done"
+        returnKeyLabel="Klar" // Only works on Android
+        blurOnSubmit
+        onSubmitEditing={() => {
+          Keyboard.dismiss();
+        }}
+        inputAccessoryViewID="klar-accessory"
+        keyboardType={smartKeyboardType}
+        // ref={ref as React.Ref<TextInput>}
+        {...smartKeyboardExtraProps}
+        {...props}
+      />
+
+      {showErrorMessage && !!error?.message && (
+        <StyledErrorText>{error?.message ?? ""}</StyledErrorText>
+      )}
+
+      {showAccessoryDoneButton && (
+        <InputAccessoryView nativeID="klar-accessory">
+          <AccesoryViewChild>
+            <View>
               <Button title="Klar" onPress={() => Keyboard.dismiss()} />
-            </StyledAccessoryViewChild>
-          </InputAccessoryView>
-        ) : null}
-      </>
-    );
-  }
-);
-
-Input.propTypes = {
-  value: PropTypes.string,
-  /**
-   * Default is blue.
-   */
-  colorSchema: PropTypes.oneOf(["neutral", "blue", "red", "purple", "green"]),
-  /** Whether or not to show the error message as red text below the input field */
-  showErrorMessage: PropTypes.bool,
-  error: PropTypes.shape({
-    isValid: PropTypes.bool.isRequired,
-    message: PropTypes.string.isRequired,
-  }),
-  onBlur: PropTypes.func,
-};
-
-Input.defaultProps = {
-  colorSchema: "blue",
-};
-
-export default Input;
+            </View>
+          </AccesoryViewChild>
+        </InputAccessoryView>
+      )}
+    </>
+  );
+}

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -110,7 +110,7 @@ function Input(
         <InputAccessoryView nativeID="klar-accessory">
           <AccesoryViewChild>
             <View>
-              <Button title="Klar" onPress={() => Keyboard.dismiss()} />
+              <Button title="Klar" onPress={Keyboard.dismiss} />
             </View>
           </AccesoryViewChild>
         </InputAccessoryView>

--- a/source/components/atoms/Input/Input.types.ts
+++ b/source/components/atoms/Input/Input.types.ts
@@ -1,0 +1,26 @@
+import { TextInputProps } from "react-native";
+
+import { PrimaryColor, ThemeType } from "../../../styles/themeHelpers";
+
+import { InputFieldType } from "../../../types/FormTypes";
+
+export interface ErrorValidation {
+  isValid: boolean;
+  message: string;
+}
+
+export type Props = Omit<TextInputProps, "onBlur"> & {
+  onBlur: (value: string) => void;
+  onMount: (value: string) => void;
+  center?: boolean;
+  transparent?: boolean;
+  colorSchema: PrimaryColor;
+  showErrorMessage?: boolean;
+  hidden?: boolean;
+  error?: ErrorValidation;
+  textAlign?: "left" | "center" | "right";
+  inputType?: InputFieldType;
+  theme: ThemeType;
+};
+
+export type KeyboardTypeExtraPropType = Record<InputFieldType, Partial<Props>>;

--- a/source/components/atoms/Input/Input.types.ts
+++ b/source/components/atoms/Input/Input.types.ts
@@ -23,4 +23,6 @@ export type Props = Omit<TextInputProps, "onBlur"> & {
   theme?: ThemeType;
 };
 
-export type KeyboardTypeExtraPropType = Record<InputFieldType, Partial<Props>>;
+export type KeyboardTypeExtraPropType = Partial<
+  Record<InputFieldType, Partial<Props>>
+>;

--- a/source/components/atoms/Input/Input.types.ts
+++ b/source/components/atoms/Input/Input.types.ts
@@ -10,17 +10,17 @@ export interface ErrorValidation {
 }
 
 export type Props = Omit<TextInputProps, "onBlur"> & {
-  onBlur: (value: string) => void;
-  onMount: (value: string) => void;
+  onBlur?: (value: string) => void;
+  onMount?: (value: string) => void;
   center?: boolean;
   transparent?: boolean;
-  colorSchema: PrimaryColor;
+  colorSchema?: PrimaryColor;
   showErrorMessage?: boolean;
   hidden?: boolean;
   error?: ErrorValidation;
   textAlign?: "left" | "center" | "right";
   inputType?: InputFieldType;
-  theme: ThemeType;
+  theme?: ThemeType;
 };
 
 export type KeyboardTypeExtraPropType = Record<InputFieldType, Partial<Props>>;


### PR DESCRIPTION
## Explain the changes you’ve made
Fix styling on "Klar" button when using number-pad and email keyboard on Ios'

Also did some refactoring.

## Explain why these changes are made
The styling were broken, making the "Klar" button looks weird.

## Explain your solution
Fixed the styling
Split types, styling into separate files
remove warnings

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Answer any form that have inputs 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
**Old keyboard styling**
<img width="345" alt="image" src="https://user-images.githubusercontent.com/9610681/173028988-ad1e69c4-fd98-4a1f-8d24-79e9239b3dc2.png">

**New keyboard styling**
<img width="330" alt="image" src="https://user-images.githubusercontent.com/9610681/173029255-aa58e693-e0fa-465d-b6c3-10a2f30775f1.png">

