### PR TITLE
Feat/redirect to settings alert

### DIFF
--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -1,4 +1,4 @@
-import { Alert, Linking } from "react-native";
+import { Alert, Linking, Platform } from "react-native";
 import ImagePicker from "react-native-image-crop-picker";
 import uuid from "react-native-uuid";
 
@@ -29,6 +29,16 @@ function showToBigFileAlert() {
   );
 }
 
+async function goToDeviceSettings() {
+  if (Platform.OS === "android") {
+    await Linking.openSettings();
+  }
+
+  if (Platform.OS === "ios") {
+    await Linking.openURL("app-settings:MittHelsingborg");
+  }
+}
+
 function showPermissionsAlert() {
   Alert.alert(
     "Tillåtelse",
@@ -40,7 +50,7 @@ function showPermissionsAlert() {
       },
       {
         text: "Inställningar",
-        onPress: () => Linking.openURL("app-settings:MittHelsingborg"),
+        onPress: goToDeviceSettings,
         style: "default",
       },
     ]

--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -1,4 +1,4 @@
-import { Alert, Linking, Platform } from "react-native";
+import { Alert, Linking } from "react-native";
 import ImagePicker from "react-native-image-crop-picker";
 import uuid from "react-native-uuid";
 
@@ -32,13 +32,7 @@ function showTooBigFileAlert() {
 }
 
 async function goToDeviceSettings() {
-  if (Platform.OS === "android") {
-    await Linking.openSettings();
-  }
-
-  if (Platform.OS === "ios") {
-    await Linking.openURL("app-settings:MittHelsingborg");
-  }
+  await Linking.openSettings();
 }
 
 function showPermissionsAlert() {

--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -20,6 +20,8 @@ const NO_IMAGE_UPLOAD_PERMISSION_CODES = [
   "E_NO_LIBRARY_PERMISSION",
 ];
 
+const SKIP_WARNING_CODES = ["E_PICKER_CANCELLED"];
+
 const MAX_IMAGE_SIZE_BYTES = 7 * 1000 * 1000;
 
 function showToBigFileAlert() {
@@ -80,8 +82,8 @@ function transformRawImage(rawImage: ImageOrVideo, questionId: string): Image {
 function handleUploadError(error: ImageUploadError) {
   if (NO_IMAGE_UPLOAD_PERMISSION_CODES.includes(error.code)) {
     showPermissionsAlert();
-  } else {
-    console.warn(error);
+  } else if (!SKIP_WARNING_CODES.includes(error.code)) {
+    console.error(error);
   }
 }
 

--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -15,12 +15,12 @@ interface ImageUploadError {
   code: PickerErrorCode;
 }
 
-const NO_IMAGE_UPLOAD_PERMISSION_CODES = [
+const NO_IMAGE_UPLOAD_PERMISSION_CODES: PickerErrorCode[] = [
   "E_NO_CAMERA_PERMISSION",
   "E_NO_LIBRARY_PERMISSION",
 ];
 
-const SKIP_WARNING_CODES = ["E_PICKER_CANCELLED"];
+const SKIP_WARNING_CODES: PickerErrorCode[] = ["E_PICKER_CANCELLED"];
 
 const MAX_IMAGE_SIZE_BYTES = 7 * 1000 * 1000;
 

--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -81,7 +81,7 @@ function handleUploadError(error: ImageUploadError) {
   if (NO_IMAGE_UPLOAD_PERMISSION_CODES.includes(error.code)) {
     showPermissionsAlert();
   } else {
-    console.error(error);
+    console.warn(error);
   }
 }
 

--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -24,7 +24,7 @@ const SKIP_WARNING_CODES: PickerErrorCode[] = ["E_PICKER_CANCELLED"];
 
 const MAX_IMAGE_SIZE_BYTES = 7 * 1000 * 1000;
 
-function showToBigFileAlert() {
+function showTooBigFileAlert() {
   Alert.alert(
     "Ogiltiga bilder",
     "Några av de angivna bilder är för stora. Varje bild får max vara 7 Mb."
@@ -99,7 +99,7 @@ export async function addImageFromCamera(questionId: string): Promise<Image[]> {
 
     if (rawImage) {
       if (rawImage.size > MAX_IMAGE_SIZE_BYTES) {
-        showToBigFileAlert();
+        showTooBigFileAlert();
       } else {
         return [rawImage].map((image) => transformRawImage(image, questionId));
       }

--- a/source/components/molecules/FilePicker/imageUpload.ts
+++ b/source/components/molecules/FilePicker/imageUpload.ts
@@ -1,14 +1,51 @@
-import { Alert } from "react-native";
-import type { ImageOrVideo } from "react-native-image-crop-picker";
+import { Alert, Linking } from "react-native";
 import ImagePicker from "react-native-image-crop-picker";
 import uuid from "react-native-uuid";
 
-import type { Image } from "../ImageDisplay/ImageDisplay";
-
-import type { AllowedFileTypes } from "../../../helpers/FileUpload";
+import type {
+  ImageOrVideo,
+  PickerErrorCode,
+} from "react-native-image-crop-picker";
 import { splitFilePath } from "../../../helpers/FileUpload";
 
+import type { AllowedFileTypes } from "../../../helpers/FileUpload";
+import type { Image } from "../ImageDisplay/ImageDisplay";
+
+interface ImageUploadError {
+  code: PickerErrorCode;
+}
+
+const NO_IMAGE_UPLOAD_PERMISSION_CODES = [
+  "E_NO_CAMERA_PERMISSION",
+  "E_NO_LIBRARY_PERMISSION",
+];
+
 const MAX_IMAGE_SIZE_BYTES = 7 * 1000 * 1000;
+
+function showToBigFileAlert() {
+  Alert.alert(
+    "Ogiltiga bilder",
+    "Några av de angivna bilder är för stora. Varje bild får max vara 7 Mb."
+  );
+}
+
+function showPermissionsAlert() {
+  Alert.alert(
+    "Tillåtelse",
+    "Mitt Helsingborg behöver din tillåtelse för att kunna lägga till bilder och filer från din enhet. Gå till inställningar för att ge tillåtelse.",
+    [
+      {
+        text: "Avbryt",
+        style: "cancel",
+      },
+      {
+        text: "Inställningar",
+        onPress: () => Linking.openURL("app-settings:MittHelsingborg"),
+        style: "default",
+      },
+    ]
+  );
+}
 
 function transformRawImage(rawImage: ImageOrVideo, questionId: string): Image {
   const filename =
@@ -30,6 +67,14 @@ function transformRawImage(rawImage: ImageOrVideo, questionId: string): Image {
   };
 }
 
+function handleUploadError(error: ImageUploadError) {
+  if (NO_IMAGE_UPLOAD_PERMISSION_CODES.includes(error.code)) {
+    showPermissionsAlert();
+  } else {
+    console.error(error);
+  }
+}
+
 export async function addImageFromCamera(questionId: string): Promise<Image[]> {
   try {
     const rawImage = await ImagePicker.openCamera({
@@ -42,16 +87,13 @@ export async function addImageFromCamera(questionId: string): Promise<Image[]> {
 
     if (rawImage) {
       if (rawImage.size > MAX_IMAGE_SIZE_BYTES) {
-        Alert.alert(
-          "Ogiltig bild",
-          "Bilden som angivits är för stor. Den får max vara 7 Mb."
-        );
+        showToBigFileAlert();
       } else {
         return [rawImage].map((image) => transformRawImage(image, questionId));
       }
     }
   } catch (error) {
-    if (error?.code !== "E_PICKER_CANCELLED") console.error(error);
+    handleUploadError(error as ImageUploadError);
   }
   return [];
 }
@@ -88,7 +130,7 @@ export async function addImagesFromLibrary(
       );
     }
   } catch (error) {
-    if (error?.code !== "E_PICKER_CANCELLED") console.error(error);
+    handleUploadError(error as ImageUploadError);
   }
 
   return [];


### PR DESCRIPTION
## Explain the changes you’ve made
Show an alert if application doesn't have access to camera and image library

## Explain why these changes are made
The increased validation in a form forces users to upload images in a step before continuing. Some users didn't gave the application permission to access the camera or the image library, which caused users being stuck in the form.
The application now shows an alert asking for permissions if it doesn't have access to the camera or image library.

## Explain your solution
The code now checks the error codes coming from the library that handles the camera and the image library. If codes that corresponds to camera and image library permissions, we then show an alert to the user.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have removed all permissions to camera and image library before answering a form
4. Make sure the form has the filepicker question type in it

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
