### PR TITLE
Fix/fetch cases with user object

### DIFF
--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -59,7 +59,6 @@ const computeCaseCardComponent = (
 ) => {
   const {
     currentPosition: { currentMainStep: currentStep, numberOfMainSteps },
-    answers,
   } = caseItem?.forms[caseItem?.currentFormId];
 
   const caseId = caseItem.id;

--- a/source/store/CaseContext.tsx
+++ b/source/store/CaseContext.tsx
@@ -123,6 +123,8 @@ function CaseProvider({
   };
 
   const fetchCases = useCallback(async () => {
+    if (!user) return;
+
     const fetchData = await fetch(user);
 
     const rawPayload = fetchData.payload as Record<string, Case>;


### PR DESCRIPTION
## Explain the changes you’ve made
Only fetch cases when a user has ben set in state

## Explain why these changes are made
In the `fetchCases` function, make sure that a user object is set in state before fetching cases belonging to the current user. This will make sure that we are not using an empty users object in `CaseSummary`since users can enter that screen regardless if a user is in state or not,

## Explain your solution
In `fetchCases`, make sure that user exists. If not, then do nothing.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run the application as normal

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
