### PR TITLE
fix: use fully qualified status type for new application

### DIFF
--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -14,7 +14,7 @@ export enum ApplicationStatusType {
   ACTIVE_ONGOING_COMPLETION = "active:ongoing:completion",
   CLOSED_PARTIALLY_APPROVED_VIVA = "closed:partiallyApproved:viva",
   CLOSED_REJECTED_VIVA = "closed:rejected:viva",
-  NEW_APPLICATION = "newApplication",
+  NEW_APPLICATION = "newApplication:viva",
   ACTIVE_ONGOING_NEW_APPLICATION = "active:ongoing:newApplication",
   ACTIVE_SUBMITTED_RANDOM_CHECK_VIVA = "active:submitted:randomCheck:viva",
   ACTIVE_SUBMITTED_COMPLETION = "active:submitted:completion:viva",


### PR DESCRIPTION
## Explain the changes you’ve made

Fixed "new application" button showing when a current basic application is in random check/completion.

## Explain why these changes are made

The button should only be visible when there is a blank new application case.

## Explain your solution

Specify the status constant used to contain `newApplication:viva` instead of just `newApplication`, as random check for example uses `active:newApplication:randomCheckRequired:viva` which would still "pass" the old check.

## How to test

Concrete example:

1. Checkout this branch
2. Verify new application button shows when there is a not started new application case
3. Verify the button does not show for random check/completion.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
