### PR TITLE
fix(formfield): add styling for preventing overlapping of components

### DIFF
--- a/source/containers/FormField/FormField.styled.ts
+++ b/source/containers/FormField/FormField.styled.ts
@@ -1,0 +1,12 @@
+import styled from "styled-components/native";
+
+const FormFieldContainer = styled.View`
+  flex: 1;
+`;
+
+const LabelContainer = styled.View`
+  width: 100%;
+  padding-bottom: 16px;
+`;
+
+export { FormFieldContainer, LabelContainer };

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { View, LayoutAnimation } from "react-native";
-import styled from "styled-components/native";
+import { LayoutAnimation } from "react-native";
 import CheckboxList from "../../components/organisms/CheckboxList";
 import DynamicCardRenderer from "../DynamicCardRenderer/DynamicCardRenderer";
 import { Input, Label, Select, Text } from "../../components/atoms";
@@ -23,6 +22,8 @@ import PdfViewer from "../../components/molecules/PdfViewer/PdfViewer";
 import BulletList from "../../components/organisms/BulletList";
 import FilePicker from "../../components/molecules/FilePicker/FilePicker";
 import FileViewer from "../../components/molecules/FileViewer/FileViewer";
+
+import { FormFieldContainer, LabelContainer } from "./FormField.styled";
 
 import getUnApprovedCompletionsDescriptions from "../../helpers/FormatCompletions";
 import { FormInputType, InputFieldType } from "../../types/FormTypes";
@@ -196,11 +197,6 @@ const inputTypes: Record<inputKeyType, InputTypeProperties> = {
   },
 };
 
-const LabelContainer = styled.View`
-  width: 100%;
-  padding-bottom: 16px;
-`;
-
 interface FormFieldProps {
   label: string;
   labelLine?: boolean;
@@ -350,7 +346,7 @@ const FormField = (props: FormFieldProps): JSX.Element => {
   });
 
   return (
-    <View>
+    <FormFieldContainer>
       <LabelContainer>
         {label ? (
           <Label
@@ -367,7 +363,7 @@ const FormField = (props: FormFieldProps): JSX.Element => {
         ) : null}
         {inputComponent}
       </LabelContainer>
-    </View>
+    </FormFieldContainer>
   );
 };
 


### PR DESCRIPTION
## Explain the changes you’ve made
Added styling on the formfield container that prevents overlapping components (especially filepicker and filepicker list).

## Explain why these changes are made
We cannot have components overlapping each other, it makes the form looks weird. 

## Explain your solution
Added styling on the formfield container which prevents overlapping.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Test a form of your likings and make sure it looks OK.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
