### PR TITLE
fix: transform markdown if exist in card component

### DIFF
--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
@@ -1,15 +1,21 @@
 import React, { useContext } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Linking } from "react-native";
+
 import Card from "../../components/molecules/Card/Card";
-import TextComponent from "../../components/atoms/Text";
-import Icon from "../../components/atoms/Icon";
-import icons from "../../helpers/Icons";
-import { launchPhone, launchEmail } from "../../helpers/LaunchExternalApp";
 import InfoModal from "../../components/molecules/InfoModal";
 import { useModal } from "../../components/molecules/Modal";
+
+import TextComponent from "../../components/atoms/Text";
+import Icon from "../../components/atoms/Icon";
+
+import icons from "../../helpers/Icons";
+import { launchPhone, launchEmail } from "../../helpers/LaunchExternalApp";
+import MarkdownConstructor from "../../helpers/MarkdownConstructor";
+
 import { replaceText } from "../Form/hooks/textReplacement";
 import AuthContext from "../../store/AuthContext";
+
 import type { PartnerInfo, User } from "../../types/UserTypes";
 
 interface Image {
@@ -137,19 +143,22 @@ const renderCardComponent = (
   completionsClarificationMessage?: string
 ) => {
   switch (component.type) {
-    case "text":
+    case "text": {
+      const replacedText = replaceText(
+        component.text,
+        user,
+        undefined,
+        partner,
+        undefined,
+        completionsClarificationMessage
+      );
+
       return (
         <Card.Text key={`${index}-${component.type}`} italic={component.italic}>
-          {replaceText(
-            component.text,
-            user,
-            undefined,
-            partner,
-            undefined,
-            completionsClarificationMessage
-          )}
+          <MarkdownConstructor rawText={replacedText} />
         </Card.Text>
       );
+    }
     case "title":
       return (
         <Card.Title key={`${index}-${component.type}`}>


### PR DESCRIPTION
## Explain the changes you’ve made
Transform text to markdown if exist in Card text component

## Explain why these changes are made
Text that is shown in the card component could contain markdown, this PR ensures that markdown is correct displayed.

## Explain your solution
Use the MarkdownConstructor component to transform into markdown if exists

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Open the `Grundansökan` form and check the first screen and its content.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
**BEFORE:**
![image](https://user-images.githubusercontent.com/9610681/186195740-03002c26-c34a-47e0-8095-75cacc74a36e.png)


**AFTER:**
![image](https://user-images.githubusercontent.com/9610681/186195660-5f7315f8-6012-4143-8e51-3a76d477f0ea.png)
