### PR TITLE
fix(bankidservice): handle correct error codes from bankid

### DIFF
--- a/source/services/BankidService.ts
+++ b/source/services/BankidService.ts
@@ -25,8 +25,8 @@ async function collect(
     const hintCode =
       response?.data?.data?.attributes?.hintCode ?? "unknownError";
 
-    if (response.status === 404) {
-      return { success: false, data: getMessage("userCancel") };
+    if (response.status === 400) {
+      return { success: false, data: "" };
     }
     if (response.status === 200 && bankIDStatus === "pending") {
       // Reconnect in one 1050 ms

--- a/source/services/BankidService.ts
+++ b/source/services/BankidService.ts
@@ -28,6 +28,11 @@ async function collect(
     if (response.status === 400) {
       return { success: false, data: "" };
     }
+
+    if (response.status === 404) {
+      return { success: false, data: getMessage("userCancel") };
+    }
+
     if (response.status === 200 && bankIDStatus === "pending") {
       // Reconnect in one 1050 ms
       await new Promise((resolve) => setTimeout(resolve, 1050));


### PR DESCRIPTION
## Explain the changes you’ve made
Handle error codes that's described in BankID documentation and whats returned from the API.

## Explain why these changes are made
The application did handle status code 404, which actually was a transformed 400 from BankID service. The documentation from bankID says that no errors should be displayed to the users if code 400 is returned, hence updating the application.

BankID docs:
https://www.bankid.com/en/utvecklare/guider/teknisk-integrationsguide/graenssnittsbeskrivning/felfall

## Explain your solution
Remove the parts that handles status code 404 and fix result of collect function.

## How to test

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure changes in branch fix/bankid-collect-response is deployed in api
4. Run the application as usual

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
