### PR TITLE
fix(imageitem): fix issues displaying images on iOS and Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "react-native-exception-handler": "^2.10.10",
     "react-native-fs": "^2.19.0",
     "react-native-image-crop-picker": "^0.37.3",
-    "react-native-image-pan-zoom": "^2.1.12",
     "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-network-info": "^5.2.1",
     "react-native-pager-view": "^5.4.15",

--- a/source/components/molecules/ImageItem/ImageItem.styled.ts
+++ b/source/components/molecules/ImageItem/ImageItem.styled.ts
@@ -3,7 +3,7 @@ import styled from "styled-components/native";
 const MAX_IMAGE_WIDTH = 120;
 const MAX_IMAGE_HEIGHT = 170;
 
-const SafeArea = styled.SafeAreaView`
+const ModalView = styled.View`
   flex: 1;
 `;
 
@@ -74,7 +74,7 @@ const ActivityIndicator = styled.ActivityIndicator`
 `;
 
 export {
-  SafeArea,
+  ModalView,
   DefaultItem,
   Flex,
   DeleteBackground,

--- a/source/components/molecules/ImageItem/ImageItem.tsx
+++ b/source/components/molecules/ImageItem/ImageItem.tsx
@@ -1,14 +1,18 @@
 import React from "react";
-import ImageZoom from "react-native-image-pan-zoom";
-import type { GestureResponderEvent } from "react-native";
-import { TouchableOpacity, Dimensions, Image as RNImage } from "react-native";
+import {
+  TouchableOpacity,
+  Dimensions,
+  Image as RNImage,
+  Platform,
+} from "react-native";
 
+import type { GestureResponderEvent } from "react-native";
 import { Icon, Button, Text } from "../../atoms";
 
 import { Modal, useModal } from "../Modal";
 
 import {
-  SafeArea,
+  ModalView,
   DefaultItem,
   Flex,
   DeleteBackground,
@@ -24,7 +28,11 @@ import defaultFileStorageService from "../../../services/storage/fileStorage/Fil
 function ImageItem({ file, onRemove }: Props): JSX.Element {
   const [modalVisible, toggleModal] = useModal();
 
-  const filePath = defaultFileStorageService.getFilePath(file.id);
+  const filePathBase = defaultFileStorageService.getFilePath(file.id);
+  const filePath =
+    Platform.OS === "android" ? `file:${filePathBase}` : filePathBase;
+
+  const imageResizeMode = Platform.OS === "android" ? "stretch" : "cover";
 
   const handleRemove = (event: GestureResponderEvent) => {
     event.stopPropagation();
@@ -53,23 +61,18 @@ function ImageItem({ file, onRemove }: Props): JSX.Element {
         </Text>
       </DefaultItem>
       <Modal visible={modalVisible} hide={toggleModal}>
-        <SafeArea>
-          <ImageZoom
-            cropWidth={Dimensions.get("window").width}
-            cropHeight={Dimensions.get("window").height * 0.89}
-            panToMove
-            enableCenterFocus={false}
-            centerOn={{
-              x: 0,
-              y: 0,
-              scale: 1.0,
-              duration: 10,
-            }}
-            minScale={1.0}
-          >
-            {filePath && <RNImage source={{ uri: filePath }} />}
-          </ImageZoom>
-        </SafeArea>
+        <ModalView>
+          {filePathBase && (
+            <RNImage
+              resizeMode={imageResizeMode}
+              source={{ uri: filePath }}
+              style={{
+                width: Dimensions.get("window").width,
+                height: Dimensions.get("window").height * 0.8,
+              }}
+            />
+          )}
+        </ModalView>
         <ButtonWrapper>
           <Button colorSchema="red" onClick={toggleModal}>
             <Text>Stäng</Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8209,11 +8209,6 @@ react-native-image-crop-picker@^0.37.3:
   resolved "https://registry.yarnpkg.com/react-native-image-crop-picker/-/react-native-image-crop-picker-0.37.3.tgz#f260e40b6a6ba8e98f4db3dde25a8f09e0936385"
   integrity sha512-ih+0pWWRUNEFQyaHwGbH9rqJNOb7EBYMwKJhTY0VmsKIA9E+usfwMmQXAFIfOnee7fTn0A2vOXkBCPQZwyvnQw==
 
-react-native-image-pan-zoom@^2.1.12:
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/react-native-image-pan-zoom/-/react-native-image-pan-zoom-2.1.12.tgz#eb98bf56fb5610379bdbfdb63219cc1baca98fd2"
-  integrity sha512-BF66XeP6dzuANsPmmFsJshM2Jyh/Mo1t8FsGc1L9Q9/sVP8MJULDabB1hms+eAoqgtyhMr5BuXV3E1hJ5U5H6Q==
-
 react-native-markdown-display@^7.0.0-alpha.2:
   version "7.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/react-native-markdown-display/-/react-native-markdown-display-7.0.0-alpha.2.tgz#a48a70d3cb5c510a52ecf7f1509a4a3d14d728aa"


### PR DESCRIPTION
## Explain the changes you’ve made
Fixed the path to the locally stored file on android.
Fixed styling issues on both iOS and Android

## Explain why these changes are made
The file path to the locally stored file on android where wrong and did not include the `file:` suffix. This lead to a path in android where the file were not stored, hence the form did not displayed any images.

Fixed styling issue when image is displayed in modal.
Also removed the image pan zoom.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run any form where images can be uploaded
4. On the image in the modal and see the result

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots
**Before**

<img width="345" alt="image" src="https://user-images.githubusercontent.com/9610681/202379009-8a4514ea-5dec-4d10-a251-bad0eabad653.png">

<img width="346" alt="image" src="https://user-images.githubusercontent.com/9610681/202379060-2e020909-edf7-4f18-bf61-c3e69e926d47.png">

**After**
<img width="347" alt="image" src="https://user-images.githubusercontent.com/9610681/202379210-9c418e2d-503a-4bec-bc40-f3d0ea5d1f2e.png">

<img width="347" alt="image" src="https://user-images.githubusercontent.com/9610681/202379254-e565737d-b163-40c9-9c9c-b92b315321e6.png">
