### PR TITLE
bug(input): fix issue on "jumping" klar button on inputtype number

### DIFF
--- a/source/components/atoms/Input/Input.styled.ts
+++ b/source/components/atoms/Input/Input.styled.ts
@@ -7,6 +7,10 @@ import type { ErrorValidation } from "./Input.types";
 
 import type { PrimaryColor, ThemeType } from "../../../theme/themeHelpers";
 
+const InputContainer = styled.View`
+  width: 100%;
+`;
+
 interface StyledInputprops {
   theme: ThemeType;
   colorSchema: PrimaryColor;
@@ -50,4 +54,4 @@ const AccesoryViewChild = styled.View`
   padding-right: 16px;
 `;
 
-export { StyledTextInput, StyledErrorText, AccesoryViewChild };
+export { InputContainer, StyledTextInput, StyledErrorText, AccesoryViewChild };

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, forwardRef } from "react";
+import React, { useEffect, forwardRef, useRef } from "react";
 import type { TextInput } from "react-native";
 import {
   Keyboard,
@@ -7,6 +7,8 @@ import {
   View,
   InputAccessoryView,
 } from "react-native";
+
+import uuid from "react-native-uuid";
 import { useTheme } from "styled-components/native";
 
 import {
@@ -63,6 +65,8 @@ function Input(
   }: Props,
   ref: React.Ref<TextInput>
 ): JSX.Element {
+  const uniqueNativeId = useRef<string>(uuid.v4());
+
   const handleBlur = () => {
     if (onBlur) onBlur(value);
   };
@@ -78,10 +82,10 @@ function Input(
   useEffect(handleMount, []);
 
   const showAccessoryDoneButton =
-    Platform.OS === "ios" && inputType !== "email" && inputType !== "text";
+    Platform.OS === "ios" && !["email", "text"].includes(inputType ?? "");
 
   return (
-    <>
+    <View>
       <StyledTextInput
         value={replaceSpace(value)}
         multiline /** Temporary fix to make field scrollable inside scrollview */
@@ -96,7 +100,7 @@ function Input(
         onSubmitEditing={() => {
           Keyboard.dismiss();
         }}
-        inputAccessoryViewID="klar-accessory"
+        inputAccessoryViewID={uniqueNativeId.current}
         keyboardType={smartKeyboardType}
         colorSchema={colorSchema}
         {...smartKeyboardExtraProps}
@@ -109,7 +113,7 @@ function Input(
       )}
 
       {showAccessoryDoneButton && (
-        <InputAccessoryView nativeID="klar-accessory">
+        <InputAccessoryView nativeID={uniqueNativeId.current}>
           <AccesoryViewChild>
             <View>
               <Button title="Klar" onPress={Keyboard.dismiss} />
@@ -117,7 +121,7 @@ function Input(
           </AccesoryViewChild>
         </InputAccessoryView>
       )}
-    </>
+    </View>
   );
 }
 

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -7,7 +7,6 @@ import {
   View,
   InputAccessoryView,
 } from "react-native";
-
 import uuid from "react-native-uuid";
 import { useTheme } from "styled-components/native";
 

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -11,6 +11,7 @@ import uuid from "react-native-uuid";
 import { useTheme } from "styled-components/native";
 
 import {
+  InputContainer,
   StyledTextInput,
   StyledErrorText,
   AccesoryViewChild,
@@ -84,7 +85,7 @@ function Input(
     Platform.OS === "ios" && !["email", "text"].includes(inputType ?? "");
 
   return (
-    <View>
+    <InputContainer>
       <StyledTextInput
         value={replaceSpace(value)}
         multiline /** Temporary fix to make field scrollable inside scrollview */
@@ -120,7 +121,7 @@ function Input(
           </AccesoryViewChild>
         </InputAccessoryView>
       )}
-    </View>
+    </InputContainer>
   );
 }
 

--- a/source/components/atoms/Input/Input.tsx
+++ b/source/components/atoms/Input/Input.tsx
@@ -65,7 +65,7 @@ function Input(
   }: Props,
   ref: React.Ref<TextInput>
 ): JSX.Element {
-  const uniqueNativeId = useRef<string>(uuid.v4());
+  const uniqueNativeId = useRef(uuid.v4() as string);
 
   const handleBlur = () => {
     if (onBlur) onBlur(value);


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed an issue on accessoryview (i.e. Klar button on textinput with type number) on ios causing the "Klar" button to "jump" and be unavailable for users.

## Explain why these changes are made
The nativeID wasn't unique when multiple textinputs where used in a form, causing accessory view to disappear. The Klar button should always be available when using textinput for number on ios.

## Explain your solution
Created a unique nativeId with uuid v4 and useRef to avoid creating a new id on every render.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Open a form and a question with multiple inputs of different kinds like email, text and number. The Klar-button should be visible and not "jump" away from screen when visible.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
