### PR TITLE
refactor(pdfitem.tsx): replace pdfview with pdf thumbnail

### DIFF
--- a/source/components/molecules/PdfDisplay/PdfItem.tsx
+++ b/source/components/molecules/PdfDisplay/PdfItem.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import styled from "styled-components/native";
-import type { GestureResponderEvent } from "react-native";
 import { TouchableOpacity, Dimensions } from "react-native";
 import PdfView from "react-native-pdf";
+import type { GestureResponderEvent } from "react-native";
+
 import { Icon, Button, Text } from "../../atoms";
+
 import { Modal, useModal } from "../Modal";
+
 import type { Pdf } from "./PdfDisplay";
 
 const MAX_PDF_WIDTH = 120;
@@ -30,6 +33,7 @@ const DeleteBackground = styled.View`
   z-index: 1;
   border-radius: 20px;
 `;
+
 const Container = styled.TouchableOpacity`
   flex: 1;
   justify-content: center;
@@ -40,7 +44,9 @@ const Container = styled.TouchableOpacity`
   shadow-color: black;
   shadow-opacity: 0.4;
   shadow-radius: 5px;
-  border: 1px solid transparent;
+  height: ${MAX_PDF_HEIGHT}px;
+  width: ${MAX_PDF_WIDTH}px;
+  background: #fff;
 `;
 
 const PdfInModal = styled(PdfView)<{ width: number; height: number }>`
@@ -77,17 +83,8 @@ const PdfItem: React.FC<Props> = ({ pdf, onRemove }) => {
           </TouchableOpacity>
         </DeleteBackground>
 
-        <Container onPress={toggleModal}>
-          <PdfView
-            pointerEvents="none"
-            source={{ uri: pdf.uri }}
-            style={{
-              width: MAX_PDF_WIDTH,
-              height: MAX_PDF_HEIGHT,
-              backgroundColor: "white",
-            }}
-            singlePage
-          />
+        <Container disabled>
+          <Icon size={32} name="picture-as-pdf" color="#F40F02" />
         </Container>
 
         <Text align="center" numberOfLines={1} style={{ width: MAX_PDF_WIDTH }}>


### PR DESCRIPTION
## Explain the changes you’ve made
Replace PDFView with a pdf thumbnail and also disable the onclick of the item.

## Explain why these changes are made
The PdfView component didn't show the first page of aPDF all the time, which resulted in a white item where shown. This behavior is confusing for the users.

## Explain your solution
Utilize the Icon component and show a PDF icon whenever a PDF has been uploaded.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
4. Run a form with Filepicker component and upload a file to the form
5. The PDF icon should be visible all the time

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots

<img width="366" alt="image" src="https://user-images.githubusercontent.com/9610681/196350502-b6644e14-319c-4987-bb0d-fe6f2584565d.png">

<img width="346" alt="image" src="https://user-images.githubusercontent.com/9610681/196351509-56b4e25a-d56c-47e9-8b33-23433de963a0.png">

