### PR TITLE
Feat/replace react native keyboard aware scroll view dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "react-native-fs": "^2.19.0",
     "react-native-image-crop-picker": "^0.37.3",
     "react-native-image-pan-zoom": "^2.1.12",
-    "react-native-keyboard-aware-scroll-view": "^0.9.3",
     "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-network-info": "^5.2.1",
     "react-native-pager-view": "^5.4.15",

--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -1,7 +1,11 @@
-import React, { useState, useRef } from "react";
-import { Dimensions, Platform } from "react-native";
+import React, { useState } from "react";
+import {
+  Dimensions,
+  Platform,
+  ScrollView,
+  KeyboardAvoidingView,
+} from "react-native";
 import PropTypes from "prop-types";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import styled from "styled-components/native";
 import FormField from "../../../containers/FormField";
 import Progressbar from "../../atoms/Progressbar/Progressbar";
@@ -12,7 +16,7 @@ import StepDescription from "./StepDescription/StepDescription";
 import StepFooter from "./StepFooter/StepFooter";
 
 import { ApplicationStatusType } from "../../../types/Case";
-import { PrimaryColor } from "../../../styles/themeHelpers";
+import type { PrimaryColor } from "../../../styles/themeHelpers";
 
 const {
   NEW_APPLICATION,
@@ -82,17 +86,13 @@ const statusTemplateMap: Record<string, DIALOG_TEMPLATE> = {
 const getDialogTemplate = (status: string): DIALOG_TEMPLATE =>
   statusTemplateMap[status] ?? DIALOG_TEMPLATE.MAIN_STEP;
 
-const StepContainer = styled.View`
+const StepContentContainer = styled.View`
   flex: 1;
-  background: ${(props) => props.theme.colors.neutrals[7]};
+  min-height: ${Dimensions.get("window").height}px;
 `;
 
 const StepBackNavigation = styled(BackNavigation)`
   padding: 24px 24px 0px 24px;
-`;
-
-const StepContentContainer = styled.View`
-  flex: 1;
 `;
 
 const StepLayout = styled.View`
@@ -102,11 +102,12 @@ const StepLayout = styled.View`
 `;
 
 const StepBody = styled.View`
-  flex-grow: 1;
+  flex: 1;
 `;
 
 const StepFieldListWrapper = styled.View`
   margin: 24px;
+  flex: 1;
 `;
 
 function Step({
@@ -219,52 +220,20 @@ function Step({
         formNavigation.back();
       };
 
-  const [returnScrollY, setReturnScrollY] = useState(0);
-  const scrollRef = useRef();
-
-  const handleFocus = (e, isSelect = false) => {
-    const scrollResponder = scrollRef.current.getScrollResponder();
-
-    e.target.measure((x, y, width, height, pageX, pageY) => {
-      let keyboardHeight = 0;
-
-      if (scrollResponder.keyboardWillOpenTo) {
-        keyboardHeight =
-          scrollResponder.keyboardWillOpenTo.startCoordinates.height;
-      }
-
-      const newReturnScrollY = pageY + height;
-
-      setReturnScrollY(newReturnScrollY);
-
-      if (isSelect) {
-        const scrollToY = newReturnScrollY + keyboardHeight;
-
-        scrollResponder.props.scrollToPosition(0, scrollToY);
-      }
-    });
-  };
-
   const showCloseFormButton = !actions.some(
     ({ type = "" }) => type === "close"
   );
   const dialogText = getDialogText(dialogTemplate);
 
+  const avoidingBehavior = Platform.OS === "ios" ? "position" : "padding";
+
   return (
-    <StepContainer>
-      <KeyboardAwareScrollView
-        keyboardShouldPersistTaps="always"
-        contentContainerStyle={{ flexGrow: 1 }}
-        resetScrollToCoords={{ x: 0, y: returnScrollY }}
-        innerRef={(r) => (scrollRef.current = r)}
-        enableAutomaticScroll
-      >
-        <CloseDialog
-          visible={dialogIsVisible}
-          title={dialogText.title}
-          body={dialogText.body}
-          buttons={dialogButtons}
-        />
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={avoidingBehavior}
+      keyboardVerticalOffset={-200}
+    >
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
         <StepContentContainer>
           {banner &&
             banner.constructor === Object &&
@@ -309,12 +278,6 @@ function Step({
                       id={field.id}
                       formNavigation={formNavigation}
                       editable={!field.disabled && isFormEditable}
-                      onFocus={(e, isSelect) => {
-                        if (Platform.OS === "android") {
-                          return;
-                        }
-                        handleFocus(e, isSelect);
-                      }}
                       onAddAnswer={onAddAnswer}
                       details={details}
                       {...field}
@@ -339,7 +302,14 @@ function Step({
             ) : null}
           </StepLayout>
         </StepContentContainer>
-      </KeyboardAwareScrollView>
+      </ScrollView>
+
+      <CloseDialog
+        visible={dialogIsVisible}
+        title={dialogText.title}
+        body={dialogText.body}
+        buttons={dialogButtons}
+      />
 
       <StepBackNavigation
         showBackButton={isBackBtnVisible && isFormEditable}
@@ -356,7 +326,7 @@ function Step({
         }}
         colorSchema={colorSchema || "blue"}
       />
-    </StepContainer>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -223,7 +223,7 @@ function Step({
   );
   const dialogText = getDialogText(dialogTemplate);
 
-  const avoidingBehavior = Platform.OS === "ios" ? "position" : "padding";
+  const avoidingBehavior = Platform.OS === "ios" ? "position" : "height";
 
   return (
     <KeyboardAvoidingView

--- a/source/components/organisms/Step/Step.tsx
+++ b/source/components/organisms/Step/Step.tsx
@@ -97,7 +97,6 @@ const StepBackNavigation = styled(BackNavigation)`
 
 const StepLayout = styled.View`
   flex: 1;
-  min-height: ${Dimensions.get("window").height - 256}px;
   flex-direction: column;
 `;
 
@@ -107,7 +106,6 @@ const StepBody = styled.View`
 
 const StepFieldListWrapper = styled.View`
   margin: 24px;
-  flex: 1;
 `;
 
 function Step({
@@ -231,7 +229,7 @@ function Step({
     <KeyboardAvoidingView
       style={{ flex: 1 }}
       behavior={avoidingBehavior}
-      keyboardVerticalOffset={-200}
+      keyboardVerticalOffset={-100}
     >
       <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
         <StepContentContainer>

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -81,7 +81,6 @@ interface FormFieldProps {
   onAddAnswer: (answer: unknown, fieldId: string) => void;
   onClick: () => void;
   onMount: () => void;
-  onFocus: () => void;
   onBlur: () => void;
   onChange?: () => void;
 }
@@ -93,7 +92,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
     component: Input,
     changeEvent: "onChangeText",
     blurEvent: "onBlur",
-    focusEvent: "onFocus",
     props: {
       showErrorMessage: true,
     },
@@ -102,7 +100,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
     component: Input,
     blurEvent: "onBlur",
     changeEvent: "onChangeText",
-    focusEvent: "onFocus",
     props: {
       showErrorMessage: true,
       keyboardType: "numeric",
@@ -120,7 +117,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
   date: {
     component: CalendarPicker,
     changeEvent: "onSelect",
-    focusEvent: "onFocus",
     initialValue: undefined,
     props: {
       showErrorMessage: true,
@@ -130,7 +126,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
   checkbox: {
     component: CheckboxField,
     changeEvent: "onChange",
-    focusEvent: "onFocus",
     blurEvent: "onBlur",
     helpInComponent: true,
     helpProp: "help",
@@ -140,7 +135,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
   editableList: {
     component: EditableList,
     changeEvent: "onInputChange",
-    focusEvent: "onFocus",
     blurEvent: "onBlur",
     helpInComponent: true,
     helpProp: "help",
@@ -163,7 +157,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
   select: {
     component: Select,
     changeEvent: "onValueChange",
-    focusEvent: "onFocus",
     blurEvent: "onBlur",
     props: {},
   },
@@ -175,7 +168,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
   summaryList: {
     component: SummaryList,
     changeEvent: "onChange",
-    focusEvent: "onFocus",
     blurEvent: "onBlur",
     helpInComponent: true,
     helpProp: "help",
@@ -183,7 +175,6 @@ const inputTypes: Record<InputKeyType, InputTypeProperties> = {
   },
   repeaterField: {
     component: RepeaterField,
-    focusEvent: "onFocus",
     blurEvent: "onBlur",
     changeEvent: "onChange",
     addAnswerEvent: "onAddAnswer",
@@ -240,7 +231,6 @@ const FormField = (props: FormFieldProps): JSX.Element => {
     id,
     onChange = () => true,
     onBlur,
-    onFocus,
     onMount,
     onAddAnswer,
     value,
@@ -270,12 +260,6 @@ const FormField = (props: FormFieldProps): JSX.Element => {
     if (onMount) onMount({ [fieldId]: value }, fieldId);
   };
 
-  const onInputFocus = (e, isSelect = false) => {
-    if (onFocus) {
-      onFocus(e, isSelect);
-    }
-  };
-
   const onInputAddAnswer = (values, fieldId = id) => {
     const answerValues = { [fieldId]: values };
     if (onAddAnswer) onAddAnswer(answerValues, fieldId);
@@ -302,8 +286,6 @@ const FormField = (props: FormFieldProps): JSX.Element => {
     inputCompProps.validationErrors = validationErrors;
   if (input && input.changeEvent) inputCompProps[input.changeEvent] = saveInput;
   if (input && input.blurEvent) inputCompProps[input.blurEvent] = onInputBlur;
-  if (input && input.focusEvent)
-    inputCompProps[input.focusEvent] = onInputFocus;
   if (input && input.helpInComponent)
     inputCompProps[input.helpProp || "help"] = help;
   if (input && input.onMountEvent)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7992,19 +7992,6 @@ react-native-image-pan-zoom@^2.1.12:
   resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
   integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
 
-react-native-iphone-x-helper@^1.0.3:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
-  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
-
-react-native-keyboard-aware-scroll-view@^0.9.3:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz#e2e9665d320c188e6b1f22f151b94eb358bf9b71"
-  integrity sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==
-  dependencies:
-    prop-types "^15.6.2"
-    react-native-iphone-x-helper "^1.0.3"
-
 react-native-markdown-display@^7.0.0-alpha.2:
   version "7.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/react-native-markdown-display/-/react-native-markdown-display-7.0.0-alpha.2.tgz#a48a70d3cb5c510a52ecf7f1509a4a3d14d728aa"


### PR DESCRIPTION
## Explain the changes you’ve made
Removed the react-native-keyboard-aware-scroll-view dependency in favor for the one provided by react-native.

## Explain why these changes are made
The usage of  react-native-keyboard-aware-scroll-view dependency were faulty and buggy, making the UI "jumps" now and then when having an input field in focus. Since react-native provides one keyboard aware view themselves we might just use that one instead and get rid of one more dependency.

Note:
The functionality between those two dependencies are different. While react-native "push" the content up to make room for the keyboard, the react-native-keyboard-aware-scroll-view dependency instead scroll the input field to correct position (if it works correctly).

## Explain your solution
Removed the react-native-keyboard-aware-scroll-view dependency and replaced it with the build in for react-native.

## How to test

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Sign in the application using the clients own keyboard
4. Try answering a form with the client keyboard 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
