### PR TITLE
Feat/add missing storybooks

### DIFF
--- a/source/components/molecules/ApiStatusMessage/ApiStatusMessage.stories.tsx
+++ b/source/components/molecules/ApiStatusMessage/ApiStatusMessage.stories.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { storiesOf } from "@storybook/react-native";
+
+import StoryWrapper from "../StoryWrapper";
+
+import ApiStatusMessage from "./ApiStatusMessage";
+
+storiesOf("ApiStatusMessage", module).add("Default", () => (
+  <StoryWrapper>
+    <ApiStatusMessage message="My error message" />
+  </StoryWrapper>
+));

--- a/source/components/molecules/ApiStatusMessage/ApiStatusMessage.styled.ts
+++ b/source/components/molecules/ApiStatusMessage/ApiStatusMessage.styled.ts
@@ -6,8 +6,6 @@ interface ApiStatusMessageContainerProps {
   theme: ThemeType;
 }
 const ApiStatusMessageContainer = styled.View<ApiStatusMessageContainerProps>`
-  position: relative;
-  top: -160px;
   min-height: 160px;
   align-self: center;
   justify-content: space-evenly;

--- a/source/components/organisms/LoginModal/LoginModal.stories.tsx
+++ b/source/components/organisms/LoginModal/LoginModal.stories.tsx
@@ -1,0 +1,83 @@
+import { storiesOf } from "@storybook/react-native";
+import React, { useState } from "react";
+import styled from "styled-components/native";
+
+import { Button, Text } from "../../atoms";
+import { StoryWrapper } from "../../molecules";
+
+import LoginModal from "./LoginModal";
+
+const FlexContainer = styled.ScrollView`
+  background-color: #fff;
+  flex: 1;
+  margin-left: 30px;
+`;
+
+interface UseLoginModalProps {
+  isLoading?: boolean;
+  isIdle?: boolean;
+  isResolved?: boolean;
+  isRejected?: boolean;
+}
+
+type UseLoginModalPropsReturn = [() => void, JSX.Element];
+
+function usePinInputModal({
+  isLoading = false,
+  isIdle = true,
+  isResolved = false,
+  isRejected = false,
+}: UseLoginModalProps): UseLoginModalPropsReturn {
+  const [showModal, setShowModal] = useState(false);
+  const toggleShowModal = () => {
+    setShowModal((currentValue) => !currentValue);
+  };
+
+  const element = (
+    <LoginModal
+      visible={showModal}
+      handleAuth={() => true}
+      isLoading={isLoading}
+      toggle={toggleShowModal}
+      handleCancelOrder={toggleShowModal}
+      isIdle={isIdle}
+      isResolved={isResolved}
+      isRejected={isRejected}
+    />
+  );
+
+  return [toggleShowModal, element];
+}
+
+const OverviewExamples = () => {
+  const [toggleDefaultModal, defaultModal] = usePinInputModal({});
+  const [toggleLoadingModal, loadingModal] = usePinInputModal({
+    isLoading: true,
+  });
+
+  return (
+    <FlexContainer>
+      <Text type="h5" style={{ marginBottom: 10 }}>
+        Default design
+      </Text>
+
+      <Button onClick={toggleDefaultModal} style={{ marginBottom: 10 }}>
+        <Text>Show default modal</Text>
+      </Button>
+
+      <Button onClick={toggleLoadingModal}>
+        <Text>Show loading modal</Text>
+      </Button>
+
+      {defaultModal}
+
+      {loadingModal}
+    </FlexContainer>
+  );
+};
+
+storiesOf("LoginModal", module).add("Overview examples", () => (
+  <StoryWrapper>
+    <OverviewExamples />
+  </StoryWrapper>
+));

--- a/source/components/organisms/PrivacyModal/PrivacyModal.stories.tsx
+++ b/source/components/organisms/PrivacyModal/PrivacyModal.stories.tsx
@@ -1,0 +1,36 @@
+import { storiesOf } from "@storybook/react-native";
+import React, { useState } from "react";
+import styled from "styled-components/native";
+
+import { Text, Button } from "../../atoms";
+import { StoryWrapper } from "../../molecules";
+
+import PrivacyModal from "./PrivacyModal";
+
+const FlexContainer = styled.ScrollView`
+  background-color: #fff;
+  flex: 1;
+  margin-left: 30px;
+`;
+
+const OverviewExamples = () => {
+  const [showModal, setShowModal] = useState(false);
+  return (
+    <FlexContainer>
+      <Text type="h5" style={{ marginBottom: 10 }}>
+        Default design
+      </Text>
+
+      <PrivacyModal visible={showModal} toggle={() => setShowModal(false)} />
+      <Button onClick={() => setShowModal((oldValue) => !oldValue)}>
+        <Text>{showModal ? "Hide" : "Show"} modal</Text>
+      </Button>
+    </FlexContainer>
+  );
+};
+
+storiesOf("PrivacyModal", module).add("Overview examples", () => (
+  <StoryWrapper>
+    <OverviewExamples />
+  </StoryWrapper>
+));

--- a/source/screens/loginScreen/LoginScreen.styled.ts
+++ b/source/screens/loginScreen/LoginScreen.styled.ts
@@ -130,6 +130,11 @@ const pickerSelectStyles = {
   },
 };
 
+const ApiStatusMessagePosition = styled.View`
+  position: relative;
+  top: -160px;
+`;
+
 export {
   ContentText,
   FlexImageBackground,
@@ -148,4 +153,5 @@ export {
   Title,
   VersionLabel,
   VersionLabelContainer,
+  ApiStatusMessagePosition,
 };

--- a/source/screens/loginScreen/LoginScreen.tsx
+++ b/source/screens/loginScreen/LoginScreen.tsx
@@ -38,6 +38,7 @@ import {
   Title,
   VersionLabel,
   VersionLabelContainer,
+  ApiStatusMessagePosition,
 } from "./LoginScreen.styled";
 import theme from "../../styles/theme";
 
@@ -100,7 +101,9 @@ function LoginScreen(): JSX.Element {
           </Header>
 
           {!!apiStatusMessage && (
-            <ApiStatusMessage message={apiStatusMessage} />
+            <ApiStatusMessagePosition>
+              <ApiStatusMessage message={apiStatusMessage} />
+            </ApiStatusMessagePosition>
           )}
 
           {(isLoading || isResolved) && (

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -43,6 +43,7 @@ function loadStories() {
   require("../source/components/organisms/BulletList/BulletList.stories");
   require("../source/components/organisms/CheckboxList/CheckboxList.stories");
   require("../source/components/organisms/FormList/FormList.stories");
+  require("../source/components/organisms/LoginModal/LoginModal.stories");
   require("../source/components/organisms/NewApplicationModal/NewApplicationModal.stories");
   require("../source/components/organisms/PinInputModal/PinInputModal.stories");
   require("../source/components/organisms/PrivacyModal/PrivacyModal.stories");
@@ -98,6 +99,7 @@ const stories = [
   "../source/components/organisms/BulletList/BulletList.stories",
   "../source/components/organisms/CheckboxList/CheckboxList.stories",
   "../source/components/organisms/FormList/FormList.stories",
+  "../source/components/organisms/LoginModal/LoginModal.stories",
   "../source/components/organisms/NewApplicationModal/NewApplicationModal.stories",
   "../source/components/organisms/PinInputModal/PinInputModal.stories",
   "../source/components/organisms/PrivacyModal/PrivacyModal.stories",

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -45,6 +45,7 @@ function loadStories() {
   require("../source/components/organisms/FormList/FormList.stories");
   require("../source/components/organisms/NewApplicationModal/NewApplicationModal.stories");
   require("../source/components/organisms/PinInputModal/PinInputModal.stories");
+  require("../source/components/organisms/PrivacyModal/PrivacyModal.stories");
   require("../source/components/organisms/Step/Step.stories");
   require("../source/components/organisms/Step/StepBanner/StepBanner.stories");
   require("../source/components/organisms/Step/StepDescription/StepDescription.stories");
@@ -99,6 +100,7 @@ const stories = [
   "../source/components/organisms/FormList/FormList.stories",
   "../source/components/organisms/NewApplicationModal/NewApplicationModal.stories",
   "../source/components/organisms/PinInputModal/PinInputModal.stories",
+  "../source/components/organisms/PrivacyModal/PrivacyModal.stories",
   "../source/components/organisms/Step/Step.stories",
   "../source/components/organisms/Step/StepBanner/StepBanner.stories",
   "../source/components/organisms/Step/StepDescription/StepDescription.stories",

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -18,6 +18,7 @@ function loadStories() {
   require("../source/components/atoms/Text/Text.stories");
   require("../source/components/atoms/TextButton/TextButton.stories");
   require("../source/components/molecules/AddressCard/AddressCard.stories");
+  require("../source/components/molecules/ApiStatusMessage/ApiStatusMessage.stories");
   require("../source/components/molecules/BackNavigation/BackNavigation.stories");
   require("../source/components/molecules/CalendarPicker/CalendarPickerForm.stories");
   require("../source/components/molecules/Card/Card.stories");
@@ -71,6 +72,7 @@ const stories = [
   "../source/components/atoms/Text/Text.stories",
   "../source/components/atoms/TextButton/TextButton.stories",
   "../source/components/molecules/AddressCard/AddressCard.stories",
+  "../source/components/molecules/ApiStatusMessage/ApiStatusMessage.stories",
   "../source/components/molecules/BackNavigation/BackNavigation.stories",
   "../source/components/molecules/CalendarPicker/CalendarPickerForm.stories",
   "../source/components/molecules/Card/Card.stories",


### PR DESCRIPTION
## Explain the changes you’ve made
Add missing storybooks for ApiStatusMessage, PrivacyModal and LoginModal components

## Explain why these changes are made
We want storybooks to our components, hence adding it.

## Explain your solution
N/A

## How to test

1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command `yarn ios` or `yarn android`
4. Search for LoginModa, ApiStatusMessage or PrivacyModal in the StoryBook UI.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
