### PR TITLE
Fix/remove button styling on preview

### DIFF
--- a/source/components/molecules/ImageDisplay/ImageItem.tsx
+++ b/source/components/molecules/ImageDisplay/ImageItem.tsx
@@ -16,6 +16,7 @@ const MAX_IMAGE_HEIGHT = 170;
 const DefaultItem = styled.TouchableOpacity`
   margin-bottom: 20px;
   margin-right: 20px;
+  padding-top: 6px;
 `;
 const Flex = styled.View`
   flex-direction: column;

--- a/source/components/molecules/ImageDisplay/ImageItem.tsx
+++ b/source/components/molecules/ImageDisplay/ImageItem.tsx
@@ -13,6 +13,10 @@ import { downloadFile } from "../../../helpers/FileUpload";
 const MAX_IMAGE_WIDTH = 120;
 const MAX_IMAGE_HEIGHT = 170;
 
+const SafeArea = styled.SafeAreaView`
+  flex: 1;
+`;
+
 const DefaultItem = styled.TouchableOpacity`
   margin-bottom: 20px;
   margin-right: 20px;
@@ -165,31 +169,33 @@ const ImageItem: React.FC<Props> = ({ image, onRemove, onChange }) => {
       <Modal visible={modalVisible} hide={toggleModal}>
         {(fileStatus === "localFileAvailable" ||
           fileStatus === "downloadedFileAvailable") && (
-          <ImageZoom
-            cropWidth={Dimensions.get("window").width}
-            cropHeight={Dimensions.get("window").height * 0.89}
-            imageWidth={image.width}
-            imageHeight={image.height}
-            panToMove
-            enableCenterFocus={false}
-            centerOn={{
-              x: 0,
-              y: 0,
-              scale: Dimensions.get("window").width / image.width,
-              duration: 10,
-            }}
-            minScale={Dimensions.get("window").width / image.width}
-          >
-            <RNImage
-              style={{ width: image.width, height: image.height }}
-              source={{
-                uri:
-                  fileStatus === "localFileAvailable"
-                    ? image.path
-                    : downloadedFilePath,
+          <SafeArea>
+            <ImageZoom
+              cropWidth={Dimensions.get("window").width}
+              cropHeight={Dimensions.get("window").height * 0.89}
+              imageWidth={image.width}
+              imageHeight={image.height}
+              panToMove
+              enableCenterFocus={false}
+              centerOn={{
+                x: 0,
+                y: 0,
+                scale: Dimensions.get("window").width / image.width,
+                duration: 10,
               }}
-            />
-          </ImageZoom>
+              minScale={Dimensions.get("window").width / image.width}
+            >
+              <RNImage
+                style={{ width: image.width, height: image.height }}
+                source={{
+                  uri:
+                    fileStatus === "localFileAvailable"
+                      ? image.path
+                      : downloadedFilePath,
+                }}
+              />
+            </ImageZoom>
+          </SafeArea>
         )}
         {(fileStatus === "downloading" || fileStatus === "checkLocalFile") && (
           <ActivityWrapperModal

--- a/source/components/molecules/PdfDisplay/PdfItem.tsx
+++ b/source/components/molecules/PdfDisplay/PdfItem.tsx
@@ -10,6 +10,10 @@ import type { Pdf } from "./PdfDisplay";
 const MAX_PDF_WIDTH = 120;
 const MAX_PDF_HEIGHT = 170;
 
+const DefaultItem = styled.View`
+  padding-top: 6px;
+`;
+
 const Flex = styled.View`
   flex-direction: column;
   align-items: center;
@@ -65,43 +69,45 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
   };
 
   return (
-    <Flex key={pdf.path}>
-      <DeleteBackground>
-        <TouchableOpacity onPress={handleRemove} activeOpacity={0.1}>
-          <Icon name="clear" color="#00213F" />
-        </TouchableOpacity>
-      </DeleteBackground>
+    <DefaultItem>
+      <Flex key={pdf.path}>
+        <DeleteBackground>
+          <TouchableOpacity onPress={handleRemove} activeOpacity={0.1}>
+            <Icon name="clear" color="#00213F" />
+          </TouchableOpacity>
+        </DeleteBackground>
 
-      <Container onPress={toggleModal}>
-        <PdfView
-          pointerEvents="none"
-          source={{ uri: pdf.uri }}
-          style={{
-            width: MAX_PDF_WIDTH,
-            height: MAX_PDF_HEIGHT,
-            backgroundColor: "white",
-          }}
-          singlePage
-        />
-      </Container>
+        <Container onPress={toggleModal}>
+          <PdfView
+            pointerEvents="none"
+            source={{ uri: pdf.uri }}
+            style={{
+              width: MAX_PDF_WIDTH,
+              height: MAX_PDF_HEIGHT,
+              backgroundColor: "white",
+            }}
+            singlePage
+          />
+        </Container>
 
-      <Text align="center" numberOfLines={1} style={{ width: MAX_PDF_WIDTH }}>
-        {pdf.displayName}
-      </Text>
+        <Text align="center" numberOfLines={1} style={{ width: MAX_PDF_WIDTH }}>
+          {pdf.displayName}
+        </Text>
 
-      <Modal visible={modalVisible} hide={toggleModal}>
-        <PdfInModal
-          source={{ uri: pdf.uri }}
-          width={Dimensions.get("window").width}
-          height={Dimensions.get("window").height * 0.89}
-        />
-        <ButtonWrapper>
-          <Button colorSchema="red" onClick={toggleModal}>
-            <Text>Stäng</Text>
-          </Button>
-        </ButtonWrapper>
-      </Modal>
-    </Flex>
+        <Modal visible={modalVisible} hide={toggleModal}>
+          <PdfInModal
+            source={{ uri: pdf.uri }}
+            width={Dimensions.get("window").width}
+            height={Dimensions.get("window").height * 0.89}
+          />
+          <ButtonWrapper>
+            <Button colorSchema="red" onClick={toggleModal}>
+              <Text>Stäng</Text>
+            </Button>
+          </ButtonWrapper>
+        </Modal>
+      </Flex>
+    </DefaultItem>
   );
 };
 


### PR DESCRIPTION
## Explain the changes you’ve made
Fix styling for PDF and Image item.

## Explain why these changes are made
Styling croped the delete button making it look weird.
Also fixed the styling on close button on image item. Now its easier to press the close button.

## Explain your solution
Styling fixes

## How to test

1. Checkout this branch
2. Swap the application to run storybook
3. Fire upp the simulator by running the command `yarn ios` or `yarn android`
4. Test it by answering a form with file picker, both files and images.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots
**BEFORE: **
<img width="339" alt="image" src="https://user-images.githubusercontent.com/9610681/195592906-55b2a201-89a5-42ab-a37f-a036ae7d0628.png">


<img width="365" alt="image" src="https://user-images.githubusercontent.com/9610681/195592823-01b06079-8b46-4f79-aa77-2b3fd8359193.png">


**AFTER:**
<img width="297" alt="image" src="https://user-images.githubusercontent.com/9610681/195592679-15654292-8dfb-4249-8053-911f3fcd28b2.png">

<img width="376" alt="image" src="https://user-images.githubusercontent.com/9610681/195592737-09ec60ba-b986-49a3-ac2f-f27ac425583f.png">
