### PR TITLE
Fix/casecalculations modal crash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 34f7420274737b6fcf2e2d9fd42641e66b4436a3
   FBReactNativeSpec: 68c23fb2cea9393190e0815b673d742fa33d2dab
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -670,11 +670,11 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
+  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: b8caca023d386d43740dfb94c2cf68f695fa5e77
   RCTTypeSafety: ec44ea1d6ad1e5cd6447b22159ff40c2ebbd23b1
   React: 9f8c8afb9a9d61b7a1b01a1c6fb7f0d4f902988f

--- a/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
+++ b/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
@@ -51,7 +51,9 @@ function CaseCalculationsModal({
   );
   const calculationCosts = convertDataToArray(calculation?.costs?.cost);
   const calculationNorm = convertDataToArray(calculation?.norm?.normpart);
-  const calculationReductions = convertDataToArray(calculation?.reductions);
+  const calculationReductions = convertDataToArray(
+    calculation?.reductions?.reduction
+  );
 
   return (
     <Modal visible={isVisible} hide={toggleModal}>

--- a/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
+++ b/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
@@ -38,7 +38,7 @@ function CaseCalculationsModal({
 
   const calculationPeriodStartDate = calculation?.periodstartdate ?? "";
   const calculationPeriodEndDate = calculation?.periodenddate ?? "";
-  const calculationIncomeSum = calculation.incomesum ?? "";
+  const calculationIncomeSum = calculation?.incomesum ?? "";
 
   const calculationCostSum = formatAmount(calculation?.costsum, true);
   const calculationNormSubTotal = formatAmount(calculation?.normsubtotal, true);

--- a/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
+++ b/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
@@ -36,6 +36,23 @@ function CaseCalculationsModal({
 
   if (!isVisible) return null;
 
+  const calculationPeriodStartDate = calculation?.periodstartdate ?? "";
+  const calculationPeriodEndDate = calculation?.periodenddate ?? "";
+  const calculationIncomeSum = calculation.incomesum ?? "";
+
+  const calculationCostSum = formatAmount(calculation?.costsum, true);
+  const calculationNormSubTotal = formatAmount(calculation?.normsubtotal, true);
+  const calculationReductionSum = formatAmount(calculation?.reductionsum);
+  const calculationCalculationSum = formatAmount(calculation?.calculationsum);
+
+  const calculationIncome = convertDataToArray(calculation?.incomes?.income);
+  const calculationPersons = convertDataToArray(
+    calculation?.calculationpersons?.calculationperson
+  );
+  const calculationCosts = convertDataToArray(calculation?.costs?.cost);
+  const calculationNorm = convertDataToArray(calculation?.norm?.normpart);
+  const calculationReductions = convertDataToArray(calculation?.reductions);
+
   return (
     <Modal visible={isVisible} hide={toggleModal}>
       <CloseModalButton
@@ -66,36 +83,30 @@ function CaseCalculationsModal({
           <Card colorSchema="red">
             <Card.Body color="neutral">
               <Card.Title colorSchema="neutral">Beräkning</Card.Title>
-              {calculation?.periodstartdate && calculation?.periodenddate && (
-                <Card.Text>{`Period: ${calculation.periodstartdate} - ${calculation.periodenddate} `}</Card.Text>
+              {calculationPeriodStartDate && calculationPeriodEndDate && (
+                <Card.Text>{`Period: ${calculationPeriodStartDate} - ${calculationPeriodEndDate} `}</Card.Text>
               )}
               <CalculationRow>
                 <Card.Text strong>Inkomster</Card.Text>
-                <Card.Text>{formatAmount(calculation.incomesum)}</Card.Text>
+                <Card.Text>{formatAmount(calculationIncomeSum)}</Card.Text>
               </CalculationRow>
               <CalculationRow>
                 <Card.Text strong>Utgifter</Card.Text>
-                <Card.Text>{formatAmount(calculation.costsum, true)}</Card.Text>
+                <Card.Text>{calculationCostSum}</Card.Text>
               </CalculationRow>
               <CalculationRow>
                 <Card.Text strong>Belopp enligt norm</Card.Text>
-                <Card.Text>
-                  {formatAmount(calculation.normsubtotal, true)}
-                </Card.Text>
+                <Card.Text>{calculationNormSubTotal}</Card.Text>
               </CalculationRow>
               <CalculationRow>
                 <Card.Text strong>Reducering</Card.Text>
                 <Card.Text>
-                  <Card.Text>
-                    {formatAmount(calculation.reductionsum)}
-                  </Card.Text>
+                  <Card.Text>{calculationReductionSum}</Card.Text>
                 </Card.Text>
               </CalculationRow>
               <CalculationRow>
                 <Card.Text strong>Summa</Card.Text>
-                <Card.Text strong>
-                  {formatAmount(calculation.calculationsum)}
-                </Card.Text>
+                <Card.Text strong>{calculationCalculationSum}</Card.Text>
               </CalculationRow>
 
               <Card.Button
@@ -118,32 +129,26 @@ function CaseCalculationsModal({
                   <DetailsTitle type="h6">
                     Personer som påverkar normen
                   </DetailsTitle>
-                  {calculation?.calculationpersons?.calculationperson &&
-                    convertDataToArray(
-                      calculation?.calculationpersons?.calculationperson
-                    ).map((person, index) => (
-                      <Card
-                        key={`${index}-${person?.name}`}
-                        colorSchema="neutral"
-                      >
-                        <Card.Title colorSchema="neutral" strong>
-                          {person?.name}
-                        </Card.Title>
-                        <Card.SubTitle colorSchema="neutral" strong>
-                          {person?.pnumber}
-                        </Card.SubTitle>
-                        <Card.Text>
-                          Norm beräknad på {person?.days} dagar
-                        </Card.Text>
-                      </Card>
-                    ))}
+                  {calculationPersons.map((person) => (
+                    <Card key={person.name} colorSchema="neutral">
+                      <Card.Title colorSchema="neutral" strong>
+                        {person.name}
+                      </Card.Title>
+                      <Card.SubTitle colorSchema="neutral" strong>
+                        {person.pnumber}
+                      </Card.SubTitle>
+                      <Card.Text>
+                        Norm beräknad på {person.days} dagar
+                      </Card.Text>
+                    </Card>
+                  ))}
 
                   <Text strong type="h6">
                     Detaljerad beräkning
                   </Text>
 
                   <DetailsTitle type="h5">Inkomster</DetailsTitle>
-                  {calculation?.incomes?.income ? (
+                  {calculationIncome.length > 0 ? (
                     <>
                       <CalculationTable>
                         <CalculationRowHeader>
@@ -156,28 +161,26 @@ function CaseCalculationsModal({
                           <CalculationRowCell />
                         </CalculationRowHeader>
 
-                        {convertDataToArray(calculation?.incomes?.income).map(
-                          (income, index) => (
-                            <CalculationRow key={`${index}-${income?.type}`}>
-                              <CalculationRowCell>
-                                <Text>{income?.type}</Text>
-                              </CalculationRowCell>
-                              <CalculationRowCell>
-                                <Text>{income?.amount} kr</Text>
-                              </CalculationRowCell>
-                              <CalculationRowCell>
-                                {income.note ? (
-                                  <HelpButton
-                                    text={income.note}
-                                    heading={income.type}
-                                    tagline=""
-                                    icon="info"
-                                  />
-                                ) : null}
-                              </CalculationRowCell>
-                            </CalculationRow>
-                          )
-                        )}
+                        {calculationIncome.map((income) => (
+                          <CalculationRow key={income.type}>
+                            <CalculationRowCell>
+                              <Text>{income.type}</Text>
+                            </CalculationRowCell>
+                            <CalculationRowCell>
+                              <Text>{income.amount} kr</Text>
+                            </CalculationRowCell>
+                            <CalculationRowCell>
+                              {income.note ? (
+                                <HelpButton
+                                  text={income.note}
+                                  heading={income.type}
+                                  tagline=""
+                                  icon="info"
+                                />
+                              ) : null}
+                            </CalculationRowCell>
+                          </CalculationRow>
+                        ))}
                       </CalculationTable>
                     </>
                   ) : (
@@ -187,7 +190,7 @@ function CaseCalculationsModal({
                   )}
 
                   <DetailsTitle type="h5">Utgifter</DetailsTitle>
-                  {calculation?.costs?.cost ? (
+                  {calculationCosts.length > 0 ? (
                     <>
                       <CalculationTable>
                         <CalculationRowHeader>
@@ -200,31 +203,29 @@ function CaseCalculationsModal({
                           </CalculationRowCell>
                           <CalculationRowCell />
                         </CalculationRowHeader>
-                        {convertDataToArray(calculation?.costs?.cost).map(
-                          (cost, index) => (
-                            <CalculationRow key={`${index}-${cost.type}`}>
-                              <CalculationRowCell>
-                                <Text>{cost?.type}</Text>
-                              </CalculationRowCell>
-                              <CalculationRowCell>
-                                <Text>{formatAmount(cost.actual)}</Text>
-                              </CalculationRowCell>
-                              <CalculationRowCell>
-                                <Text>{formatAmount(cost.approved)}</Text>
-                              </CalculationRowCell>
-                              <CalculationRowCell>
-                                {cost.note ? (
-                                  <HelpButton
-                                    text={cost.note}
-                                    heading={cost.type}
-                                    tagline=""
-                                    icon="info"
-                                  />
-                                ) : null}
-                              </CalculationRowCell>
-                            </CalculationRow>
-                          )
-                        )}
+                        {calculationCosts.map((cost) => (
+                          <CalculationRow key={cost.type}>
+                            <CalculationRowCell>
+                              <Text>{cost.type}</Text>
+                            </CalculationRowCell>
+                            <CalculationRowCell>
+                              <Text>{formatAmount(cost.actual)}</Text>
+                            </CalculationRowCell>
+                            <CalculationRowCell>
+                              <Text>{formatAmount(cost.approved)}</Text>
+                            </CalculationRowCell>
+                            <CalculationRowCell>
+                              {cost.note ? (
+                                <HelpButton
+                                  text={cost.note}
+                                  heading={cost.type}
+                                  tagline=""
+                                  icon="info"
+                                />
+                              ) : null}
+                            </CalculationRowCell>
+                          </CalculationRow>
+                        ))}
                       </CalculationTable>
                     </>
                   ) : (
@@ -235,9 +236,9 @@ function CaseCalculationsModal({
 
                   <DetailsTitle type="h5">Belopp enligt norm</DetailsTitle>
 
-                  {calculation?.norm?.normpart ? (
+                  {calculationNorm.length > 0 ? (
                     <>
-                      {calculation.norm.normpart?.map((part, index) => {
+                      {calculationNorm.map((part, index) => {
                         const bottomPadding =
                           calculation.norm.normpart.length === index + 1
                             ? 0
@@ -245,7 +246,7 @@ function CaseCalculationsModal({
 
                         return (
                           <CalculationRow
-                            key={`${index}-${part.type}`}
+                            key={part.type}
                             paddingBottom={bottomPadding}
                           >
                             <CalculationRowCell flex={2}>
@@ -267,19 +268,17 @@ function CaseCalculationsModal({
                   )}
 
                   <DetailsTitle type="h5">Reducering</DetailsTitle>
-                  {calculation?.reductions?.reduction ? (
+                  {calculationReductions.length > 0 ? (
                     <>
-                      {convertDataToArray(
-                        calculation?.reductions?.reduction
-                      ).map((reduction, index) => (
-                        <CalculationRow key={`${index}-${reduction.type}`}>
+                      {calculationReductions.map((reduction) => (
+                        <CalculationRow key={reduction.type}>
                           <CalculationRowCell>
-                            <Text>{reduction?.type}</Text>
+                            <Text>{reduction.type}</Text>
                           </CalculationRowCell>
                           <CalculationRowCell>
                             <Text>
-                              {reduction?.days}{" "}
-                              {reduction?.days > 1 ? "dagar" : "dag"}
+                              {reduction.days}{" "}
+                              {reduction.days > 1 ? "dagar" : "dag"}
                             </Text>
                           </CalculationRowCell>
                           <CalculationRowCell>
@@ -299,9 +298,7 @@ function CaseCalculationsModal({
 
                   <CalculationRow>
                     <Card.Text strong>Summa</Card.Text>
-                    <Card.Text strong>
-                      {formatAmount(calculation.calculationsum)}
-                    </Card.Text>
+                    <Card.Text strong>{calculationCalculationSum}</Card.Text>
                   </CalculationRow>
                 </>
               )}

--- a/source/components/organisms/index.ts
+++ b/source/components/organisms/index.ts
@@ -2,5 +2,5 @@ export { default as Step } from "./Step";
 export { default as SummaryList } from "./SummaryList";
 export { default as PrivacyModal } from "./PrivacyModal/PrivacyModal";
 export { default as LoginModal } from "./LoginModal/LoginModal";
-export { default as CaseCalculationModal } from "./CaseCalculationsModal/CaseCalculationsModal";
+export { default as CaseCalculationsModal } from "./CaseCalculationsModal/CaseCalculationsModal";
 export { default as RemoveCaseModal } from "./RemoveCaseModal/RemoveCaseModal";

--- a/source/helpers/FormatVivaData.ts
+++ b/source/helpers/FormatVivaData.ts
@@ -23,7 +23,8 @@ const formatAmount = (value, negative = false) => {
  * (VIVA nonconsecutively returns arrays and objects)
  * @param {Object|string[]} data
  */
-const convertDataToArray = (data) => (Array.isArray(data) ? data : [data]);
+const convertDataToArray = (data) =>
+  Array.isArray(data) ? data : [data].filter(Boolean);
 
 /**
  * Returns sum of multiple amounts with Swedish currency

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -31,7 +31,7 @@ import type {
   Workflow,
   Journal,
   Decision,
-  Calculation,
+  Calculations,
 } from "../../types/Case";
 
 import statusTypeConstantMapper from "./statusTypeConstantMapper";
@@ -229,7 +229,7 @@ const CaseSummary = (props: Props): JSX.Element => {
   const { workflow = {}, administrators } = details;
   const {
     decision = {} as Decision,
-    calculations = {} as Record<string, Calculation>,
+    calculations = {} as Calculations,
     journals = {} as Journal,
   } = workflow as Workflow;
 
@@ -387,7 +387,7 @@ const CaseSummary = (props: Props): JSX.Element => {
       <CaseCalculationsModal
         isVisible={isModalVisible}
         toggleModal={toggleModal}
-        calculation={calculations.calculation}
+        calculation={calculations?.calculation}
         decisions={decisions}
         notes={journals?.journal?.notes?.note ?? []}
       />

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -15,7 +15,7 @@ import type { PrimaryColor } from "../../theme/themeHelpers";
 import { Icon, Text } from "../../components/atoms";
 import { Card, ScreenWrapper, CaseCard } from "../../components/molecules";
 import {
-  CaseCalculationModal,
+  CaseCalculationsModal,
   RemoveCaseModal,
 } from "../../components/organisms";
 import { useModal } from "../../components/molecules/Modal";
@@ -384,7 +384,7 @@ const CaseSummary = (props: Props): JSX.Element => {
         )}
       </Container>
 
-      <CaseCalculationModal
+      <CaseCalculationsModal
         isVisible={isModalVisible}
         toggleModal={toggleModal}
         calculation={calculations.calculation}

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -62,6 +62,51 @@ interface CalculationNorm {
   normpart: CalculationNormpart[];
 }
 
+interface CalculationPerson {
+  name: string | null;
+  pnumber: string | null;
+  norm: string | null;
+  days: string | null;
+  home: string | null;
+  daycare: string | null;
+}
+
+interface CalculationPersons {
+  calculationperson: CalculationPerson[] | CalculationPerson;
+}
+
+interface Cost {
+  type: string | null;
+  actual: string | null;
+  approved: string | null;
+  note: string | null;
+}
+
+interface Costs {
+  cost: Cost | Cost[];
+}
+
+interface Income {
+  type: string;
+  amount: string;
+  note: Note;
+}
+
+interface Incomes {
+  income: Income | Income[];
+}
+
+interface Reduction {
+  type: string;
+  days: string;
+  note: Note;
+  amount: string;
+}
+
+interface Reductions {
+  reduction: Reduction | Reduction[];
+}
+
 export interface Calculation {
   periodstartdate: string;
   periodenddate: string;
@@ -71,6 +116,14 @@ export interface Calculation {
   reductionsum: string;
   calculationsum: string;
   norm: CalculationNorm;
+  calculationpersons: CalculationPersons;
+  costs: Costs;
+  incomes: Incomes;
+  reductions: Reductions;
+}
+
+export interface Calculations {
+  calculation: Calculation;
 }
 
 export interface Note {
@@ -93,7 +146,7 @@ export interface Decision {
 
 export interface Workflow {
   application: Application;
-  calculations: Record<string, Calculation>;
+  calculations: Calculations;
   journals: Journal;
   decision: Decision;
 }


### PR DESCRIPTION
## Explain the changes you’ve made
Add "livrem och hänglen" on calculations in casecalculationsmodal

## Explain why these changes are made
Sentry did report a crash which originates from the casecalculation modal. Since calculations are very nested, there is a possibility that the crash originated from that property.

## Explain your solution
Default every property in the nested calculations object. 

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Create a case with calculations with type `closed:approved:viva` 
4. Go to case summary and watch all calculations

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
