### PR TITLE
fix: (completions) get duedate from correct attribute

### DIFF
--- a/source/containers/Form/hooks/test/textReplacement.test.ts
+++ b/source/containers/Form/hooks/test/textReplacement.test.ts
@@ -302,7 +302,7 @@ describe("replaceCaseItemText", () => {
   });
 
   it("replaces text on multiple `to` properties with multiple keys", () => {
-    const expectedDescription = `Month: January, duedate: ${mockCase.details.workflow.application.completionduedate}`;
+    const expectedDescription = "Month: January, duedate: 2022-05-16";
 
     mockCase.status.detailedDescription =
       "Month: #MONTH_NAME, duedate: #COMPLETION_DUEDATE";

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -21,13 +21,13 @@ type CaseItemReplacementRuleType = {
 const caseItemReplacementRules: CaseItemReplacementRuleType[] = [
   {
     key: "#MONTH_NAME",
-    from: "details.workflow.application.periodstartdate",
+    from: "details.period.startDate",
     to: ["status.description", "status.detailedDescription"],
     timeFormat: "MMMM",
   },
   {
     key: "#COMPLETION_DUEDATE",
-    from: "details.workflow.application.completionduedate",
+    from: "details.completions.dueDate",
     to: ["status.description", "status.detailedDescription"],
   },
   {


### PR DESCRIPTION
We should avoid getting data from the viva raw workflow data.