### PR TITLE
fix: remove unnecessary delete attachment calls

### DIFF
--- a/source/components/molecules/FileDisplay/FileDisplay.tsx
+++ b/source/components/molecules/FileDisplay/FileDisplay.tsx
@@ -21,8 +21,8 @@ const FileDisplay: React.FC<Props> = ({ files, answers, onChange }) => {
   const [horizontalScrollPercentage, setHorizontalScrollPercentage] =
     useState(0);
 
-  const deleteFileFromCloudStorage = async (file: File) => {
-    void remove(`users/me/attachments/${file.uploadedFileName}`);
+  const deleteFileFromCloudStorage = async (fileName: string) => {
+    void remove(`users/me/attachments/${fileName}`);
   };
 
   const removeFile = (file: File) => {
@@ -33,7 +33,7 @@ const FileDisplay: React.FC<Props> = ({ files, answers, onChange }) => {
     }
 
     if (file.uploadedFileName) {
-      void deleteFileFromCloudStorage(file);
+      void deleteFileFromCloudStorage(file.uploadedFileName);
     }
   };
 

--- a/source/components/molecules/FileDisplay/FileDisplay.tsx
+++ b/source/components/molecules/FileDisplay/FileDisplay.tsx
@@ -31,7 +31,10 @@ const FileDisplay: React.FC<Props> = ({ files, answers, onChange }) => {
       const newFiles = answer.filter(({ id }) => id !== file.id);
       onChange(newFiles, file.questionId);
     }
-    void deleteFileFromCloudStorage(file);
+
+    if (file.uploadedFileName) {
+      void deleteFileFromCloudStorage(file);
+    }
   };
 
   const updateImage = (file: File) => {


### PR DESCRIPTION
## Explain the changes you’ve made
Remove unnecessary delete attachments calls for files that haven't yet been uploaded, causing the request to fail.

## Explain why these changes are made
It is unnecessary to delete an attachment if the file hasn't been uploaded yet.

## Explain your solution
When an attachment gets uploaded, the local state in the application sets the uploadedFileName property, marking the attachment uploaded. Before we call the delete attachment api, we now check that the item has that property set.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a form that have the FilePicker component 
4. Upload files with the component
5. Delete files from the FileDisplay and check the network tab

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
