### PR TITLE
fix(useragreementtext.ts): change authority

### DIFF
--- a/source/assets/text/userAgreementText.ts
+++ b/source/assets/text/userAgreementText.ts
@@ -50,7 +50,7 @@ Om du vill komma i kontakt med Stadens dataskyddsombud ring 042-10 50 00 (växel
 
 
 
-Om du vill klaga på vår behandling av dina personuppgifter kan du vända dig till Datainspektionen, [http://www.datainspektionen.se/](http://www.datainspektionen.se/)
+Om du vill klaga på vår behandling av dina personuppgifter kan du vända dig till Integritetsskyddsmyndigheten, [http://www.imy.se](http://www.imy.se)
 `;
 
 export default userAgreementText;


### PR DESCRIPTION
## Explain the changes you’ve made
Change name on authority handling user data

## Explain why these changes are made
Dataskyddsinspektionen did change its name 1 of januari 2021 to Integritetsskyddsmyndigheten, hence changing it.

## Explain your solution
Changed the useragreement text with correct authority name and url.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Open the privacy modal in the login scree
4. Check the new authority at the bottom of the modal

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

<img width="369" alt="image" src="https://user-images.githubusercontent.com/9610681/195325684-63e85355-6332-4976-9759-eb42d6c404fc.png">
