### PR TITLE
fix(pininputmodal): use number-pad as keyboardinputtype

### DIFF
--- a/source/components/organisms/PinInputModal/PinInputModal.tsx
+++ b/source/components/organisms/PinInputModal/PinInputModal.tsx
@@ -55,6 +55,7 @@ export default function PinInputModal({
               onChangeText={setPin}
               onBlur={() => undefined}
               onMount={() => undefined}
+              keyboardType="number-pad"
             />
             {error && <ErrorText>{error}</ErrorText>}
             <ButtonContainer>


### PR DESCRIPTION
## Explain the changes you’ve made
Use number-pad instead of original keyboard type for pininputmodal

## Explain why these changes are made
When typing a pin with the keyboard, it makes more sense using number-pad than original keyboard layout.

## Explain your solution
Changed the keyboardtype property in the input component to be number-pad. This works for both android and ios

## How to test
1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command `yarn ios` or `yarn android`
4. Search for pininputmodal and try it out with the new keyboard

## Tested environments

- [x] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
![simulator_screenshot_E5D97FC7-7797-43B8-BCC4-F5FB7EE46941](https://user-images.githubusercontent.com/9610681/178502342-0ecaae85-d0d6-4ea8-85a9-eccbe99d061a.png)

![image](https://user-images.githubusercontent.com/9610681/178502652-9ddc24ed-32da-4ab8-81af-52e55435bb19.png)
