### PR TITLE
fix(formactions): remove validation of step answers for summarylist

### DIFF
--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -509,27 +509,11 @@ export function validateAllStepAnswers(
   // Validate all question inputs.
   state.validations = {};
   currentStepQuestions.forEach((question: any) => {
-    const itemsToValidate = [question];
+    const answer = state.formAnswers[question.id] || "";
+    dirtyFields[question.id] = true;
 
-    if (itemsToValidate.length > 0) {
-      itemsToValidate.forEach((validationItem) => {
-        const answer = state.formAnswers[validationItem.id] || "";
-        dirtyFields[validationItem.id] = true;
-
-        if (
-          shouldValidateAnswer(
-            validationItem,
-            state.formAnswers,
-            state.allQuestions
-          )
-        ) {
-          state = validateAnswer(
-            state,
-            { [validationItem.id]: answer },
-            validationItem.id
-          );
-        }
-      });
+    if (shouldValidateAnswer(question, state.formAnswers, state.allQuestions)) {
+      state = validateAnswer(state, { [question.id]: answer }, question.id);
     }
   });
 

--- a/source/containers/Form/hooks/formActions.ts
+++ b/source/containers/Form/hooks/formActions.ts
@@ -509,12 +509,7 @@ export function validateAllStepAnswers(
   // Validate all question inputs.
   state.validations = {};
   currentStepQuestions.forEach((question: any) => {
-    const { type, items } = question;
-    let itemsToValidate = [question];
-
-    if (type === "summaryList") {
-      itemsToValidate = items?.length > 0 ? items : [];
-    }
+    const itemsToValidate = [question];
 
     if (itemsToValidate.length > 0) {
       itemsToValidate.forEach((validationItem) => {


### PR DESCRIPTION
## Explain the changes you’ve made
Remove validation on step answers for summary list

## Explain why these changes are made
The validation on a summarylist did cause validation on fields that wasn't showed in the list. This caused the user to not be able to continue in the form since the hidden fields required values.

## Explain your solution
in `formActions`, remove code that handle validation for summarylist.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run a grundansökan form with validation "Grundansökan v.3 med valideringar" with id: 3ffa1100-fb93-11ec-b1b7-a797f65e09cb

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
