### PR TITLE
fix(caseoverview): change error message when wrong pin is provided

### DIFF
--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -230,7 +230,6 @@ const computeCaseCardComponent = (
   }
 
   const shouldShowPin = isWaitingForSign && !isCoApplicant;
-
   if (shouldShowPin) {
     const partner = persons.find((person) => person.role === "coApplicant");
     const partnerName = partner?.firstName;
@@ -469,7 +468,7 @@ function CaseOverview(props: CaseOverviewProps): JSX.Element {
       );
       if (provideError) {
         console.warn("provide pin error:", provideError);
-        setModalError("Något blev fel");
+        setModalError("Fel kod - försök igen");
       } else {
         closeOpenModal();
         onRefresh();


### PR DESCRIPTION
## Explain the changes you’ve made
Change the error message shown to the user when wrong pin provided in the pininputmodal 

## Explain why these changes are made
We should be more specific on what kind of error occurred, hence changing the error message.

## Explain your solution
Changing the string where the error message is set in the application

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Create and update a case that suits the logic in `CaseOverview` so that the pininput modal can be opened 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
![image](https://user-images.githubusercontent.com/9610681/178658199-5e6154fb-97d1-4199-a413-0128d1087c10.png)
