### PR TITLE
fix(validation): pass arguments correctly to validation methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/react-test-renderer": "^17.0.1",
     "@types/styled-components": "^5.1.14",
     "@types/styled-components-react-native": "^5.1.1",
+    "@types/validator": "^13.7.7",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "axios-mock-adapter": "^1.20.0",

--- a/source/helpers/ValidationHelper.ts
+++ b/source/helpers/ValidationHelper.ts
@@ -1,5 +1,4 @@
 import validator from "validator";
-
 /**
  * Checks if a string is a valid personal identity number
  * @param {string} pin Personal identity number
@@ -34,6 +33,29 @@ export const sanitizePin = (pin) => {
   return sanitizedPin;
 };
 
+function sanitizeRuleArguments(
+  args?: unknown
+): unknown[] | Record<string, unknown> {
+  if (args === undefined) {
+    return {};
+  }
+
+  if (Array.isArray(args)) {
+    return args;
+  }
+
+  if (typeof args === "object") {
+    const argsAsRecord = args as Record<string, unknown>;
+    if (typeof argsAsRecord.options === "object") {
+      return argsAsRecord.options as Record<string, unknown>;
+    }
+
+    return Object.values(argsAsRecord);
+  }
+
+  return [args];
+}
+
 /**
  * Use library validator.js to validate inputs.
  *
@@ -58,13 +80,8 @@ export const validateInput = (value, rules) =>
       if (value === false || value === undefined || value === null) {
         valueToValidate = "";
       }
-      /**
-       * Retrieve the validation method defined in the rule from the validator.js package and execute.
-       * An array of args will be created if multiple args defined. Single arg will be passed as is.
-       */
-      const ruleArgs = rule.args || [];
-      const validationMethodArgs =
-        rule.arg || Object.keys(ruleArgs).map((key) => ruleArgs[key]);
+
+      const validationMethodArgs = sanitizeRuleArguments(rule.args);
       const validationMethod =
         typeof rule.method === "string" ? validator[rule.method] : rule.method;
       /** For any other rule than the isEmpty, an empty value should be treated as valid. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,6 +2480,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/validator@^13.7.7":
+  version "13.7.7"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.7.tgz#e87cf34dd08522d21acf30130fd8941f433b81b5"
+  integrity sha512-jiEw2kTUJ8Jsh4A1K4b5Pkjj9Xz6FktLLOQ36ZVLRkmxFbpTvAV2VRoKMojz8UlZxNg/2dZqzpigH4JYn1bkQg==
+
 "@types/webpack-env@^1.15.0", "@types/webpack-env@^1.15.3":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.17.0.tgz#f99ce359f1bfd87da90cc4a57cab0a18f34a48d0"


### PR DESCRIPTION
## Explain the changes you’ve made

Fixed arguments not being passed correctly to validation methods.

## Explain why these changes are made

So validation behaves correctly.

## Explain your solution

Before arguments were incorrectly coerced to an array even when an object was expected. These arguments were silently ignored (like min/max length for personal number fields).

## How to test

Concrete example:

1. Checkout this branch
2. Verify personal number fields now correctly only accepts 12-digit strings
3. Verify the rest of validation works as expected

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
