### PR TITLE
Feat/required property filepicker

### DIFF
--- a/source/components/molecules/FilePicker/FilePicker.stories.tsx
+++ b/source/components/molecules/FilePicker/FilePicker.stories.tsx
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import { storiesOf } from "@storybook/react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import StoryWrapper from "../StoryWrapper";
-import FilePicker, { File, FileType } from "./FilePicker";
+import FilePicker from "./FilePicker";
+import { File, FileType } from "./FilePicker.types";
 
 const Component = () => {
   const [values, setValues] = useState<File[]>([]);

--- a/source/components/molecules/FilePicker/FilePicker.stories.tsx
+++ b/source/components/molecules/FilePicker/FilePicker.stories.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from "react";
 import { storiesOf } from "@storybook/react-native";
 import { ScrollView } from "react-native-gesture-handler";
+
 import StoryWrapper from "../StoryWrapper";
 import FilePicker from "./FilePicker";
-import { File, FileType } from "./FilePicker.types";
+
+import { FileType } from "./FilePicker.types";
+import type { File } from "./FilePicker.types";
 
 const Component = () => {
   const [values, setValues] = useState<File[]>([]);

--- a/source/components/molecules/FilePicker/FilePicker.styled.ts
+++ b/source/components/molecules/FilePicker/FilePicker.styled.ts
@@ -1,9 +1,15 @@
 import styled from "styled-components/native";
 
-import { PrimaryColor, ComplementaryColor } from "../../../styles/themeHelpers";
+import { Text } from "../../atoms";
+
+import {
+  PrimaryColor,
+  ComplementaryColor,
+  ThemeType,
+} from "../../../styles/themeHelpers";
 
 const Wrapper = styled.View`
-  padding: 15px 0 0 0;
+  padding: 16px 0 16px 0;
 `;
 const ButtonContainer = styled.View`
   display: flex;
@@ -43,4 +49,16 @@ const OverflowAvoidingView = styled.View`
   flex: 1;
 `;
 
-export { Wrapper, ButtonContainer, PopupContainer, OverflowAvoidingView };
+const ErrorText = styled(Text)`
+  text-align: center;
+  padding-top: 16px;
+  color: ${({ theme }: { theme: ThemeType }) => theme.colors.primary.red[1]};
+`;
+
+export {
+  Wrapper,
+  ButtonContainer,
+  PopupContainer,
+  OverflowAvoidingView,
+  ErrorText,
+};

--- a/source/components/molecules/FilePicker/FilePicker.tsx
+++ b/source/components/molecules/FilePicker/FilePicker.tsx
@@ -2,14 +2,9 @@ import React from "react";
 import { Text, Icon, Button } from "../../atoms";
 import { BackgroundBlurWrapper } from "../../atoms/BackgroundBlur";
 import { Modal, useModal } from "../Modal";
-import {
-  getValidColorSchema,
-  PrimaryColor,
-} from "../../../styles/themeHelpers";
+import { getValidColorSchema } from "../../../styles/themeHelpers";
 import FileDisplay from "../FileDisplay/FileDisplay";
 import { splitFilePath } from "../../../helpers/FileUpload";
-import { Pdf } from "../PdfDisplay/PdfDisplay";
-import { Image } from "../ImageDisplay/ImageDisplay";
 
 import { addImagesFromLibrary, addImageFromCamera } from "./imageUpload";
 import { addPdfFromLibrary } from "./pdfUpload";
@@ -21,32 +16,16 @@ import {
   ButtonContainer,
   PopupContainer,
   OverflowAvoidingView,
+  ErrorText,
 } from "./FilePicker.styled";
 
-export enum FileType {
-  ALL = "all",
-  PDF = "pdf",
-  IMAGES = "images",
-}
+import { FileType, Props, File } from "./FilePicker.types";
 
 const fileTypeMap: Record<FileType, (FileType.PDF | FileType.IMAGES)[]> = {
   [FileType.ALL]: [FileType.PDF, FileType.IMAGES],
   [FileType.PDF]: [FileType.PDF],
   [FileType.IMAGES]: [FileType.IMAGES],
 };
-
-export type File = Image | Pdf;
-
-interface Props {
-  buttonText: string;
-  value: File[] | "";
-  answers: Record<string, File[]>;
-  colorSchema: PrimaryColor;
-  id: string;
-  preferredFileName?: string;
-  fileType: FileType;
-  onChange: (value: File[], id: string) => void;
-}
 
 const FilePicker: React.FC<Props> = ({
   buttonText,
@@ -57,6 +36,7 @@ const FilePicker: React.FC<Props> = ({
   id,
   preferredFileName,
   fileType,
+  error,
 }) => {
   const [choiceModalVisible, toggleChoiceModal] = useModal();
 
@@ -148,6 +128,8 @@ const FilePicker: React.FC<Props> = ({
             <Text>{buttonText || "Ladda upp fil"}</Text>
           </Button>
         </ButtonContainer>
+
+        {error?.isValid === false && <ErrorText>{error.message}</ErrorText>}
       </Wrapper>
 
       <Modal

--- a/source/components/molecules/FilePicker/FilePicker.types.ts
+++ b/source/components/molecules/FilePicker/FilePicker.types.ts
@@ -1,0 +1,29 @@
+import { Pdf } from "../PdfDisplay/PdfDisplay";
+import { Image } from "../ImageDisplay/ImageDisplay";
+
+import { PrimaryColor } from "../../../styles/themeHelpers";
+
+export enum FileType {
+  ALL = "all",
+  PDF = "pdf",
+  IMAGES = "images",
+}
+
+export type File = Image | Pdf;
+
+export interface ErrorValidation {
+  isValid: boolean;
+  message: string;
+}
+
+export interface Props {
+  buttonText: string;
+  value: File[] | "";
+  answers: Record<string, File[]>;
+  colorSchema: PrimaryColor;
+  id: string;
+  preferredFileName?: string;
+  fileType: FileType;
+  error?: ErrorValidation;
+  onChange: (value: File[], id: string) => void;
+}

--- a/source/components/molecules/FilePicker/test/FilePicker.test.tsx
+++ b/source/components/molecules/FilePicker/test/FilePicker.test.tsx
@@ -4,9 +4,11 @@ import { fireEvent, waitFor } from "@testing-library/react-native";
 import { AllowedFileTypes } from "../../../../helpers/FileUpload";
 import { render } from "../../../../../test-utils";
 
-import FilePicker, { FileType } from "../FilePicker";
+import FilePicker from "../FilePicker";
 import * as Pdf from "../pdfUpload";
 import * as Images from "../imageUpload";
+
+import { FileType, ErrorValidation } from "../FilePicker.types";
 
 jest.mock("../pdfUpload");
 jest.mock("../imageUpload");
@@ -16,13 +18,19 @@ const addFileButtonText = "Filer";
 const addImagesFromCameraButtonText = "Kamera";
 const addImagesFromCameraLibraryButtonText = "Bildbibliotek";
 const mockId = "mockId";
+const mockErrorMessageText = "Error message";
 
 interface Props {
   fileType?: FileType;
+  error?: ErrorValidation;
   onChange?: () => Promise<void>;
 }
 const renderComponent = (props = {}) => {
-  const { onChange = jest.fn(), fileType = FileType.ALL }: Props = props;
+  const {
+    fileType = FileType.ALL,
+    error = { isValid: true, message: "" },
+    onChange = jest.fn(),
+  }: Props = props;
 
   return render(
     <FilePicker
@@ -33,6 +41,7 @@ const renderComponent = (props = {}) => {
       fileType={fileType}
       onChange={onChange}
       value={[]}
+      error={error}
     />
   );
 };
@@ -44,6 +53,15 @@ it("renders the component", () => {
   expect(queryByText(addFileButtonText)).toBeNull();
   expect(queryByText(addImagesFromCameraButtonText)).toBeNull();
   expect(queryByText(addImagesFromCameraLibraryButtonText)).toBeNull();
+  expect(queryByText(mockErrorMessageText)).toBeNull();
+});
+
+it("renders the error message when provided", () => {
+  const error = { isValid: false, message: mockErrorMessageText };
+
+  const { queryByText } = renderComponent({ error });
+
+  expect(queryByText(mockErrorMessageText)).not.toBeNull();
 });
 
 it("opens the bottom modal on component button click", () => {

--- a/source/components/molecules/FilePicker/test/FilePicker.test.tsx
+++ b/source/components/molecules/FilePicker/test/FilePicker.test.tsx
@@ -8,7 +8,8 @@ import FilePicker from "../FilePicker";
 import * as Pdf from "../pdfUpload";
 import * as Images from "../imageUpload";
 
-import { FileType, ErrorValidation } from "../FilePicker.types";
+import { FileType } from "../FilePicker.types";
+import type { ErrorValidation } from "../FilePicker.types";
 
 jest.mock("../pdfUpload");
 jest.mock("../imageUpload");

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -362,7 +362,9 @@ export function validateAnswer(
   if (!question) return state;
 
   if (
-    ["text", "number", "date", "checkbox", "select"].includes(question.type)
+    ["text", "number", "date", "checkbox", "select", "filePicker"].includes(
+      question.type
+    )
   ) {
     const { validation } = question;
     if (


### PR DESCRIPTION
## Explain the changes you’ve made
Updated the FilePicker component to handle required property from form builder.

## Explain why these changes are made
There is a need to force users to upload files in the form

## Explain your solution
Updated the filepicker component to use the error property and to show an error message if the required property is set in the form.

## How to test

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you run form builder with these changes: https://github.com/helsingborg-stad/mitt-helsingborg-form-builder/pull/66
4. Make sure you have a FilePicker with the required property set
5. Run the application and run the form mentioned above

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
