### PR TITLE
fix(android): disable landscape orientation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+        android:screenOrientation="userPortrait"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize"
         android:exported="true">


### PR DESCRIPTION
## Explain the changes you’ve made

Disabled landscape mode on Android.

## Explain why these changes are made

For consistency since iOS also has landscape disabled. Landscape is disabled since layouts are not designed for landscape and are problematic right now.

## Explain your solution

Added part to manifest that locks Android screen orientation.

## How to test

Concrete example:

1. Checkout this branch
2. Deploy on Android
3. Verify app stays in portrait mode even if rotating device.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
