### PR TITLE
feat(formuploader): delete attachments after upload success

### DIFF
--- a/source/containers/Form/FormUploader.tsx
+++ b/source/containers/Form/FormUploader.tsx
@@ -112,6 +112,11 @@ function FormUploader({
     },
   };
 
+  const deleteLocalAttachments = () =>
+    Promise.all(
+      attachments.map(({ id }) => defaultFileStorageService.removeFile(id))
+    );
+
   const [{ resolved, rejected, isPending, count }, { retry }] = useQueue(
     handleUploadFile,
     [...attachments],
@@ -120,6 +125,7 @@ function FormUploader({
 
   const handleResolvedImage = () => {
     if (!isPending && resolved.length === count && onResolved) {
+      void deleteLocalAttachments();
       onResolved();
     }
   };

--- a/source/screens/DevFeaturesScreen.tsx
+++ b/source/screens/DevFeaturesScreen.tsx
@@ -16,6 +16,8 @@ import StorageService from "../services/storage/StorageService";
 import useSetupForm from "./caseScreens/useSetupForm";
 
 import type { Answer } from "../types/Case";
+import defaultFileStorageService from "../services/storage/fileStorage/FileStorageService";
+import { splitFilePath } from "../helpers/FileUpload";
 
 const Container = styled.ScrollView`
   flex: 1;
@@ -36,6 +38,14 @@ const DeveloperScreen = (props: any): JSX.Element => {
   const [setupForm] = useSetupForm();
 
   const colorSchema = "neutral";
+
+  const deleteLocalFiles = async () => {
+    const files = await defaultFileStorageService.getFileList();
+    const fileIds = files.map((file) => splitFilePath(file).name);
+    return Promise.all(
+      fileIds.map((id) => defaultFileStorageService.removeFile(id))
+    );
+  };
 
   return (
     <ScreenWrapper>
@@ -64,6 +74,7 @@ const DeveloperScreen = (props: any): JSX.Element => {
             colorSchema={colorSchema}
             onClick={async () => {
               void StorageService.clearData();
+              void deleteLocalFiles();
               await authContext.handleLogout();
             }}
           >


### PR DESCRIPTION
## Explain the changes you’ve made

Added code to delete attachments from local storage after uploading has succeeded.

## Explain why these changes are made

So the device storage doesn't fill up over time too much. Attachments are no longer needed after upload.

## Explain your solution

Added a function that runs after all uploads are done. It runs as an unmanaged promise as I'm not sure how to handle if it potentially fails.

## How to test

Concrete example:

1. Checkout this branch
2. Run through a form with file picker(s)
3. Make sure files are deleted after upload (check debug info in profile screen before and after).

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
