### PR TITLE
fix: remove duplicate key warning from react in SummaryList

### DIFF
--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -333,7 +333,7 @@ const SummaryList: React.FC<Props> = ({
           index,
           value: "SPACER_VALUE",
           item: {
-            id: `spacer-${index}`,
+            id: `spacer-${index}-${value.items[0].id}-${value.items[0].inputId}`,
             title: "SPACER",
             type: "spacer",
             category: lastCategory,

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,18 +1,20 @@
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components/native";
-import { isObject } from "../../../helpers/Objects";
-import GroupedList from "../../molecules/GroupedList/GroupedList";
-import Text from "../../atoms/Text/Text";
-import Heading from "../../atoms/Heading";
+
+import { GroupedList } from "../../molecules";
+
+import { Text, Heading } from "../../atoms";
+
 import SummaryListItemComponent from "./SummaryListItem";
-import {
-  getValidColorSchema,
-  PrimaryColor,
-  ThemeType,
-} from "../../../styles/themeHelpers";
-import { Help } from "../../../types/FormTypes";
-import { InputType } from "../../atoms/Input/Input";
+
+import { isObject } from "../../../helpers/Objects";
+
+import { getValidColorSchema } from "../../../styles/themeHelpers";
+
+import type { PrimaryColor, ThemeType } from "../../../styles/themeHelpers";
+import type { InputType } from "../../atoms/Input/Input";
+import type { Help } from "../../../types/FormTypes";
 
 const SumLabel = styled(Heading)<{ colorSchema: string }>`
   margin-top: 5px;
@@ -362,6 +364,8 @@ const SummaryList: React.FC<Props> = ({
   });
 
   reorganizedList.forEach((listEntry) => {
+    const summaryListItemKey = `${listEntry.item.id}-${listEntry.item.inputId}-${listEntry.index}`;
+
     if (ArrayType.includes(listEntry.item.type)) {
       // in this case we have some answers from a repeater field, and need to loop over and show each one
       const validationError = validationErrors?.[listEntry.item.id]?.[
@@ -383,7 +387,7 @@ const SummaryList: React.FC<Props> = ({
             listEntry.description ||
             listEntry.otherassetDescription
           }
-          key={`${listEntry.item.inputId}-${listEntry.index}`}
+          key={summaryListItemKey}
           value={listEntry.value ?? ""}
           changeFromInput={changeFromInput(listEntry.item, listEntry.index)}
           onBlur={onItemBlur(listEntry.item, listEntry.index)}
@@ -410,7 +414,7 @@ const SummaryList: React.FC<Props> = ({
       listItems.push(
         <SummaryListItemComponent
           item={listEntry.item}
-          key={`${listEntry.item.id}`}
+          key={summaryListItemKey}
           value={answers[listEntry.item.id][listEntry.item.inputId]}
           changeFromInput={changeFromInput(listEntry.item)}
           onBlur={onItemBlur(listEntry.item)}


### PR DESCRIPTION
## Explain the changes you’ve made
Remove warning when react reders lists with no unique keys in them.
Note that this only affects `SummaryList`.

## Explain why these changes are made
Keys help React identify which items have changed, are added, or are removed, therefore they need to be unique.

## Explain your solution
In `SummaryList` component, create a unique key combined of `item.id`, `item.inputId` and `index` (not map index). which should be unique enough.

## How to test

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run the `Grundansökan` form and answer it as much as possible. 
4. When entering the summary pages no warnings should appear, accept warnings about `cardSpace`, which is an added component in formbuilder for adding space with no unique key.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
