### PR TITLE
Feat/show uploaded file filename

### DIFF
--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -11,10 +11,14 @@ import { splitFilePath } from "../../../helpers/FileUpload";
 const MAX_IMAGE_SIZE_BYTES = 7 * 1000 * 1000;
 
 function transformRawImage(rawImage: ImageOrVideo, questionId: string): Image {
+  const filename =
+    splitFilePath(rawImage.path).nameWithExt ?? rawImage?.filename;
+
   return {
     questionId,
     path: rawImage.path,
-    filename: splitFilePath(rawImage.path).nameWithExt ?? rawImage?.filename,
+    filename,
+    displayName: filename,
     width: rawImage.width,
     height: rawImage.height,
     size: rawImage.size,

--- a/source/components/molecules/FilePicker/pdfUpload.ts
+++ b/source/components/molecules/FilePicker/pdfUpload.ts
@@ -28,10 +28,13 @@ export async function addPdfFromLibrary(questionId: string): Promise<Pdf[]> {
       const split = splitFilePath(pdf?.name);
       const filePath = removeUriScheme(pdf.fileCopyUri ?? pdf.uri);
 
+      const filename = `${split.name}${split.ext}`;
+
       return {
         ...pdf,
         questionId,
-        filename: `${split.name}${split.ext}`,
+        filename,
+        displayName: filename,
         fileType: "pdf" as AllowedFileTypes,
         path: filePath,
         id: uuid.v4() as string,

--- a/source/components/molecules/ImageDisplay/ImageDisplay.tsx
+++ b/source/components/molecules/ImageDisplay/ImageDisplay.tsx
@@ -26,6 +26,7 @@ export interface Image extends CropPickerImage {
   index?: number;
   questionId: string;
   fileType: AllowedFileTypes;
+  displayName: string;
   id: string;
 }
 

--- a/source/components/molecules/ImageDisplay/ImageItem.tsx
+++ b/source/components/molecules/ImageDisplay/ImageItem.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components/native";
@@ -11,22 +10,23 @@ import { Modal, useModal } from "../Modal";
 import type { Image } from "./ImageDisplay";
 import { downloadFile } from "../../../helpers/FileUpload";
 
+const MAX_IMAGE_WIDTH = 120;
+
 const DefaultItem = styled.TouchableOpacity`
   margin-bottom: 20px;
+  margin-right: 20px;
 `;
 const Flex = styled.View`
   flex-direction: column;
   align-items: center;
   padding: 0;
   padding-top: 10px;
-  padding-right: 20px;
-  margin: 0;
 `;
 
 const DeleteBackground = styled.View`
   position: absolute;
-  top: 2px;
-  right: 7px;
+  top: 10px;
+  right: 2px;
   padding: 4px;
   elevation: 3;
   background: #eeeeee;
@@ -34,26 +34,25 @@ const DeleteBackground = styled.View`
   border-radius: 20px;
 `;
 const ButtonWrapper = styled.View`
-  padding: 5px;
   flex-direction: row;
+  margin-bottom: 40px;
   justify-content: center;
 `;
 const IconContainer = styled.View`
-  margin: 2px
+  margin: 2px;
   elevation: 2;
   shadow-offset: 0px 2px;
   shadow-color: black;
   shadow-opacity: 0.4;
   shadow-radius: 5px;
   border: 1px solid transparent;
-  elevation: 1;
 `;
 const ImageIcon = styled.Image`
-  width: 120px;
+  width: ${MAX_IMAGE_WIDTH}px;
   height: 170px;
 `;
 const ActivityWrapper = styled.View`
-  width: 120px;
+  width: ${MAX_IMAGE_WIDTH}px;
   height: 170px;
   flex-direction: row;
   justify-content: center;
@@ -153,6 +152,13 @@ const ImageItem: React.FC<Props> = ({ image, onRemove, onChange }) => {
               )}
           </IconContainer>
         </Flex>
+        <Text
+          align="center"
+          numberOfLines={1}
+          style={{ width: MAX_IMAGE_WIDTH }}
+        >
+          {image.displayName}
+        </Text>
       </DefaultItem>
       <Modal visible={modalVisible} hide={toggleModal}>
         {(fileStatus === "localFileAvailable" ||

--- a/source/components/molecules/ImageDisplay/ImageItem.tsx
+++ b/source/components/molecules/ImageDisplay/ImageItem.tsx
@@ -11,6 +11,7 @@ import type { Image } from "./ImageDisplay";
 import { downloadFile } from "../../../helpers/FileUpload";
 
 const MAX_IMAGE_WIDTH = 120;
+const MAX_IMAGE_HEIGHT = 170;
 
 const DefaultItem = styled.TouchableOpacity`
   margin-bottom: 20px;
@@ -49,11 +50,11 @@ const IconContainer = styled.View`
 `;
 const ImageIcon = styled.Image`
   width: ${MAX_IMAGE_WIDTH}px;
-  height: 170px;
+  height: ${MAX_IMAGE_HEIGHT}px;
 `;
 const ActivityWrapper = styled.View`
   width: ${MAX_IMAGE_WIDTH}px;
-  height: 170px;
+  height: ${MAX_IMAGE_HEIGHT}px;
   flex-direction: row;
   justify-content: center;
   align-items: center;

--- a/source/components/molecules/PdfDisplay/PdfDisplay.tsx
+++ b/source/components/molecules/PdfDisplay/PdfDisplay.tsx
@@ -29,6 +29,7 @@ export interface Pdf extends DocumentPickerResponse {
   fileType: AllowedFileTypes;
   path: string;
   filename?: string;
+  displayName: string;
   id: string;
 }
 

--- a/source/components/molecules/PdfDisplay/PdfItem.tsx
+++ b/source/components/molecules/PdfDisplay/PdfItem.tsx
@@ -1,24 +1,20 @@
 import React from "react";
 import styled from "styled-components/native";
 import type { GestureResponderEvent } from "react-native";
-import { TouchableOpacity, Dimensions, Pressable } from "react-native";
+import { TouchableOpacity, Dimensions } from "react-native";
 import PdfView from "react-native-pdf";
 import { Icon, Button, Text } from "../../atoms";
 import { Modal, useModal } from "../Modal";
 import type { Pdf } from "./PdfDisplay";
 
 const MAX_PDF_WIDTH = 120;
+const MAX_PDF_HEIGHT = 170;
 
-const DefaultItem = styled.TouchableOpacity`
-  margin-right: 20px;
-`;
 const Flex = styled.View`
   flex-direction: column;
   align-items: center;
-  padding: 0;
   padding-top: 10px;
-  margin: 0;
-  margin-bottom: 20px;
+  margin: 0px 20px 20px 0px;
 `;
 const DeleteBackground = styled.View`
   position: absolute;
@@ -30,12 +26,10 @@ const DeleteBackground = styled.View`
   z-index: 1;
   border-radius: 20px;
 `;
-const Container = styled.View`
-  margin: 2px;
+const Container = styled.TouchableOpacity`
   flex: 1;
   justify-content: center;
   align-items: center;
-  margin-top: 15px;
   margin: 2px;
   elevation: 2;
   shadow-offset: 0px 2px;
@@ -71,37 +65,30 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
   };
 
   return (
-    <React.Fragment key={pdf.path}>
-      <DefaultItem>
-        <Flex>
-          <DeleteBackground>
-            <TouchableOpacity onPress={handleRemove} activeOpacity={0.1}>
-              <Icon name="clear" color="#00213F" />
-            </TouchableOpacity>
-          </DeleteBackground>
-          <Container>
-            <Pressable onPress={toggleModal}>
-              <PdfView
-                source={{ uri: pdf.uri }}
-                style={{
-                  flex: 1,
-                  width: MAX_PDF_WIDTH,
-                  height: 170,
-                  backgroundColor: "white",
-                }}
-                singlePage
-              />
-            </Pressable>
-          </Container>
-          <Text
-            align="center"
-            numberOfLines={1}
-            style={{ width: MAX_PDF_WIDTH }}
-          >
-            {pdf.displayName}
-          </Text>
-        </Flex>
-      </DefaultItem>
+    <Flex key={pdf.path}>
+      <DeleteBackground>
+        <TouchableOpacity onPress={handleRemove} activeOpacity={0.1}>
+          <Icon name="clear" color="#00213F" />
+        </TouchableOpacity>
+      </DeleteBackground>
+
+      <Container onPress={toggleModal}>
+        <PdfView
+          pointerEvents="none"
+          source={{ uri: pdf.uri }}
+          style={{
+            width: MAX_PDF_WIDTH,
+            height: MAX_PDF_HEIGHT,
+            backgroundColor: "white",
+          }}
+          singlePage
+        />
+      </Container>
+
+      <Text align="center" numberOfLines={1} style={{ width: MAX_PDF_WIDTH }}>
+        {pdf.displayName}
+      </Text>
+
       <Modal visible={modalVisible} hide={toggleModal}>
         <PdfInModal
           source={{ uri: pdf.uri }}
@@ -114,7 +101,7 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
           </Button>
         </ButtonWrapper>
       </Modal>
-    </React.Fragment>
+    </Flex>
   );
 };
 

--- a/source/components/molecules/PdfDisplay/PdfItem.tsx
+++ b/source/components/molecules/PdfDisplay/PdfItem.tsx
@@ -7,19 +7,23 @@ import { Icon, Button, Text } from "../../atoms";
 import { Modal, useModal } from "../Modal";
 import type { Pdf } from "./PdfDisplay";
 
+const MAX_PDF_WIDTH = 120;
+
+const DefaultItem = styled.TouchableOpacity`
+  margin-right: 20px;
+`;
 const Flex = styled.View`
   flex-direction: column;
   align-items: center;
   padding: 0;
   padding-top: 10px;
-  padding-right: 20px;
   margin: 0;
   margin-bottom: 20px;
 `;
 const DeleteBackground = styled.View`
   position: absolute;
-  top: 2px;
-  right: 7px;
+  top: 10px;
+  right: 2px;
   padding: 4px;
   elevation: 3;
   background: #eeeeee;
@@ -27,12 +31,12 @@ const DeleteBackground = styled.View`
   border-radius: 20px;
 `;
 const Container = styled.View`
-  margin: 2px
+  margin: 2px;
   flex: 1;
   justify-content: center;
   align-items: center;
   margin-top: 15px;
-  margin: 2px
+  margin: 2px;
   elevation: 2;
   shadow-offset: 0px 2px;
   shadow-color: black;
@@ -40,6 +44,7 @@ const Container = styled.View`
   shadow-radius: 5px;
   border: 1px solid transparent;
 `;
+
 const PdfInModal = styled(PdfView)<{ width: number; height: number }>`
   background-color: white;
   flex: 1;
@@ -47,7 +52,7 @@ const PdfInModal = styled(PdfView)<{ width: number; height: number }>`
   height: ${({ height }) => height}px;
 `;
 const ButtonWrapper = styled.View`
-  padding: 5px;
+  padding-bottom: 40px;
   flex-direction: row;
   justify-content: center;
 `;
@@ -67,27 +72,36 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
 
   return (
     <React.Fragment key={pdf.path}>
-      <Flex>
-        <DeleteBackground>
-          <TouchableOpacity onPress={handleRemove} activeOpacity={0.1}>
-            <Icon name="clear" color="#00213F" />
-          </TouchableOpacity>
-        </DeleteBackground>
-        <Container>
-          <Pressable onPress={toggleModal}>
-            <PdfView
-              source={{ uri: pdf.uri }}
-              style={{
-                flex: 1,
-                width: 120,
-                height: 170,
-                backgroundColor: "white",
-              }}
-              singlePage
-            />
-          </Pressable>
-        </Container>
-      </Flex>
+      <DefaultItem>
+        <Flex>
+          <DeleteBackground>
+            <TouchableOpacity onPress={handleRemove} activeOpacity={0.1}>
+              <Icon name="clear" color="#00213F" />
+            </TouchableOpacity>
+          </DeleteBackground>
+          <Container>
+            <Pressable onPress={toggleModal}>
+              <PdfView
+                source={{ uri: pdf.uri }}
+                style={{
+                  flex: 1,
+                  width: MAX_PDF_WIDTH,
+                  height: 170,
+                  backgroundColor: "white",
+                }}
+                singlePage
+              />
+            </Pressable>
+          </Container>
+          <Text
+            align="center"
+            numberOfLines={1}
+            style={{ width: MAX_PDF_WIDTH }}
+          >
+            {pdf.displayName}
+          </Text>
+        </Flex>
+      </DefaultItem>
       <Modal visible={modalVisible} hide={toggleModal}>
         <PdfInModal
           source={{ uri: pdf.uri }}


### PR DESCRIPTION
## Explain the changes you’ve made
Show the filename under the file or image that has been uploaded in a form.
Also fixed an issue where files couldn't be "dragable" in the scroll list.

## Explain why these changes are made
The preview for images and files are a bit laggy and sometimes only white images are displayed. By adding the filename under the preview makes the user understand which image or file that has been uploaded.

## Explain your solution
Added new property (displayName) for both image and file type and added a text component under the preview.
Removed all touch events from the pdfview to make the content scrollable

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Answer a form where you would upload files or images with FilePicker

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
