### PR TITLE
Fix/fix encryption service types

### DIFF
--- a/source/helpers/ApiRequest.ts
+++ b/source/helpers/ApiRequest.ts
@@ -2,7 +2,9 @@ import axios from "axios";
 import { Platform } from "react-native";
 import DeviceInfo from "react-native-device-info";
 
-import StorageService, { ACCESS_TOKEN_KEY } from "../services/StorageService";
+import StorageService, {
+  ACCESS_TOKEN_KEY,
+} from "../services/storage/StorageService";
 import { buildServiceUrl } from "./UrlHelper";
 import { name } from "../../package.json";
 import EnvironmentConfigurationService from "../services/EnvironmentConfigurationService";

--- a/source/helpers/FileUpload.ts
+++ b/source/helpers/FileUpload.ts
@@ -1,7 +1,9 @@
 import axios from "axios";
 import ReactNativeBlobUtil from "react-native-blob-util";
 
-import StorageService, { ACCESS_TOKEN_KEY } from "../services/StorageService";
+import StorageService, {
+  ACCESS_TOKEN_KEY,
+} from "../services/storage/StorageService";
 import { buildServiceUrl } from "./UrlHelper";
 import EnvironmentConfigurationService from "../services/EnvironmentConfigurationService";
 

--- a/source/helpers/filePicker.stories.tsx
+++ b/source/helpers/filePicker.stories.tsx
@@ -4,9 +4,11 @@ import styled from "styled-components/native";
 import type { DocumentPickerResponse } from "react-native-document-picker";
 import DocumentPicker from "react-native-document-picker";
 import PdfView from "react-native-pdf";
+
 import { Button, Text } from "../components/atoms";
 import StoryWrapper from "../components/molecules/StoryWrapper";
-import { wrappedDefaultStorage } from "../services/StorageService";
+
+import { wrappedDefaultStorage } from "../services/storage/StorageService";
 
 const ButtonRow = styled.View`
   display: flex;

--- a/source/navigator/AuthStack.tsx
+++ b/source/navigator/AuthStack.tsx
@@ -4,7 +4,7 @@ import LoginScreen from "../screens/loginScreen/LoginScreen";
 import Onboarding from "../screens/onboarding";
 import StorageService, {
   ONBOARDING_DISABLED,
-} from "../services/StorageService";
+} from "../services/storage/StorageService";
 
 const Stack = createNativeStackNavigator();
 

--- a/source/screens/DevFeaturesScreen.tsx
+++ b/source/screens/DevFeaturesScreen.tsx
@@ -1,14 +1,17 @@
-import FormList from "app/components/organisms/FormList/FormList";
-import AuthContext from "app/store/AuthContext";
-import { CaseDispatch } from "app/store/CaseContext";
 import PropTypes from "prop-types";
 import React, { useContext } from "react";
 import styled from "styled-components/native";
 import env from "react-native-config";
+
+import { CaseDispatch } from "../store/CaseContext";
+import AuthContext from "../store/AuthContext";
+
+import FormList from "../components/organisms/FormList/FormList";
 import { Button, Text } from "../components/atoms";
 import Header from "../components/molecules/Header";
 import ScreenWrapper from "../components/molecules/ScreenWrapper";
-import StorageService from "../services/StorageService";
+
+import StorageService from "../services/storage/StorageService";
 
 const Container = styled.ScrollView`
   flex: 1;

--- a/source/screens/onboarding/Onboarding.tsx
+++ b/source/screens/onboarding/Onboarding.tsx
@@ -9,7 +9,7 @@ import Dot from "./Dot";
 import Slide from "./Slide";
 import { Button, Text } from "../../components/atoms";
 
-import { ONBOARDING_DISABLED } from "../../services/StorageService";
+import { ONBOARDING_DISABLED } from "../../services/storage/StorageService";
 
 import {
   OnboardingContainer,

--- a/source/services/AuthService.ts
+++ b/source/services/AuthService.ts
@@ -2,7 +2,7 @@ import JwtDecode from "jwt-decode";
 import StorageService, {
   ACCESS_TOKEN_KEY,
   REFRESH_TOKEN_KEY,
-} from "./StorageService";
+} from "./storage/StorageService";
 import { post, get } from "../helpers/ApiRequest";
 import { getMessage } from "../helpers/MessageHelper";
 

--- a/source/services/encryption/CaseEncryptionHelper.ts
+++ b/source/services/encryption/CaseEncryptionHelper.ts
@@ -1,4 +1,3 @@
-import type { IStorage } from "./CaseEncryptionService";
 import type {
   Answer,
   AnsweredForm,
@@ -12,9 +11,11 @@ import type {
   EncryptionExceptionStatus,
 } from "../../types/Encryption";
 import { EncryptionErrorStatus, EncryptionType } from "../../types/Encryption";
-import { wrappedDefaultStorage } from "../StorageService";
 import { DeviceLocalAESStrategy } from "./DeviceLocalAESStrategy";
-import type { IEncryptionStrategy } from "./EncryptionStrategy";
+import type {
+  EncryptionStrategyDependencies,
+  IEncryptionStrategy,
+} from "./EncryptionStrategy";
 import { PasswordStrategy } from "./PasswordStrategy";
 
 type StrategyMap = {
@@ -204,13 +205,13 @@ export function makeCaseWithNewForm(caseData: Case, form: AnsweredForm): Case {
 export function getPasswordForForm(
   form: AnsweredForm,
   user: UserInterface,
-  storage: IStorage = wrappedDefaultStorage
+  dependencies: EncryptionStrategyDependencies
 ): Promise<string | null> {
   return PasswordStrategy.getPassword(
     {
       encryptionDetails: form.encryption,
       user,
     },
-    { storage }
+    dependencies
   );
 }

--- a/source/services/encryption/DeviceLocalAESStrategy.ts
+++ b/source/services/encryption/DeviceLocalAESStrategy.ts
@@ -59,14 +59,11 @@ export const DeviceLocalAESStrategy: IEncryptionStrategy<DeviceLocalAESParams> =
       dependencies: EncryptionStrategyDependencies
     ): Promise<DeviceLocalAESParams | null> {
       const paramsId = this.getParamsID(context);
-      const params = await dependencies.storage.getData(paramsId);
+      const params = await dependencies.getData(paramsId);
 
       if (!params) {
         const newParams = await createAesParams();
-        await dependencies.storage.saveData(
-          paramsId,
-          JSON.stringify(newParams)
-        );
+        await dependencies.saveData(paramsId, JSON.stringify(newParams));
         return newParams;
       }
       return JSON.parse(params);

--- a/source/services/encryption/DeviceLocalAESStrategy.ts
+++ b/source/services/encryption/DeviceLocalAESStrategy.ts
@@ -2,7 +2,7 @@ import { NativeModules } from "react-native";
 import { ALGO_SALT, ALGO_ROUNDS, ALGO_LENGTH } from "./constants";
 import type {
   EncryptionContext,
-  EncryptionDependencies,
+  EncryptionStrategyDependencies,
   IEncryptionStrategy,
 } from "./EncryptionStrategy";
 import { EncryptionPossibility } from "./EncryptionStrategy";
@@ -45,7 +45,7 @@ export const DeviceLocalAESStrategy: IEncryptionStrategy<DeviceLocalAESParams> =
 
     async canDecrypt(
       context: EncryptionContext,
-      dependencies: EncryptionDependencies
+      dependencies: EncryptionStrategyDependencies
     ): Promise<boolean> {
       return this.getParams(context, dependencies) !== null;
     },
@@ -56,7 +56,7 @@ export const DeviceLocalAESStrategy: IEncryptionStrategy<DeviceLocalAESParams> =
 
     async getParams(
       context: EncryptionContext,
-      dependencies: EncryptionDependencies
+      dependencies: EncryptionStrategyDependencies
     ): Promise<DeviceLocalAESParams | null> {
       const paramsId = this.getParamsID(context);
       const params = await dependencies.storage.getData(paramsId);

--- a/source/services/encryption/EncryptionStrategy.ts
+++ b/source/services/encryption/EncryptionStrategy.ts
@@ -1,6 +1,5 @@
 import type { EncryptionDetails } from "../../types/Encryption";
 import type { UserInterface } from "./CaseEncryptionHelper";
-import type { IStorage } from "./CaseEncryptionService";
 
 export interface EncryptionContext {
   user?: UserInterface;
@@ -8,8 +7,9 @@ export interface EncryptionContext {
   extra?: Record<string, unknown>;
 }
 
-export interface EncryptionDependencies {
-  storage: IStorage;
+export interface EncryptionStrategyDependencies {
+  getData(key: string): Promise<string | null>;
+  saveData(key: string, payload: string): Promise<void>;
 }
 
 export enum EncryptionPossibility {
@@ -22,15 +22,15 @@ export interface IEncryptionStrategy<TParams> {
   decrypt(params: TParams, payload: string): Promise<string>;
   getPossibilityToEncrypt(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<EncryptionPossibility>;
   canDecrypt(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<boolean>;
   getParamsID(context: EncryptionContext): string;
   getParams(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<TParams | null>;
 }

--- a/source/services/encryption/PasswordStrategy.ts
+++ b/source/services/encryption/PasswordStrategy.ts
@@ -35,7 +35,7 @@ export async function generateRandomPin(): Promise<string> {
   return pin;
 }
 
-export interface IPasswordStrategy extends IEncryptionStrategy<PasswordParams> {
+interface IPasswordStrategy extends IEncryptionStrategy<PasswordParams> {
   generateAndSaveBasicPinPassword(
     context: EncryptionContext,
     dependencies: EncryptionStrategyDependencies

--- a/source/services/encryption/PasswordStrategy.ts
+++ b/source/services/encryption/PasswordStrategy.ts
@@ -104,7 +104,7 @@ export const PasswordStrategy: IPasswordStrategy = {
     dependencies: EncryptionStrategyDependencies
   ): Promise<PasswordParams | null> {
     const paramsId = this.getParamsID(context);
-    const params = await dependencies.storage.getData(paramsId);
+    const params = await dependencies.getData(paramsId);
 
     if (!params) {
       return null;
@@ -122,7 +122,7 @@ export const PasswordStrategy: IPasswordStrategy = {
     const params: PasswordParams = {
       password: pin,
     };
-    await dependencies.storage.saveData(paramsId, JSON.stringify(params));
+    await dependencies.saveData(paramsId, JSON.stringify(params));
     return pin;
   },
 
@@ -160,6 +160,6 @@ export const PasswordStrategy: IPasswordStrategy = {
     const params: PasswordParams = {
       password,
     };
-    await dependencies.storage.saveData(paramsId, JSON.stringify(params));
+    await dependencies.saveData(paramsId, JSON.stringify(params));
   },
 };

--- a/source/services/encryption/PasswordStrategy.ts
+++ b/source/services/encryption/PasswordStrategy.ts
@@ -8,7 +8,7 @@ import { EncryptionPossibility } from "./EncryptionStrategy";
 import type { DeviceLocalAESParams } from "./DeviceLocalAESStrategy";
 import type {
   EncryptionContext,
-  EncryptionDependencies,
+  EncryptionStrategyDependencies,
   IEncryptionStrategy,
 } from "./EncryptionStrategy";
 
@@ -38,20 +38,20 @@ export async function generateRandomPin(): Promise<string> {
 export interface IPasswordStrategy extends IEncryptionStrategy<PasswordParams> {
   generateAndSaveBasicPinPassword(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<string>;
   providePassword(
     password: string,
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<void>;
   getPassword(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<string | null>;
   hasPassword(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<boolean>;
 }
 
@@ -68,7 +68,7 @@ export const PasswordStrategy: IPasswordStrategy = {
 
   async getPossibilityToEncrypt(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<EncryptionPossibility> {
     const params = await this.getParams(context, dependencies);
     if (params !== null) {
@@ -80,7 +80,7 @@ export const PasswordStrategy: IPasswordStrategy = {
 
   async canDecrypt(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<boolean> {
     const params = await this.getParams(context, dependencies);
     return params !== null;
@@ -101,7 +101,7 @@ export const PasswordStrategy: IPasswordStrategy = {
 
   async getParams(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<PasswordParams | null> {
     const paramsId = this.getParamsID(context);
     const params = await dependencies.storage.getData(paramsId);
@@ -115,7 +115,7 @@ export const PasswordStrategy: IPasswordStrategy = {
 
   async generateAndSaveBasicPinPassword(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<string> {
     const pin = await generateRandomPin();
     const paramsId = this.getParamsID(context);
@@ -128,7 +128,7 @@ export const PasswordStrategy: IPasswordStrategy = {
 
   async getPassword(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<string | null> {
     const params = await this.getParams(context, dependencies);
     return params?.password ?? null;
@@ -136,7 +136,7 @@ export const PasswordStrategy: IPasswordStrategy = {
 
   async hasPassword(
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<boolean> {
     const password = await this.getPassword(context, dependencies);
     return password !== null;
@@ -145,7 +145,7 @@ export const PasswordStrategy: IPasswordStrategy = {
   async providePassword(
     password: string,
     context: EncryptionContext,
-    dependencies: EncryptionDependencies
+    dependencies: EncryptionStrategyDependencies
   ): Promise<void> {
     const paramsId = this.getParamsID(context);
     const existingParams = await this.getParams(context, dependencies);

--- a/source/services/encryption/test/CaseEncryptionService.test.ts
+++ b/source/services/encryption/test/CaseEncryptionService.test.ts
@@ -39,7 +39,7 @@ import { generateRandomPin, PasswordStrategy } from "../PasswordStrategy";
 import { to } from "../../../helpers/Misc";
 import type {
   EncryptionContext,
-  EncryptionDependencies,
+  EncryptionStrategyDependencies,
 } from "../EncryptionStrategy";
 
 function makeMockCase(
@@ -691,7 +691,9 @@ describe("CaseEncryptionService (Password specific)", () => {
     const context: EncryptionContext = {
       encryptionDetails: getEncryptionFromCase(CASE_DECRYPTED_PARTNER),
     };
-    const dependencies: EncryptionDependencies = { storage: mockStorage };
+    const dependencies: EncryptionStrategyDependencies = {
+      storage: mockStorage,
+    };
 
     const firstPassword = await PasswordStrategy.getPassword(
       context,
@@ -715,7 +717,9 @@ describe("CaseEncryptionService (Password specific)", () => {
     const context: EncryptionContext = {
       encryptionDetails: getEncryptionFromCase(CASE_DECRYPTED_PARTNER),
     };
-    const dependencies: EncryptionDependencies = { storage: mockStorage };
+    const dependencies: EncryptionStrategyDependencies = {
+      storage: mockStorage,
+    };
 
     const firstCheck = await PasswordStrategy.hasPassword(
       context,
@@ -739,7 +743,9 @@ describe("CaseEncryptionService (Password specific)", () => {
     const context: EncryptionContext = {
       encryptionDetails: getEncryptionFromCase(CASE_DECRYPTED_PARTNER),
     };
-    const dependencies: EncryptionDependencies = { storage: mockStorage };
+    const dependencies: EncryptionStrategyDependencies = {
+      storage: mockStorage,
+    };
     const testPassword = "test password";
 
     await PasswordStrategy.providePassword(testPassword, context, dependencies);

--- a/source/services/index.ts
+++ b/source/services/index.ts
@@ -1,3 +1,0 @@
-import * as StorageService from "./StorageService";
-
-export { StorageService };

--- a/source/services/storage/StorageService.ts
+++ b/source/services/storage/StorageService.ts
@@ -6,7 +6,6 @@
 
 import { Component } from "react";
 import AsyncStorage from "@react-native-community/async-storage";
-// import type { IStorage } from "../encryption";
 
 export interface IStorage {
   getData(key: string): Promise<string | null>;

--- a/source/services/storage/StorageService.ts
+++ b/source/services/storage/StorageService.ts
@@ -7,7 +7,7 @@
 import { Component } from "react";
 import AsyncStorage from "@react-native-community/async-storage";
 
-export interface IStorage {
+interface IStorage {
   getData(key: string): Promise<string | null>;
   saveData(key: string, payload: string): Promise<void>;
 }

--- a/source/services/storage/StorageService.ts
+++ b/source/services/storage/StorageService.ts
@@ -6,7 +6,12 @@
 
 import { Component } from "react";
 import AsyncStorage from "@react-native-community/async-storage";
-import type { IStorage } from "./encryption";
+// import type { IStorage } from "../encryption";
+
+export interface IStorage {
+  getData(key: string): Promise<string | null>;
+  saveData(key: string, payload: string): Promise<void>;
+}
 
 // Storage key definitions
 export const ONBOARDING_DISABLED = "@app:onboarding_disabled";

--- a/source/store/AppContext.tsx
+++ b/source/store/AppContext.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from "react";
 import env from "react-native-config";
-import StorageService, { APP_ENV_KEY } from "../services/StorageService";
+import StorageService, {
+  APP_ENV_KEY,
+} from "../services/storage/StorageService";
 
-export interface AppProviderState {
+interface AppProviderState {
   mode: string;
   handleSetMode(newMode: string): void;
   isDevMode: boolean;

--- a/source/store/CaseContext.tsx
+++ b/source/store/CaseContext.tsx
@@ -30,7 +30,7 @@ import {
   getDataToDecryptFromForm,
   getEncryptionFromCase,
 } from "../services/encryption/CaseEncryptionHelper";
-import { wrappedDefaultStorage } from "../services/StorageService";
+import { wrappedDefaultStorage } from "../services/storage/StorageService";
 
 const CaseState = React.createContext<ContextState>(defaultInitialState);
 const CaseDispatch = React.createContext<Dispatch>({});

--- a/source/store/actions/CaseActions.ts
+++ b/source/store/actions/CaseActions.ts
@@ -13,7 +13,7 @@ import { ApplicationStatusType } from "../../types/Case";
 import type { UserInterface } from "../../services/encryption/CaseEncryptionHelper";
 import { getCurrentForm } from "../../services/encryption/CaseEncryptionHelper";
 import { CaseEncryptionService } from "../../services/encryption";
-import { wrappedDefaultStorage } from "../../services/StorageService";
+import { wrappedDefaultStorage } from "../../services/storage/StorageService";
 import { to } from "../../helpers/Misc";
 import { PasswordStrategy } from "../../services/encryption/PasswordStrategy";
 import { filterAsync } from "../../helpers/Objects";


### PR DESCRIPTION
## Explain the changes you’ve made
Remove the dependency of IStorage for encryption service.

## Explain why these changes are made
The EncryptionService should not be aware of IStorage, hence removing that dependency.

## Explain your solution
Moved the Istorage dependency to StorageService file instead of EncryptionService. Renamed storage property to dependencies and created a new interface for that object.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Run the application as normal. You should be able to decrypt and encrypt form answers

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
