### PR TITLE
Feat/encryptionKeyId

### DIFF
--- a/source/screens/caseScreens/useGetFormPasswords.test.ts
+++ b/source/screens/caseScreens/useGetFormPasswords.test.ts
@@ -9,14 +9,15 @@ import type { User } from "../../types/UserTypes";
 jest.mock("../../services/encryption/CaseEncryptionHelper");
 jest.mock("../../services/storage/StorageService");
 
-function createTestCase(caseId: string, symmetricKeyName: string | null) {
+function createTestCase(caseId: string, encryptionKeyId: string | null) {
   return {
     currentFormId: "formId",
     id: caseId,
     forms: {
       formId: {
         encryption: {
-          symmetricKeyName,
+          encryptionKeyId,
+          symmetricKeyName: encryptionKeyId,
         },
       },
     },
@@ -52,27 +53,6 @@ it("returns form passwords for single case", async () => {
   expect(result.current).toEqual(expectedResult);
 });
 
-it("returns null as password when symmetricKeyName is missing", async () => {
-  jest
-    .spyOn(caseEncryptionHelper, "getPasswordForForm")
-    .mockResolvedValueOnce("password1");
-
-  const expectedResult = {
-    caseId: null,
-  };
-  const caseItems = {
-    caseId: createTestCase("caseId", null),
-  };
-
-  const { result, waitForNextUpdate } = renderHook(() =>
-    useGetFormPassword(caseItems, user)
-  );
-
-  await waitForNextUpdate();
-
-  expect(result.current).toEqual(expectedResult);
-});
-
 it("returns passwords for multiple cases", async () => {
   jest
     .spyOn(caseEncryptionHelper, "getPasswordForForm")
@@ -86,29 +66,6 @@ it("returns passwords for multiple cases", async () => {
   const caseItems = {
     caseId1: createTestCase("caseId1", "keyName1"),
     caseId2: createTestCase("caseId2", "keyName2"),
-  };
-
-  const { result, waitForNextUpdate } = renderHook(() =>
-    useGetFormPassword(caseItems, user)
-  );
-
-  await waitForNextUpdate();
-
-  expect(result.current).toEqual(expectedResult);
-});
-
-it("returns passwords only for cases with symmetricKeyName", async () => {
-  jest
-    .spyOn(caseEncryptionHelper, "getPasswordForForm")
-    .mockResolvedValueOnce("password1");
-
-  const expectedResult = {
-    caseId1: "password1",
-    caseId2: null,
-  };
-  const caseItems = {
-    caseId1: createTestCase("caseId1", "keyName1"),
-    caseId2: createTestCase("caseId2", null),
   };
 
   const { result, waitForNextUpdate } = renderHook(() =>

--- a/source/screens/caseScreens/useGetFormPasswords.ts
+++ b/source/screens/caseScreens/useGetFormPasswords.ts
@@ -22,12 +22,11 @@ function useGetFormPasswords(
     async (caseItem: Case, caseUser: User): Promise<PasswordPair> => {
       const { currentFormId, id } = caseItem;
       const form = caseItem.forms[currentFormId];
-      const hasSymmetricKey = !!form.encryption?.symmetricKeyName;
-
-      const encryptionPin = hasSymmetricKey
-        ? await getPasswordForForm(form, caseUser, wrappedDefaultStorage)
-        : null;
-
+      const encryptionPin = await getPasswordForForm(
+        form,
+        caseUser,
+        wrappedDefaultStorage
+      );
       return { id, password: encryptionPin };
     },
     []

--- a/source/services/encryption/PasswordStrategy.ts
+++ b/source/services/encryption/PasswordStrategy.ts
@@ -91,7 +91,9 @@ export const PasswordStrategy: IPasswordStrategy = {
   },
 
   getParamsID(context: EncryptionContext): string {
-    const paramsID = context.encryptionDetails?.symmetricKeyName;
+    const paramsID =
+      context.encryptionDetails?.encryptionKeyId ??
+      context.encryptionDetails?.symmetricKeyName;
 
     if (!paramsID) {
       throw new EncryptionException(

--- a/source/types/Encryption.ts
+++ b/source/types/Encryption.ts
@@ -51,6 +51,7 @@ declare module "react-native" {
 export interface EncryptionDetails {
   type: EncryptionType;
   symmetricKeyName?: string;
+  encryptionKeyId?: string;
   primes?: {
     P: PossiblySerializedCryptoNumber;
     G: PossiblySerializedCryptoNumber;


### PR DESCRIPTION
(Merge #769 first!)

## Explain the changes you’ve made

Added support for handling `encryptionKeyId`.

## Explain why these changes are made

`symmetricKeyName` has become a misleading name as it no longer has anything to do with symmetric key. Just renaming it will break existing cases however, so we introduce a new variable that will take its place once it has been fully adopted (should only take around 1 case period).

## How to test

Concrete example:

1. Have a recurring case ongoing/encrypted
2. Checkout this branch
3. Update app without removing storage data
4. Verify old case can still be decrypted
5. Create a new case using `encryptionKeyId` instead ([API PR 449](https://github.com/helsingborg-stad/helsingborg-io-sls-api/pull/449))
6. Verify it can be encrypted/decrypted as expected

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
