### PR TITLE
fix(bankidservice): handle correct error codes from bankid

### DIFF
--- a/source/services/BankidService.ts
+++ b/source/services/BankidService.ts
@@ -29,10 +29,6 @@ async function collect(
       return { success: false, data: "" };
     }
 
-    if (response.status === 404) {
-      return { success: false, data: getMessage("userCancel") };
-    }
-
     if (response.status === 200 && bankIDStatus === "pending") {
       // Reconnect in one 1050 ms
       await new Promise((resolve) => setTimeout(resolve, 1050));


### PR DESCRIPTION
## Explain the changes you’ve made
Remove logic for handling status code 404 from backend.

## Explain why these changes are made
Status code 404 is no longer returned from backend since that wasn't handled by BankID according to their documentation.

## Explain your solution
Remove the logic handling 404 status code. 

## How to test

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Try to login with BankID and cancel the request. Cancel the request on both BankID application and the application modal for canceling.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
