### PR TITLE
fix(loginmodal.tsx): remove onsubmitediting

### DIFF
--- a/source/components/organisms/LoginModal/LoginModal.tsx
+++ b/source/components/organisms/LoginModal/LoginModal.tsx
@@ -95,7 +95,6 @@ function LoginModal({
                 onChangeText={handlePersonalNumber}
                 keyboardType="number-pad"
                 maxLength={12}
-                onSubmitEditing={handleLoginExternalDevice}
                 center
               />
               <Button


### PR DESCRIPTION
## Explain the changes you’ve made
Disable onsubmitediting which could trigger the login flow with an empty personal number.

## Explain why these changes are made
Login with an empty personal number caused the login flow to fail, which were expected since you cannot login with an empty personal number. 
This behavior is also only on Android, hence changing it to align it with Ios devices.

## Explain your solution
remove the onsubmitediting callback from the login input. The user can now only trigger the login from the login button.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. On android, login with externa BankID, **don't** add a personal number, press the "accept"- button on the keyboard, the keyboard should only be minimized and not start the login flow
4. On Ios, it should work as usual

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.
