### PR TITLE
fix(encryption): generate pin/key for random check and completion

### DIFF
--- a/source/store/actions/CaseActions.ts
+++ b/source/store/actions/CaseActions.ts
@@ -19,7 +19,14 @@ import { to } from "../../helpers/Misc";
 import { PasswordStrategy } from "../../services/encryption/PasswordStrategy";
 import { filterAsync } from "../../helpers/Objects";
 
-const { NOT_STARTED, NEW_APPLICATION } = ApplicationStatusType;
+const {
+  NOT_STARTED,
+  NEW_APPLICATION,
+  ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
+  ACTIVE_SUBMITTED_RANDOM_CHECK_VIVA,
+  ACTIVE_COMPLETION_REQUIRED_VIVA,
+  ACTIVE_SUBMITTED_COMPLETION,
+} = ApplicationStatusType;
 
 export async function updateCase(
   {
@@ -169,14 +176,20 @@ async function getCasesThatShouldGeneratePin(
   user: UserInterface,
   cases: Case[]
 ): Promise<Case[]> {
-  const notStartedCases = cases.filter(
+  const casesNeedingPin = cases.filter(
     (caseData) =>
-      [NOT_STARTED, NEW_APPLICATION].filter((statusType) =>
-        caseData.status.type.includes(statusType)
-      ).length > 0
+      [
+        NOT_STARTED,
+        NEW_APPLICATION,
+        ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
+        ACTIVE_SUBMITTED_RANDOM_CHECK_VIVA,
+        ACTIVE_COMPLETION_REQUIRED_VIVA,
+        ACTIVE_SUBMITTED_COMPLETION,
+      ].filter((statusType) => caseData.status.type.includes(statusType))
+        .length > 0
   );
 
-  const casesWhereUserIsMainApplicant = notStartedCases.filter((caseData) => {
+  const casesWhereUserIsMainApplicant = casesNeedingPin.filter((caseData) => {
     const selfPerson = caseData.persons.find(
       (person) => person.personalNumber === user.personalNumber
     );


### PR DESCRIPTION
## Explain the changes you’ve made

Generate pin/key for cases with statuses regarding random check and completion.

## Explain why these changes are made

After the switch to always use password-based encryption random check and completion was not taken into account and will need to generate new keys since their encryptionKeyId can change over time.

## How to test

Concrete example:

1. Checkout this branch
2. Do random check or completion (__not__ via dev features)
3. Verify you can save and submit as usual
4. After sending in once, verify you can save and submit as usual again for the same case

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
