### PR TITLE
Feat/download attachment at form startup

### DIFF
--- a/source/components/molecules/CloseDialog/CloseDialog.tsx
+++ b/source/components/molecules/CloseDialog/CloseDialog.tsx
@@ -67,7 +67,7 @@ interface CloseDialogProps {
   visible?: boolean;
   title: string;
   body: string;
-  buttons: Array<{
+  buttons?: Array<{
     text: string;
     color?: PrimaryColor;
     clickHandler: () => void;
@@ -78,7 +78,7 @@ const CloseDialog: React.FC<CloseDialogProps> = ({
   visible,
   title,
   body,
-  buttons,
+  buttons = [],
 }) => (
   <Modal
     visible={visible ?? false}

--- a/source/screens/DevFeaturesScreen.tsx
+++ b/source/screens/DevFeaturesScreen.tsx
@@ -45,11 +45,11 @@ const DeveloperScreen = (props: any): JSX.Element => {
         <FormList
           heading="Ansökningsformulär"
           onClickCallback={async (form) => {
-            if (createCase !== undefined && form) {
+            if (createCase && form) {
               createCase(form, async ({ id, forms, currentFormId }) => {
                 await setupForm(
                   forms[currentFormId].answers as Answer[],
-                  form?.id as string
+                  form.id as string
                 );
                 navigation.navigate("Form", { caseId: id });
               });

--- a/source/screens/DevFeaturesScreen.tsx
+++ b/source/screens/DevFeaturesScreen.tsx
@@ -13,6 +13,10 @@ import ScreenWrapper from "../components/molecules/ScreenWrapper";
 
 import StorageService from "../services/storage/StorageService";
 
+import useSetupForm from "./caseScreens/useSetupForm";
+
+import type { Answer } from "../types/Case";
+
 const Container = styled.ScrollView`
   flex: 1;
   padding-left: 16px;
@@ -29,6 +33,8 @@ const DeveloperScreen = (props: any): JSX.Element => {
   const { createCase } = useContext(CaseDispatch);
   const authContext = useContext(AuthContext);
 
+  const [setupForm] = useSetupForm();
+
   const colorSchema = "neutral";
 
   return (
@@ -39,8 +45,12 @@ const DeveloperScreen = (props: any): JSX.Element => {
         <FormList
           heading="Ansökningsformulär"
           onClickCallback={async (form) => {
-            if (createCase !== undefined) {
-              createCase(form, async ({ id }) => {
+            if (createCase !== undefined && form) {
+              createCase(form, async ({ id, forms, currentFormId }) => {
+                await setupForm(
+                  forms[currentFormId].answers as Answer[],
+                  form?.id as string
+                );
                 navigation.navigate("Form", { caseId: id });
               });
             }

--- a/source/screens/caseScreens/useSetupForm.ts
+++ b/source/screens/caseScreens/useSetupForm.ts
@@ -1,0 +1,41 @@
+import { useContext, useCallback } from "react";
+
+import FormContext from "../../store/FormContext";
+
+import fileStorageService from "../../services/storage/fileStorage/FileStorageService";
+
+import type { Answer } from "../../types/Case";
+
+const setUpAttachments = async (answers: Answer[]): Promise<void> => {
+  const answerValues = answers.flatMap(
+    ({ value }) => (Array.isArray(value) && value) || []
+  );
+
+  const ensureAttachmentsFor = answerValues.filter(
+    ({ id, uploadedId }) => id && uploadedId
+  );
+
+  await Promise.all(
+    ensureAttachmentsFor.map(({ id, uploadedId }) =>
+      fileStorageService.ensureFile(id as string, uploadedId as string)
+    )
+  );
+};
+
+function useSetupForm(): [
+  (caseAnswers: Answer[], formId: string) => Promise<void>
+] {
+  const { getForm } = useContext(FormContext);
+
+  const setUpForm = useCallback(
+    async (caseAnswers: Answer[], formId: string) => {
+      await getForm(formId);
+      await setUpAttachments(caseAnswers);
+    },
+    [getForm]
+  );
+
+  return [setUpForm];
+}
+
+export default useSetupForm;

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -166,7 +166,7 @@ interface AnswerField {
 
 export interface Answer {
   field: AnswerField;
-  value: string | boolean;
+  value: string | boolean | Record<string, string | number>[];
 }
 
 export interface EncryptedAnswersWrapper {


### PR DESCRIPTION
## Explain the changes you’ve made
Created new hook called useFormSetup which downloads attachments using the new FileStorageService and also downloads and saves the current form the the form context state.

## Explain why these changes are made
In order to download attachments before a user interacts with a form, the attachments and form needs to be controllable downloaded. When both the attachments and form are downloaded, the form can be opened.

This means that formcasescreen can remove a lot of code handling these things.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run any form of your likings, the form should be downloaded before the form is opened 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
