### PR TITLE
fix(navigationbuttongroup/field): fix bug regarding icon not

### DIFF
--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.styled.ts
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.styled.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components/native";
+
+const ButtonFieldWrapper = styled.View`
+  height: auto;
+  width: auto;
+  border-radius: 0;
+  border-style: solid;
+  margin: 2px;
+`;
+
+export default ButtonFieldWrapper;

--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.tsx
@@ -1,35 +1,9 @@
 import React from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components/native";
 import { Button, Icon, Text } from "../../atoms";
 
-const ButtonFieldWrapper = styled.View`
-  height: auto;
-  width: auto;
-  border-radius: 0;
-  border-style: solid;
-  margin: 2px;
-`;
+import ButtonFieldWrapper from "./NavigationButtonField.styled";
 
-export type NavigationActionType =
-  | { type: "navigateDown"; stepId: string }
-  | { type: "navigateUp" }
-  | { type: "navigateNext" }
-  | { type: "navigateBack" };
-
-export interface Props {
-  iconName?: string;
-  text?: string;
-  colorSchema?: string;
-  navigationType: NavigationActionType;
-  formNavigation: {
-    next: () => void;
-    back: () => void;
-    down: (targetStepId: string) => void;
-    up: () => void;
-    createSnapshot: () => void;
-  };
-}
+import type { Props } from "./NavigationButtonField.types";
 
 // TODO: Move navigation logic to a smart container component,
 // this dumb component do not need to know about how formNavigation is handled.
@@ -39,7 +13,7 @@ const NavigationButtonField: React.FC<Props> = ({
   text,
   navigationType,
   formNavigation,
-  colorSchema,
+  colorSchema = "blue",
 }) => {
   const onClick = () => {
     // This logic could be broken out and placed elsewhere.
@@ -66,40 +40,11 @@ const NavigationButtonField: React.FC<Props> = ({
   return (
     <ButtonFieldWrapper>
       <Button variant="outlined" onClick={onClick} colorSchema={colorSchema}>
-        {iconName.length ? <Icon name={iconName} /> : null}
+        <Icon color="red" name={iconName || "add"} />
         {text && <Text>{text}</Text>}
       </Button>
     </ButtonFieldWrapper>
   );
-};
-
-NavigationButtonField.propTypes = {
-  /**
-   * Name of the icon to be displayed
-   */
-  iconName: PropTypes.string,
-  /**
-   * Text string for button
-   */
-  text: PropTypes.string,
-  /**
-   * Function is triggered when button is clicked
-   */
-  navigationType: PropTypes.any,
-  /**
-   * Color schema of the button
-   */
-  colorSchema: PropTypes.oneOf(["blue", "red", "purple", "green"]),
-  /**
-   * Object with navigation event for a form.
-   */
-  formNavigation: PropTypes.any,
-};
-
-NavigationButtonField.defaultProps = {
-  iconName: "add",
-  text: "",
-  colorSchema: "blue",
 };
 
 export default NavigationButtonField;

--- a/source/components/molecules/NavigationButtonField/NavigationButtonField.types.ts
+++ b/source/components/molecules/NavigationButtonField/NavigationButtonField.types.ts
@@ -1,0 +1,26 @@
+type NavigationActionType =
+  | "navigateDown"
+  | "navigateUp"
+  | "navigateNext"
+  | "navigateBack";
+
+interface NavigationAction {
+  type: NavigationActionType;
+  stepId: string;
+}
+
+interface FormNavigation {
+  next: () => void;
+  back: () => void;
+  down: (targetStepId: string) => void;
+  up: () => void;
+  createSnapshot: () => void;
+}
+
+export interface Props {
+  iconName?: string;
+  text?: string;
+  colorSchema?: string;
+  navigationType: NavigationAction;
+  formNavigation: FormNavigation;
+}

--- a/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.styled.ts
+++ b/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.styled.ts
@@ -1,0 +1,14 @@
+import styled from "styled-components/native";
+
+interface ScrollContainerProps {
+  horizontal?: boolean;
+}
+const ScrollContainer = styled.ScrollView<ScrollContainerProps>`
+  padding-bottom: 16px;
+  ${({ horizontal }) =>
+    horizontal &&
+    `margin-right: -24px;
+    margin-left: -24px;`}
+`;
+
+export default ScrollContainer;

--- a/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
+++ b/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.tsx
@@ -1,30 +1,13 @@
 import React, { useState } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components/native";
 import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
-import type { Props as ButtonProps } from "../NavigationButtonField/NavigationButtonField";
+
 import NavigationButtonField from "../NavigationButtonField/NavigationButtonField";
-import type { PrimaryColor } from "../../../theme/themeHelpers";
+
 import { HorizontalScrollIndicator } from "../../atoms";
 
-const ScrollContainer = styled.ScrollView`
-  padding-bottom: 16px;
-  ${(props) =>
-    props.horizontal &&
-    `margin-right: -24px;
-    margin-left: -24px;`}
-`;
-interface Props {
-  buttons: ButtonProps[];
-  horizontal: boolean;
-  formNavigation: {
-    next: () => void;
-    back: () => void;
-    down: (targetStepId: string) => void;
-    up: () => void;
-  };
-  colorSchema?: PrimaryColor;
-}
+import ScrollContainer from "./NavigationButtonGroup.styled";
+
+import type { Props } from "./NavigationButtonGroup.types";
 
 const NavigationButtonGroup: React.FC<Props> = ({
   buttons,
@@ -51,11 +34,14 @@ const NavigationButtonGroup: React.FC<Props> = ({
         onScroll={handleScroll}
         showsHorizontalScrollIndicator={false}
       >
-        {buttons.map((button, index) => (
+        {buttons.map((button) => (
           <NavigationButtonField
-            {...{ colorSchema, ...button }}
+            key={`button${button.navigationType.stepId}`}
+            iconName={button.iconName}
+            text={button.text}
+            colorSchema={colorSchema}
+            navigationType={button.navigationType}
             formNavigation={formNavigation}
-            key={`button${index}`}
           />
         ))}
       </ScrollContainer>
@@ -64,13 +50,6 @@ const NavigationButtonGroup: React.FC<Props> = ({
       )}
     </>
   );
-};
-
-NavigationButtonGroup.propTypes = {
-  horizontal: PropTypes.bool,
-  buttons: PropTypes.array,
-  formNavigation: PropTypes.any,
-  colorSchema: PropTypes.oneOf(["blue", "red", "green", "purple", "neutral"]),
 };
 
 export default NavigationButtonGroup;

--- a/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.types.ts
+++ b/source/components/molecules/NavigationButtonGroup/NavigationButtonGroup.types.ts
@@ -1,0 +1,16 @@
+import type { Props as Button } from "../NavigationButtonField/NavigationButtonField.types";
+import type { PrimaryColor } from "../../../theme/themeHelpers";
+
+interface FormNavigation {
+  next: () => void;
+  back: () => void;
+  down: (targetStepId: string) => void;
+  up: () => void;
+}
+
+export interface Props {
+  buttons: Button[];
+  horizontal: boolean;
+  formNavigation: FormNavigation;
+  colorSchema?: PrimaryColor;
+}


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed a bug where icons where not shown in a NavigationButtonGroup.
Also rewrite the components to agreed format.

## Explain why these changes are made
All buttons in a navigation button group should be able to show icons when added.

## Explain your solution
The `NavigationButtonField` component didn't actually default to the `add` icon since the parameter `iconName` were an empty string. Function parameters do not default the value on a parameter if it's an empty string.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run a form where a navigationbuttongroup and/or navigationbuttonfield is present
4. Check if icons are shown in the group

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
**BEFORE:**
<img width="355" alt="image" src="https://user-images.githubusercontent.com/9610681/196406110-30467bf5-01c7-44e7-b1d1-9df5e554d080.png">

**AFTER:**
<img width="364" alt="image" src="https://user-images.githubusercontent.com/9610681/196406058-65665ce0-a66d-4ce6-ba4c-5880df8abc81.png">
