### PR TITLE
fix(markdownconstructor): fix styling for faulty bullet list

### DIFF
--- a/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
+++ b/source/containers/DynamicCardRenderer/DynamicCardRenderer.tsx
@@ -154,9 +154,11 @@ const renderCardComponent = (
       );
 
       return (
-        <Card.Text key={`${index}-${component.type}`} italic={component.italic}>
-          <MarkdownConstructor rawText={replacedText} />
-        </Card.Text>
+        <MarkdownConstructor
+          key={`${index}-${component.type}`}
+          rawText={replacedText}
+          italic={component.italic ?? false}
+        />
       );
     }
     case "title":

--- a/source/helpers/MarkdownConstructor.tsx
+++ b/source/helpers/MarkdownConstructor.tsx
@@ -40,6 +40,12 @@ const markDownStyles = {
     alignItems: "flex-start",
     justifyContent: "flex-start",
   },
+  bullet_list: {
+    flexWrap: "wrap",
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "flex-start",
+  },
 };
 
 const MarkdownConstructor = (props) => {

--- a/source/helpers/MarkdownConstructor.tsx
+++ b/source/helpers/MarkdownConstructor.tsx
@@ -44,12 +44,6 @@ const markDownStyles = {
     alignItems: "flex-start",
     justifyContent: "flex-start",
   },
-  bullet_list: {
-    flexWrap: "wrap",
-    flexDirection: "row",
-    alignItems: "flex-start",
-    justifyContent: "flex-start",
-  },
 };
 
 interface Props {

--- a/source/helpers/MarkdownConstructor.tsx
+++ b/source/helpers/MarkdownConstructor.tsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useRef } from "react";
 import Markdown from "react-native-markdown-display";
 import Text from "../components/atoms/Text";
 
@@ -9,8 +9,12 @@ import Text from "../components/atoms/Text";
  * Using own custom implementation of Text (...atoms/Text).
  *
  */
-const markdownRules = {
-  text: (node) => <Text key={node.key}>{node.content}</Text>,
+const markdownRules = (italic: boolean) => ({
+  text: (node) => (
+    <Text italic={italic} key={node.key}>
+      {node.content}
+    </Text>
+  ),
   strong: (node, children, _parent, _styles) => (
     <Text key={node.key}>
       {React.Children.map(children, (child, _index) =>
@@ -18,7 +22,7 @@ const markdownRules = {
       )}
     </Text>
   ),
-};
+});
 
 /**
  * Override markdown styles.
@@ -48,11 +52,15 @@ const markDownStyles = {
   },
 };
 
-const MarkdownConstructor = (props) => {
-  const { rawText } = props;
+interface Props {
+  rawText: string;
+  italic: boolean;
+}
+const MarkdownConstructor = ({ rawText, italic }: Props): JSX.Element => {
+  const rules = useRef(markdownRules(italic));
 
   return (
-    <Markdown rules={markdownRules} style={markDownStyles}>
+    <Markdown rules={rules.current} style={markDownStyles}>
       {rawText}
     </Markdown>
   );


### PR DESCRIPTION
## Explain the changes you’ve made
Fix faulty styling for markdown bullet list causing only bullets to be shown in a form. 

## Explain why these changes are made
We must be able to see bullet texts in a form

## Explain your solution
Only use the markdownconstructor component when card text is shown. Wrapping the markdownconstructor in a text component caused the styling of the markdown to be faulty.
Removed the text flickering by using `useRef` hook from react to avoid the rules being re-rendered on state change. 
Added italic property to align with formbuilder.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. start a form which uses Card (and card text) component
4. Make sure bullet list is written as markdown in one of the form questions
5. check the result in the application

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/9610681/186880649-9bd36b3f-ea2e-4723-bea1-e12d3c7f957f.png)

**After:**
![image](https://user-images.githubusercontent.com/9610681/186880591-fd623bf3-3528-4b2f-84b0-78f8bcd2a5fe.png)
