### PR TITLE
Fix/bankid collect crash

### DIFF
--- a/source/helpers/MessageHelper.ts
+++ b/source/helpers/MessageHelper.ts
@@ -1,4 +1,14 @@
-const messages = {
+type BankIDMessageKey =
+  | "userCancel"
+  | "startFailed"
+  | "expiredTransaction"
+  | "certificateErr"
+  | "userSign"
+  | "unknownError"
+  | "technicalError"
+  | "userNotFound";
+
+const messages: Record<BankIDMessageKey, string> = {
   /** BankID recommended user messages * */
   userCancel: "Åtgärden avbruten.",
   certificateErr:
@@ -22,6 +32,7 @@ const messages = {
  * @param {String} key  Key for the message
  * @return {String}     Value of the message
  */
-const getMessage = (key) => messages[key] || messages.unknownError;
+const getMessage = (key: BankIDMessageKey): string =>
+  messages[key] || messages.unknownError;
 
-export { getMessage };
+export default getMessage;

--- a/source/helpers/MessageHelper.ts
+++ b/source/helpers/MessageHelper.ts
@@ -6,7 +6,8 @@ type BankIDMessageKey =
   | "userSign"
   | "unknownError"
   | "technicalError"
-  | "userNotFound";
+  | "userNotFound"
+  | "unkownError",
 
 const messages: Record<BankIDMessageKey, string> = {
   /** BankID recommended user messages * */
@@ -24,6 +25,7 @@ const messages: Record<BankIDMessageKey, string> = {
   unknownError: "Okänt fel. Försök igen.",
   userNotFound:
     "Du har tyvärr inte åtkomst till tjänsten. För vidare hjälp ring kontaktcenter på 042-10 50 00.",
+  unkownError: "Okänt fel. Försök igen.",
 };
 
 /**

--- a/source/helpers/MessageHelper.ts
+++ b/source/helpers/MessageHelper.ts
@@ -7,7 +7,7 @@ type BankIDMessageKey =
   | "unknownError"
   | "technicalError"
   | "userNotFound"
-  | "unkownError",
+  | "unkownError";
 
 const messages: Record<BankIDMessageKey, string> = {
   /** BankID recommended user messages * */

--- a/source/helpers/MessageHelper.ts
+++ b/source/helpers/MessageHelper.ts
@@ -6,8 +6,7 @@ type BankIDMessageKey =
   | "userSign"
   | "unknownError"
   | "technicalError"
-  | "userNotFound"
-  | "unkownError";
+  | "userNotFound";
 
 const messages: Record<BankIDMessageKey, string> = {
   /** BankID recommended user messages * */
@@ -25,7 +24,6 @@ const messages: Record<BankIDMessageKey, string> = {
   unknownError: "Okänt fel. Försök igen.",
   userNotFound:
     "Du har tyvärr inte åtkomst till tjänsten. För vidare hjälp ring kontaktcenter på 042-10 50 00.",
-  unkownError: "Okänt fel. Försök igen.",
 };
 
 /**

--- a/source/services/AuthService.ts
+++ b/source/services/AuthService.ts
@@ -157,7 +157,7 @@ export async function getUserProfile(accessToken) {
         throw new Error(getMessage("userNotFound"));
       }
 
-      throw new Error(getMessage("unkownError"));
+      throw new Error(getMessage("unknownError"));
     }
   } catch (error) {
     return [null, error];

--- a/source/services/AuthService.ts
+++ b/source/services/AuthService.ts
@@ -4,7 +4,7 @@ import StorageService, {
   REFRESH_TOKEN_KEY,
 } from "./storage/StorageService";
 import { post, get } from "../helpers/ApiRequest";
-import { getMessage } from "../helpers/MessageHelper";
+import getMessage from "../helpers/MessageHelper";
 
 /**
  * This function retrives the accessToken from AsyncStorage and decodes it.

--- a/source/services/BankidService.ts
+++ b/source/services/BankidService.ts
@@ -36,7 +36,7 @@ async function collect(
     if (response.status === 200 && bankIDStatus === "failed") {
       return { success: false, data: getMessage(hintCode) };
     }
-    return { success: true, data: response.data.data };
+    return { success: true, data: response?.data?.data };
   } catch (error) {
     console.error(`BankID Collect Error: ${error}`);
     return { success: false, data: getMessage("unkownError") };

--- a/source/services/BankidService.ts
+++ b/source/services/BankidService.ts
@@ -23,7 +23,7 @@ async function collect(
     const response = await post("auth/bankid/collect", { orderRef });
     const bankIDStatus = response?.data?.data?.attributes?.status;
     const hintCode =
-      response?.data?.data?.attributes?.hintCode ?? "unkownError";
+      response?.data?.data?.attributes?.hintCode ?? "unknownError";
 
     if (response.status === 404) {
       return { success: false, data: getMessage("userCancel") };
@@ -39,7 +39,7 @@ async function collect(
     return { success: true, data: response?.data?.data };
   } catch (error) {
     console.error(`BankID Collect Error: ${error}`);
-    return { success: false, data: getMessage("unkownError") };
+    return { success: false, data: getMessage("unknownError") };
   }
 }
 

--- a/source/services/BankidService.ts
+++ b/source/services/BankidService.ts
@@ -16,18 +16,15 @@ async function getIPForBankID() {
  * Function for polling the status in a BankID authentication process.
  * @param {string} orderRef A valid BankID order reference
  */
-async function collect(orderRef: string) {
+async function collect(
+  orderRef: string
+): Promise<{ success: boolean; data: string }> {
   try {
     const response = await post("auth/bankid/collect", { orderRef });
     const bankIDStatus = response?.data?.data?.attributes?.status;
+    const hintCode =
+      response?.data?.data?.attributes?.hintCode ?? "unkownError";
 
-    if (response.status === 502) {
-      // Status 502 is a connection timeout error,
-      // may happen when the connection was pending for too long,
-      // and the remote server or a proxy closed it
-      // let's reconnect
-      return await collect(orderRef);
-    }
     if (response.status === 404) {
       return { success: false, data: getMessage("userCancel") };
     }
@@ -37,7 +34,7 @@ async function collect(orderRef: string) {
       return await collect(orderRef);
     }
     if (response.status === 200 && bankIDStatus === "failed") {
-      return { success: false, data: getMessage(response.data.data.hintCode) };
+      return { success: false, data: getMessage(hintCode) };
     }
     return { success: true, data: response.data.data };
   } catch (error) {


### PR DESCRIPTION
## Explain the changes you’ve made
Make sure collect function doesn't handle undefined values

## Explain why these changes are made
A crash were reported in sentry that collect function were handled undefined values. 
Also, this PR also covers a faulty status code 502 which isn't time out status code.

## Explain your solution
Use optional chaining where needed.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Try sign in
4. abort the sign in on both bankId app and modal in app.
5. try sign a case and abort signing

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
