### PR TITLE
refactor(fileuploaderlist): clearify which button contains to which h…

### DIFF
--- a/source/components/molecules/FileUploaderList/FileUploaderList.styled.ts
+++ b/source/components/molecules/FileUploaderList/FileUploaderList.styled.ts
@@ -1,19 +1,23 @@
 import styled from "styled-components/native";
 import type { ThemeType, PrimaryColor } from "../../../theme/themeHelpers";
 
-export const Container = styled.View<{ theme: ThemeType }>`
-  margin: ${(props) => props.theme.sizes[0]}px;
+export const Container = styled.View<{
+  theme: ThemeType;
+  colorSchema: PrimaryColor;
+}>`
+  margin: ${(props) => props.theme.sizes[0]}px 0px;
   flex: 1;
   border-radius: 5px;
-  background: #eee;
-  padding: 0px 16px;
+  background: ${({ theme, colorSchema }) =>
+    theme.colors.complementary[colorSchema][3]};
+  padding: 16px 16px;
 `;
 
 export const UploaderLabelContainer = styled.View`
   flex: 1;
   align-items: center;
   justify-content: center;
-  padding: 24px 16px 0px 16px;
+  padding: 8px 16px 0px 16px;
 `;
 
 export const UploaderLabel = styled.Text<{

--- a/source/components/molecules/FileUploaderList/FileUploaderList.styled.ts
+++ b/source/components/molecules/FileUploaderList/FileUploaderList.styled.ts
@@ -4,13 +4,23 @@ import type { ThemeType, PrimaryColor } from "../../../theme/themeHelpers";
 export const Container = styled.View<{ theme: ThemeType }>`
   margin: ${(props) => props.theme.sizes[0]}px;
   flex: 1;
+  border-radius: 5px;
+  background: #eee;
+  padding: 0px 16px;
+`;
+
+export const UploaderLabelContainer = styled.View`
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px 0px 16px;
 `;
 
 export const UploaderLabel = styled.Text<{
   theme: ThemeType;
   colorSchema: PrimaryColor;
 }>`
-  font-weight: 500;
+  font-weight: 700;
   margin: 0;
   font-size: 16px;
   color: ${({ theme, colorSchema }) => theme.colors.primary[colorSchema][1]};

--- a/source/components/molecules/FileUploaderList/FileUploaderList.tsx
+++ b/source/components/molecules/FileUploaderList/FileUploaderList.tsx
@@ -7,7 +7,11 @@ import type {
   FileUploaderInternalItem,
   FileUploaderProps,
 } from "./FileUploaderList.types";
-import { Container, UploaderLabel } from "./FileUploaderList.styled";
+import {
+  Container,
+  UploaderLabel,
+  UploaderLabelContainer,
+} from "./FileUploaderList.styled";
 
 function makeInternalItem(
   text: string,
@@ -46,9 +50,11 @@ export default function FileUploaderList({
     <>
       {items.map((entry) => (
         <Container key={entry.id}>
-          <UploaderLabel colorSchema={colorSchema}>
-            • {entry.text}
-          </UploaderLabel>
+          <UploaderLabelContainer>
+            <UploaderLabel colorSchema={colorSchema}>
+              {entry.text}
+            </UploaderLabel>
+          </UploaderLabelContainer>
           <FilePicker
             colorSchema={colorSchema}
             buttonText="Ladda upp fil"

--- a/source/components/molecules/FileUploaderList/FileUploaderList.tsx
+++ b/source/components/molecules/FileUploaderList/FileUploaderList.tsx
@@ -49,7 +49,7 @@ export default function FileUploaderList({
   return (
     <>
       {items.map((entry) => (
-        <Container key={entry.id}>
+        <Container key={entry.id} colorSchema={colorSchema}>
           <UploaderLabelContainer>
             <UploaderLabel colorSchema={colorSchema}>
               {entry.text}


### PR DESCRIPTION
## Explain the changes you’ve made
Clarify on which uploader header belongs to which button

## Explain why these changes are made
Users were having issues understanding on which header belonged to which upload button which resulting in users were uploading wrong files to wrong header.

## Explain your solution
Made a surrounding "card" on both the header and button. See picture below

## How to test

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a case with completions
4. ... or run storybok

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots
**BEFORE:**

<img width="362" alt="image" src="https://user-images.githubusercontent.com/9610681/197157298-cfbd8be9-2cd2-4ef1-b955-e222b6027582.png">

<img width="354" alt="image" src="https://user-images.githubusercontent.com/9610681/197159816-78eac327-3cf2-46f9-9db9-d86a0e0fccae.png">


**AFTER:**

<img width="356" alt="image" src="https://user-images.githubusercontent.com/9610681/197157195-c89be1b6-731c-40d5-b4ba-ef5491e0dadb.png">

<img width="357" alt="image" src="https://user-images.githubusercontent.com/9610681/197159937-80337e7f-0072-4687-ae56-267cf4161973.png">
