### PR TITLE
bug: fixed bug on overlapping filepicker components

### DIFF
--- a/source/components/molecules/FilePicker/FilePicker.styled.ts
+++ b/source/components/molecules/FilePicker/FilePicker.styled.ts
@@ -39,4 +39,8 @@ const PopupContainer = styled.View<PopupContainerProps>`
   justify-content: space-between;
 `;
 
-export { Wrapper, ButtonContainer, PopupContainer };
+const OverflowAvoidingView = styled.View`
+  flex: 1;
+`;
+
+export { Wrapper, ButtonContainer, PopupContainer, OverflowAvoidingView };

--- a/source/components/molecules/FilePicker/FilePicker.tsx
+++ b/source/components/molecules/FilePicker/FilePicker.tsx
@@ -16,7 +16,12 @@ import { addPdfFromLibrary } from "./pdfUpload";
 import PopupButton from "./PopupButton";
 import PopupLabel from "./PopupLabel";
 
-import { Wrapper, ButtonContainer, PopupContainer } from "./FilePicker.styled";
+import {
+  Wrapper,
+  ButtonContainer,
+  PopupContainer,
+  OverflowAvoidingView,
+} from "./FilePicker.styled";
 
 export enum FileType {
   ALL = "all",
@@ -133,7 +138,9 @@ const FilePicker: React.FC<Props> = ({
     <>
       <Wrapper>
         {files !== "" && (
-          <FileDisplay files={files} onChange={onChange} answers={answers} />
+          <OverflowAvoidingView>
+            <FileDisplay files={files} onChange={onChange} answers={answers} />
+          </OverflowAvoidingView>
         )}
         <ButtonContainer>
           <Button colorSchema={validColorSchema} onClick={toggleChoiceModal}>


### PR DESCRIPTION
## Explain the changes you’ve made
Having two FilePicker components directly after each other in a form causing the below one to overlap the one above.

## Explain why these changes are made
FilerPicker components should not overlap each other.

## Explain your solution
Added a new View that wrapped the FileDisplay component

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a form with two filepicker components on the same side 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots
**Before fix android**
![image](https://user-images.githubusercontent.com/9610681/174081690-bb9450a5-749d-4c30-9337-c5c874dfd108.png)

**After fix android**
![image](https://user-images.githubusercontent.com/9610681/174082073-7a9e6c3f-4e50-4a7d-ad54-d7b6380963c0.png)

**Before fix Ios**
![image](https://user-images.githubusercontent.com/9610681/174081842-2bfa211e-e5ad-4c9f-be98-345321320917.png)

**After fix Ios**
![image](https://user-images.githubusercontent.com/9610681/174081969-5b0577b5-8d5d-40ee-bd5a-66a04d92459e.png)
