### PR TITLE
Feat/replace react native reanimated

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -411,8 +411,6 @@ PODS:
     - RNNotifee/NotifeeCore (= 5.2.1)
   - RNNotifee/NotifeeCore (5.2.1):
     - React-Core
-  - RNReanimated (1.13.4):
-    - React-Core
   - RNScreens (3.13.1):
     - React-Core
     - React-RCTImage
@@ -506,7 +504,6 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
   - "RNNotifee (from `../node_modules/@notifee/react-native`)"
-  - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
@@ -633,8 +630,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-image-crop-picker"
   RNNotifee:
     :path: "../node_modules/@notifee/react-native"
-  RNReanimated:
-    :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   RNSentry:
@@ -709,7 +704,6 @@ SPEC CHECKSUMS:
   RNGestureHandler: 4f4986408310a43f1606c391f38f76e0d6e790d5
   RNImageCropPicker: 44e2807bc410741f35d4c45b6586aedfe3da39d2
   RNNotifee: aa2db7658fd17b5c44ea96b7062bcade3787a10e
-  RNReanimated: c1b56d030d1616239861534d9adb531f8cffab68
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSentry: fc5a7ed36b2298b6b98699b3d6357ccc4d407722
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -395,8 +395,6 @@ PODS:
     - React-Core
   - RNFS (2.19.0):
     - React-Core
-  - RNGestureHandler (2.4.1):
-    - React-Core
   - RNImageCropPicker (0.37.3):
     - React-Core
     - React-RCTImage
@@ -501,7 +499,6 @@ DEPENDENCIES:
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNFS (from `../node_modules/react-native-fs`)
-  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
   - "RNNotifee (from `../node_modules/@notifee/react-native`)"
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -624,8 +621,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-device-info"
   RNFS:
     :path: "../node_modules/react-native-fs"
-  RNGestureHandler:
-    :path: "../node_modules/react-native-gesture-handler"
   RNImageCropPicker:
     :path: "../node_modules/react-native-image-crop-picker"
   RNNotifee:
@@ -655,11 +650,11 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: bf7577d12ac6ccf53ab8b5af3c6ccf0dd8458c5c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 0aa6c1c27e1d65920df35ceea5341a5fe76bdb79
   RCTTypeSafety: d76a59d00632891e11ed7522dba3fd1a995e573a
   React: ab8c09da2e7704f4b3ebad4baa6cfdfcc852dcb5
@@ -701,7 +696,6 @@ SPEC CHECKSUMS:
   RNCPicker: 2c31098349f499e7ab4da6c1ce26f7537d271062
   RNDeviceInfo: 36286df381fcaf1933ff9d2d3c34ba2abeb2d8d8
   RNFS: fc610f78fdf8bfc89a9e5cc2f898519f4dba1002
-  RNGestureHandler: 4f4986408310a43f1606c391f38f76e0d6e790d5
   RNImageCropPicker: 44e2807bc410741f35d4c45b6586aedfe3da39d2
   RNNotifee: aa2db7658fd17b5c44ea96b7062bcade3787a10e
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19

--- a/jestSetupFile.ts
+++ b/jestSetupFile.ts
@@ -1,5 +1,4 @@
 import { NativeModules } from "react-native";
-import "react-native-gesture-handler/jestSetup";
 import "@testing-library/jest-dom";
 
 import mockRNDeviceInfo from "react-native-device-info/jest/react-native-device-info-mock";

--- a/jestSetupFile.ts
+++ b/jestSetupFile.ts
@@ -40,19 +40,6 @@ jest.mock("@react-native-community/async-storage", () =>
 );
 
 /**
- * Mock react-native-reanimated
- */
-jest.mock("react-native-reanimated", () => {
-  const Reanimated = jest.requireActual("react-native-reanimated/mock");
-
-  // The mock for `call` immediately calls the callback which is incorrect
-  // So we override it with a no-op
-  Reanimated.default.call = () => {};
-
-  return Reanimated;
-});
-
-/**
  * Mock NativeAnimatedHelper
  */
 jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper");

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-native-document-picker": "^8.1.0",
     "react-native-exception-handler": "^2.10.10",
     "react-native-fs": "^2.19.0",
-    "react-native-gesture-handler": "^2.4.1",
     "react-native-image-crop-picker": "^0.37.3",
     "react-native-image-pan-zoom": "^2.1.12",
     "react-native-keyboard-aware-scroll-view": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
     "react-native-pager-view": "^5.4.15",
     "react-native-pdf": "^6.5.0",
     "react-native-picker-select": "^8.0.4",
-    "react-native-reanimated": "^1.13.4",
-    "react-native-redash": "^14.2.4",
     "react-native-restart": "^0.0.24",
     "react-native-safe-area-context": "^4.2.5",
     "react-native-screens": "^3.13.1",

--- a/source/components/molecules/FilePicker/FilePicker.stories.tsx
+++ b/source/components/molecules/FilePicker/FilePicker.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
+import { ScrollView } from "react-native";
 import { storiesOf } from "@storybook/react-native";
-import { ScrollView } from "react-native-gesture-handler";
 
 import StoryWrapper from "../StoryWrapper";
 import FilePicker from "./FilePicker";

--- a/source/screens/onboarding/Dot.tsx
+++ b/source/screens/onboarding/Dot.tsx
@@ -1,30 +1,29 @@
-import React from 'react';
-import { Text } from 'react-native';
-import Animated, { Extrapolate, interpolate } from 'react-native-reanimated';
+import React from "react";
+import { Text, Animated } from "react-native";
 
 interface DotProps {
   index: number;
-  currentIndex: Animated.Node<number>;
+  currentIndex: Animated.AnimatedDivision;
 }
 
-const Dot = ({ index, currentIndex }: DotProps) => {
-  const opacity = interpolate(currentIndex, {
+const Dot = ({ index, currentIndex }: DotProps): JSX.Element => {
+  const opacity = currentIndex.interpolate({
     inputRange: [index - 1, index, index + 1],
     outputRange: [0.5, 1, 0.5],
-    extrapolate: Extrapolate.CLAMP,
+    extrapolate: "clamp",
   });
 
-  const scale = interpolate(currentIndex, {
+  const scale = currentIndex.interpolate({
     inputRange: [index - 1, index, index + 1],
     outputRange: [0.5, 1, 0.5],
-    extrapolate: Extrapolate.CLAMP,
+    extrapolate: "clamp",
   });
 
   return (
     <Animated.View
       style={{
         opacity,
-        backgroundColor: '#2CB9B9',
+        backgroundColor: "#2CB9B9",
         width: 8,
         height: 8,
         borderRadius: 4,

--- a/source/screens/onboarding/Onboarding.styled.ts
+++ b/source/screens/onboarding/Onboarding.styled.ts
@@ -1,0 +1,78 @@
+import { Animated } from "react-native";
+import styled from "styled-components/native";
+
+import { Button, Text } from "../../components/atoms";
+
+const OnboardingContainer = styled.View`
+  flex: 1;
+`;
+
+const AnimatedScrollContainer = styled(Animated.View)`
+  flex: 6;
+`;
+
+const FooterContainer = styled.View`
+  height: 90px;
+`;
+
+const AnimatedFooterBackground = styled(Animated.View)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;
+
+const FooterContent = styled.View`
+  flex: 1;
+  flex-direction: row;
+  padding-top: 10px;
+`;
+
+const FooterPagination = styled.View`
+  padding-top: 10px;
+  padding-left: 40px;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+const SliderContinueButtonContainer = styled.View`
+  flex: 1;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding-right: 24px;
+`;
+
+const SkipButtonContainer = styled.View`
+  flex-direction: row;
+  align-items: flex-end;
+  align-self: flex-end;
+  height: 64px;
+  margin-top: 16px;
+  margin-bottom: -16px;
+  margin-right: 16px;
+  z-index: 10;
+`;
+
+const ContinueButton = styled(Button)`
+  background-color: transparent;
+`;
+
+const ContinueButtonText = styled(Text)`
+  color: ${(props) => props.theme.colors.primary[props.colorSchema][0]};
+  font-size: ${(props) => props.theme.fontSizes[3]}px;
+`;
+
+export {
+  OnboardingContainer,
+  AnimatedScrollContainer,
+  FooterContainer,
+  AnimatedFooterBackground,
+  FooterContent,
+  FooterPagination,
+  SliderContinueButtonContainer,
+  SkipButtonContainer,
+  ContinueButton,
+  ContinueButtonText,
+};

--- a/source/screens/onboarding/Onboarding.types.ts
+++ b/source/screens/onboarding/Onboarding.types.ts
@@ -1,0 +1,7 @@
+export interface Navigation {
+  reset: (parameters: { index: number; routes: { name: string }[] }) => void;
+}
+
+export interface Props {
+  navigation: Navigation;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,11 +2569,6 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abs-svg-path@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/abs-svg-path/-/abs-svg-path-0.1.1.tgz#df601c8e8d2ba10d4a76d625e236a9a39c2723bf"
-  integrity sha1-32Acjo0roQ1KdtYl4japo5wnI78=
-
 absolute-path@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/absolute-path/-/absolute-path-0.0.0.tgz#a78762fbdadfb5297be99b15d35a785b2f095bf7"
@@ -3668,11 +3663,6 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.1:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-
 core-js@^3.0.1, core-js@^3.6.5:
   version "3.22.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.0.tgz#b52007870c5e091517352e833b77f0b2d2b259f3"
@@ -4649,11 +4639,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs-css-vars@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
-  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
-
 fbjs@^0.8.9:
   version "0.8.18"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.18.tgz#9835e0addb9aca2eff53295cd79ca1cfc7c9662a"
@@ -4666,20 +4651,6 @@ fbjs@^0.8.9:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.30"
-
-fbjs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
-  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
-  dependencies:
-    core-js "^2.4.1"
-    fbjs-css-vars "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -7253,13 +7224,6 @@ normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-normalize-svg-path@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz#0e614eca23c39f0cffe821d6be6cd17e569a766c"
-  integrity sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==
-  dependencies:
-    svg-arc-to-cubic-bezier "^3.0.0"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -7578,11 +7542,6 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
-
-parse-svg-path@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/parse-svg-path/-/parse-svg-path-0.1.2.tgz#7a7ec0d1eb06fa5325c7d3e009b859a09b5d49eb"
-  integrity sha1-en7A0esG+lMlx9PgCbhZoJtdSes=
 
 parse5@6.0.1:
   version "6.0.1"
@@ -8103,22 +8062,6 @@ react-native-picker-select@^8.0.4:
   dependencies:
     "@react-native-picker/picker" "^1.8.3"
     lodash.isequal "^4.5.0"
-
-react-native-reanimated@^1.13.4:
-  version "1.13.4"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.13.4.tgz#f57c65e80ab5d2f60bf7dd21716c0bad8108b84e"
-  integrity sha512-sFbZFh0WanKTa0Fz7GXCZUjWpk/u04ytprcIs4Kb+ijfQHChXva3m3yQZfvbrhRbABJNHrdeuyDgJxDM2mcBgw==
-  dependencies:
-    fbjs "^1.0.0"
-
-react-native-redash@^14.2.4:
-  version "14.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-redash/-/react-native-redash-14.2.4.tgz#5dbb4b2f1a7441bb304fe3494b89e0dc9010c8ef"
-  integrity sha512-/1R9UxXv3ffKcrbxolqa2B247Cgd3ikyEm2q1VlBng77Es6PAD4LAOXQ83pBavvwNfOsbhF3ebkbMpJcLaVt3Q==
-  dependencies:
-    abs-svg-path "^0.1.1"
-    normalize-svg-path "^1.0.1"
-    parse-svg-path "^0.1.2"
 
 react-native-restart@^0.0.24:
   version "0.0.24"
@@ -9194,11 +9137,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-svg-arc-to-cubic-bezier@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz#390c450035ae1c4a0104d90650304c3bc814abe6"
-  integrity sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==
-
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -9494,7 +9432,7 @@ typescript@^4.1.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
-ua-parser-js@^0.7.18, ua-parser-js@^0.7.30:
+ua-parser-js@^0.7.30:
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,13 +772,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@egjs/hammerjs@^2.0.17":
-  version "2.0.17"
-  resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
-  integrity sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==
-  dependencies:
-    "@types/hammerjs" "^2.0.36"
-
 "@emmetio/abbreviation@^2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@emmetio/abbreviation/-/abbreviation-2.2.3.tgz#2b3c0383c1a4652f677d5b56fb3f1616fe16ef10"
@@ -2150,11 +2143,6 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
-
-"@types/hammerjs@^2.0.36":
-  version "2.0.41"
-  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
-  integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
 
 "@types/hast@^2.0.0":
   version "2.3.4"
@@ -7993,17 +7981,6 @@ react-native-fs@^2.19.0:
   dependencies:
     base-64 "^0.1.0"
     utf8 "^3.0.0"
-
-react-native-gesture-handler@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.4.1.tgz#f4cb1784b6dcdf41ae35b4fff6022ec21038e2cd"
-  integrity sha512-qJHkZAWyuvZvEm8jV6TsYKeTgkYmoNsKrO/CEx0YaisAcHSiaiMx2Dy/0/QQ7oZr3t5aL4rJqWtOEZCADNbfeQ==
-  dependencies:
-    "@egjs/hammerjs" "^2.0.17"
-    hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
-    lodash "^4.17.21"
-    prop-types "^15.7.2"
 
 react-native-image-crop-picker@^0.37.3:
   version "0.37.3"


### PR DESCRIPTION
## Explain the changes you’ve made
Remove the dependency of react-native-reanimated and react-native-redash by using the native Animated class from react-native.

Also refactored to the agreed format on files

## Explain why these changes are made
react-native-reanimated seemed overkill for the functionality we were using it for, and it was also a blocker for updating react-native to newer versions, hence removing the dependency.

## Explain your solution
Use Animated class from react-native instead.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Reset app data if necessary
4. Run the onboarding screen and check that the animation is as before

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
