### PR TITLE
Bugg/hiding text in infomodal

### DIFF
--- a/source/components/molecules/InfoModal/InfoModal.styled.ts
+++ b/source/components/molecules/InfoModal/InfoModal.styled.ts
@@ -1,0 +1,44 @@
+import styled from "styled-components/native";
+
+import type { DefaultStyledProps } from "./InfoModal.types";
+
+const UnifiedPadding = [12, 24]; // Vertical padding, Horizontal padding
+
+const PopupContainer = styled.View`
+  max-height: 80%;
+  padding: 0px;
+  width: 80%;
+  background-color: white;
+  flex-direction: column;
+  border-radius: 6px;
+`;
+
+const Wrapper = styled.View`
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Header = styled.View<DefaultStyledProps>`
+  padding: ${UnifiedPadding[0]}px ${UnifiedPadding[1]}px ${UnifiedPadding[0]}px
+    ${UnifiedPadding[1]}px;
+  border-bottom-color: ${({ theme }) => theme.colors.complementary.neutral[1]};
+  border-bottom-width: 1px;
+  margin: 10px 10px 0px 10px;
+  justify-content: center;
+  flex-direction: row;
+`;
+
+const Form = styled.ScrollView<DefaultStyledProps>`
+  padding: ${UnifiedPadding[0]}px ${UnifiedPadding[1]}px 0px
+    ${UnifiedPadding[1]}px;
+  border-bottom-color: ${({ theme }) => theme.colors.complementary.neutral[1]};
+  border-bottom-width: 1px;
+`;
+
+const Footer = styled.View`
+  padding: ${UnifiedPadding[0]}px ${UnifiedPadding[1]}px ${UnifiedPadding[0]}px
+    ${UnifiedPadding[1]}px;
+`;
+
+export { PopupContainer, Wrapper, Header, Form, Footer };

--- a/source/components/molecules/InfoModal/InfoModal.tsx
+++ b/source/components/molecules/InfoModal/InfoModal.tsx
@@ -1,107 +1,33 @@
-import React, { useState } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components/native";
-import { View, Dimensions } from "react-native";
+import React from "react";
 
 import { Modal } from "../Modal";
-
 import { Button, Text, Heading } from "../../atoms";
 import { BackgroundBlurWrapper } from "../../atoms/BackgroundBlur";
 
 import MarkdownConstructor from "../../../helpers/MarkdownConstructor";
 
 import { getValidColorSchema } from "../../../styles/themeHelpers";
+import {
+  PopupContainer,
+  Wrapper,
+  Header,
+  Form,
+  Footer,
+} from "./InfoModal.styled";
 
-import type { PrimaryColor } from "../../../styles/themeHelpers";
+import type { Props } from "./InfoModal.types";
 
-const UnifiedPadding = [12, 24]; // Vertical padding, Horizontal padding
+const InfoModal: React.FC<Props> = (props) => {
+  const {
+    visible,
+    heading,
+    markdownText,
+    buttonText,
+    colorSchema,
+    toggleModal,
+  } = props;
 
-const PopupContainer = styled.View<{ height: number }>`
-  position: absolute;
-  z-index: 1000;
-  top: 15%;
-  left: 10%;
-  right: 10%;
-  height: ${(props) => props.height}px;
-  padding: 0px;
-  width: 80%;
-  background-color: white;
-  flex-direction: column;
-  border-radius: 6px;
-  shadow-offset: 0 0;
-  shadow-opacity: 0.1;
-  shadow-radius: 6px;
-`;
-const Wrapper = styled.View`
-  max-height: 100%;
-`;
-const Header = styled.View`
-  padding: ${UnifiedPadding[0]}px ${UnifiedPadding[1]}px ${UnifiedPadding[0]}px
-    ${UnifiedPadding[1]}px;
-  border-bottom-color: ${(props) =>
-    props.theme.colors.complementary.neutral[1]};
-  border-bottom-width: 1px;
-  margin: 10px;
-  margin-bottom: 0px;
-  justify-content: center;
-  flex-direction: row;
-`;
-const Form = styled.ScrollView`
-  padding: ${UnifiedPadding[0]}px ${UnifiedPadding[1]}px ${UnifiedPadding[0]}px
-    ${UnifiedPadding[1]}px;
-  max-height: 90%;
-  min-height: 30%;
-  border-bottom-color: ${(props) =>
-    props.theme.colors.complementary.neutral[1]};
-  border-bottom-width: 1px;
-  margin: 10px;
-  margin-top: 0px;
-`;
-
-const Footer = styled.View`
-  padding: ${UnifiedPadding[0]}px ${UnifiedPadding[1]}px ${UnifiedPadding[0]}px
-    ${UnifiedPadding[1]}px;
-`;
-
-interface Node {
-  content: string;
-  key: string;
-}
-
-const markdownRules = {
-  text: (node: Node) => (
-    <Text style={{ fontSize: 16 }} key={node.key}>
-      {node.content}
-    </Text>
-  ),
-  bullet_list: (node: Node, children, parent, styles) => (
-    <View key={node.key} style={[styles.list, styles.listUnordered]}>
-      {children}
-    </View>
-  ),
-};
-
-interface Props {
-  visible: boolean;
-  toggleModal: () => void;
-  heading?: string;
-  markdownText: string;
-  buttonText?: string;
-  colorSchema?: PrimaryColor;
-}
-
-const InfoModal: React.FC<Props> = ({
-  visible,
-  toggleModal,
-  heading,
-  markdownText,
-  buttonText,
-  colorSchema,
-  ...other
-}) => {
   const validColorSchema = getValidColorSchema(colorSchema);
-  const windowHeight = Dimensions.get("window").height;
-  const [height, setHeight] = useState(800);
 
   return (
     <Modal
@@ -110,25 +36,21 @@ const InfoModal: React.FC<Props> = ({
       transparent
       presentationStyle="overFullScreen"
       animationType="fade"
-      {...other}
     >
       <BackgroundBlurWrapper>
-        <PopupContainer height={Math.min(0.7 * windowHeight, height)}>
-          <Wrapper
-            onLayout={(layoutEvent) => {
-              setHeight(layoutEvent.nativeEvent.layout.height);
-            }}
-          >
+        <Wrapper>
+          <PopupContainer>
             {heading && (
               <Header>
                 <Heading>{heading}</Heading>
               </Header>
             )}
-            <Form>
-              <MarkdownConstructor
-                rules={markdownRules}
-                rawText={markdownText}
-              />
+            <Form
+              contentContainerStyle={{
+                paddingBottom: 30,
+              }}
+            >
+              <MarkdownConstructor rawText={markdownText} />
             </Form>
             <Footer>
               <Button
@@ -140,20 +62,11 @@ const InfoModal: React.FC<Props> = ({
                 <Text>{buttonText || "Stäng"}</Text>
               </Button>
             </Footer>
-          </Wrapper>
-        </PopupContainer>
+          </PopupContainer>
+        </Wrapper>
       </BackgroundBlurWrapper>
     </Modal>
   );
-};
-
-InfoModal.propTypes = {
-  visible: PropTypes.bool.isRequired,
-  toggleModal: PropTypes.func.isRequired,
-  heading: PropTypes.string,
-  markdownText: PropTypes.string,
-  buttonText: PropTypes.string,
-  colorSchema: PropTypes.oneOf(["green", "blue", "red", "neutral", "purple"]),
 };
 
 export default InfoModal;

--- a/source/components/molecules/InfoModal/InfoModal.tsx
+++ b/source/components/molecules/InfoModal/InfoModal.tsx
@@ -2,14 +2,17 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components/native";
 import { View, Dimensions } from "react-native";
-import {
-  PrimaryColor,
-  getValidColorSchema,
-} from "../../../styles/themeHelpers";
+
 import { Modal } from "../Modal";
+
 import { Button, Text, Heading } from "../../atoms";
 import { BackgroundBlurWrapper } from "../../atoms/BackgroundBlur";
+
 import MarkdownConstructor from "../../../helpers/MarkdownConstructor";
+
+import { getValidColorSchema } from "../../../styles/themeHelpers";
+
+import type { PrimaryColor } from "../../../styles/themeHelpers";
 
 const UnifiedPadding = [12, 24]; // Vertical padding, Horizontal padding
 

--- a/source/components/molecules/InfoModal/InfoModal.types.ts
+++ b/source/components/molecules/InfoModal/InfoModal.types.ts
@@ -1,0 +1,18 @@
+import type {
+  PrimaryColor,
+  ComplementaryColor,
+  ThemeType,
+} from "../../../styles/themeHelpers";
+
+export interface DefaultStyledProps {
+  theme: ThemeType;
+}
+
+export interface Props {
+  visible: boolean;
+  heading?: string;
+  markdownText: string;
+  buttonText?: string;
+  colorSchema: PrimaryColor | ComplementaryColor;
+  toggleModal: () => void;
+}


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed a bug where information in `InfoModal` were hidden below the button section

## Explain why these changes are made
In order to see all information in the modal, these changes are needed.

## Explain your solution
Fixed the styling in the modal so that the lowest part in the markdown content has extra padding. Also removed logic for calculating the height of the modal, this is now done by css.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Answer a form where the InfoModal is used, `Grundansökan` as an example

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots
**Before**

![image](https://user-images.githubusercontent.com/9610681/179186100-c3eeefd6-6e2e-43bd-9048-447e3aa0f3a0.png)

**After**
![simulator_screenshot_A1DEB83E-6576-4BD0-99C7-D8B3EF02B262](https://user-images.githubusercontent.com/9610681/179186249-6e0a060e-e85e-47c2-9cdb-d303d4e6edd3.png)

