### PR TITLE
fix(formfield.tsx): add required symbol on required fields

### DIFF
--- a/source/components/molecules/EditableList/EditableList.tsx
+++ b/source/components/molecules/EditableList/EditableList.tsx
@@ -281,44 +281,54 @@ function EditableList({
       )}
     >
       <EditableListBody>
-        {inputs.map((input, index) => [
-          <EditableListItem
-            colorSchema={colorSchema}
-            editable={editable && !input.disabled}
-            key={`${input.key}-${index}`}
-            error={error ? error[input.key] : undefined}
-            activeOpacity={1.0}
-            onPress={() => handleListItemPress(index)}
-          >
-            <EditableListItemLabelWrapper
-              alignAtStart={input.type === "select"}
+        {inputs.map((input, index) => {
+          const requiredSymbol = input.validation.isRequired ? " *" : "";
+          return [
+            <EditableListItem
+              colorSchema={colorSchema}
+              editable={editable && !input.disabled}
+              key={`${input.key}-${index}`}
+              error={error ? error[input.key] : undefined}
+              activeOpacity={1.0}
+              onPress={() => handleListItemPress(index)}
             >
-              <EditableListItemLabel editable={editable}>
-                {input.label}
-              </EditableListItemLabel>
-            </EditableListItemLabelWrapper>
-            <EditableListItemInputWrapper>
-              <InputComponent
-                {...{ input, colorSchema, onChange, onInputBlur, value, state }}
-                editable={editable && !input.disabled}
-                ref={(element) => {
-                  inputRefs.current[index] = element;
-                }}
-                onInputFocus={(event, isSelect) =>
-                  onInputFocus(event, index, isSelect)
-                }
-                onClose={(event, isSelect) =>
-                  onInputScrollTo(event, index, isSelect)
-                }
-              />
-            </EditableListItemInputWrapper>
-          </EditableListItem>,
-          isInputValid(input) && (
-            <StyledErrorText>
-              {error[input.key].validationMessage}
-            </StyledErrorText>
-          ),
-        ])}
+              <EditableListItemLabelWrapper
+                alignAtStart={input.type === "select"}
+              >
+                <EditableListItemLabel editable={editable}>
+                  {`${input.label}${requiredSymbol}`}
+                </EditableListItemLabel>
+              </EditableListItemLabelWrapper>
+              <EditableListItemInputWrapper>
+                <InputComponent
+                  {...{
+                    input,
+                    colorSchema,
+                    onChange,
+                    onInputBlur,
+                    value,
+                    state,
+                  }}
+                  editable={editable && !input.disabled}
+                  ref={(element) => {
+                    inputRefs.current[index] = element;
+                  }}
+                  onInputFocus={(event, isSelect) =>
+                    onInputFocus(event, index, isSelect)
+                  }
+                  onClose={(event, isSelect) =>
+                    onInputScrollTo(event, index, isSelect)
+                  }
+                />
+              </EditableListItemInputWrapper>
+            </EditableListItem>,
+            isInputValid(input) && (
+              <StyledErrorText>
+                {error[input.key].validationMessage}
+              </StyledErrorText>
+            ),
+          ];
+        })}
       </EditableListBody>
     </Fieldset>
   );

--- a/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterField/RepeaterFieldListItem.tsx
@@ -259,6 +259,8 @@ const RepeaterFieldListItem: React.FC<Props> = ({
           : undefined;
         const showErrorMessage = !error?.[input.id]?.isValid;
 
+        const requiredSymbol = input?.validation?.isRequired ? " *" : "";
+
         return (
           <RepeaterItem
             colorSchema={validColorSchema}
@@ -281,7 +283,7 @@ const RepeaterFieldListItem: React.FC<Props> = ({
             <InputLabelWrapper>
               <InputLabel
                 colorSchema={validColorSchema}
-              >{`${input.title}`}</InputLabel>
+              >{`${input.title}${requiredSymbol}`}</InputLabel>
             </InputLabelWrapper>
             <InputWrapper colorSchema={validColorSchema}>
               <InputComponent

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -332,6 +332,8 @@ const FormField = (props: FormFieldProps): JSX.Element => {
     },
   });
 
+  const requiredSymbol = props?.validation?.isRequired ? "*" : "";
+
   return (
     <FormFieldContainer>
       <LabelContainer>
@@ -345,7 +347,7 @@ const FormField = (props: FormFieldProps): JSX.Element => {
                 : {}
             }
           >
-            {label}
+            {`${label}${requiredSymbol}`}
           </Label>
         )}
       </LabelContainer>

--- a/source/containers/FormField/FormField.tsx
+++ b/source/containers/FormField/FormField.tsx
@@ -332,7 +332,7 @@ const FormField = (props: FormFieldProps): JSX.Element => {
     },
   });
 
-  const requiredSymbol = props?.validation?.isRequired ? "*" : "";
+  const requiredSymbol = props?.validation?.isRequired ? " *" : "";
 
   return (
     <FormFieldContainer>


### PR DESCRIPTION
## Explain the changes you’ve made
Added required symbol (*) after an inputs label to make it more clear that an input is required in a form.

## Explain why these changes are made
It is not always obvious that an input is required to be filled in before a user can continue in a form. Normally a star (*) is added to let the user know that something needs attention. 

## Explain your solution
Check the props.validation object if the `isRequired` property is true, if so, then an star (*) is added to the label.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a form with required inputs
4. Run the form in the application and see the results 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
