### PR TITLE
fix(package.json): update react-native-pdf package

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -316,7 +316,7 @@ PODS:
     - React
   - react-native-pager-view (5.4.25):
     - React-Core
-  - react-native-pdf (6.5.0):
+  - react-native-pdf (6.6.2):
     - React-Core
   - react-native-progress-bar-android (1.0.4):
     - React
@@ -665,11 +665,11 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0
@@ -690,7 +690,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: f68191637788994baed5f57d12994aa32cf8bf88
   react-native-network-info: d1290ffc0bd0709e11436f5b8d7f605dcc5c4530
   react-native-pager-view: da490aa1f902c9a5aeecf0909cc975ad0e92e53e
-  react-native-pdf: de35db0d8f1e5d37e65e887554f7d4bd062af56b
+  react-native-pdf: 33c622cbdf776a649929e8b9d1ce2d313347c4fa
   react-native-progress-bar-android: be43138ab7da30d51fc038bafa98e9ed594d0c40
   react-native-progress-view: 9e6b6a5305a9115c2157ae3b8852081aba0aab7c
   react-native-restart: 45c8dca02491980f2958595333cbccd6877cb57e

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-network-info": "^5.2.1",
     "react-native-pager-view": "^5.4.15",
-    "react-native-pdf": "^6.5.0",
+    "react-native-pdf": "^6.6.0",
     "react-native-picker-select": "^8.0.4",
     "react-native-restart": "^0.0.24",
     "react-native-safe-area-context": "^4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8224,12 +8224,13 @@ react-native-pager-view@^5.4.15:
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.25.tgz#cd639d5387a7f3d5581b55a33c5faa1cbc200f97"
   integrity sha512-3drrYwaLat2fYszymZe3nHMPASJ4aJMaxiejfA1V5SK3OygYmdtmV2u5prX7TnjueJzGSyyaCYEr2JlrRt4YPg==
 
-react-native-pdf@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-pdf/-/react-native-pdf-6.5.0.tgz#3418c9a3a95aa6a52463093f242ea3f5d943a5d7"
-  integrity sha512-R/RNF+/nhFXBkhrdAWLQRhtg9xcZkq/3wC+wq9lA+ORgn1sx+6VDtU7hWnY047FK0FRG8REUj4jILVSdpG2zDg==
+react-native-pdf@^6.6.0:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/react-native-pdf/-/react-native-pdf-6.6.2.tgz#a119aa3fd908c2c0a92102a78562530a35b9154b"
+  integrity sha512-gqxNPSzL0lNN1dGYAz9ObSLb0shUTB8x1u69qKLMSmwuxFTpGui5PNNgpH8q/nlpL9zBzMVVc/AXEuDCwRyxEQ==
   dependencies:
     crypto-js "^3.2.0"
+    deprecated-react-native-prop-types "^2.3.0"
 
 react-native-picker-select@^8.0.4:
   version "8.0.4"


### PR DESCRIPTION
## Explain the changes you’ve made
Updated to latest version of react-native-pdf library which caused an warning to be displayed.

## Explain why these changes are made
The react-native-pdf package prevented us from updating to latest versions of react-native and react because of an deprecated library included in the package. 

## Explain your solution
Updated the version in package.json

## How to test

1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command `yarn ios` or `yarn android`
4. Answer a form which has a question that uses react-native-pdf like FilePicker or PdfUploader

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
