### PR TITLE
Feat/show user submitted answers

### DIFF
--- a/source/components/molecules/CaseCard/CaseCard.styled.ts
+++ b/source/components/molecules/CaseCard/CaseCard.styled.ts
@@ -1,0 +1,27 @@
+import styled from "styled-components/native";
+import { Card } from "..";
+
+Card.LargeText = styled(Card.Text)`
+  font-size: ${(props) => props.theme.fontSizes[4]}px;
+  font-weight: ${(props) => props.theme.fontWeights[1]};
+  margin-bottom: 4px;
+`;
+
+Card.Meta = styled(Card.Text)`
+  font-size: ${(props) => props.theme.fontSizes[3]}px;
+  ${(props) => `color: ${props.theme.colors.neutrals[1]};`}
+`;
+
+Card.PinText = styled(Card.Text)`
+  font-size: ${(props) => props.theme.fontSizes[9]}px;
+  font-weight: ${(props) => props.theme.fontWeights[1]};
+  line-height: ${(props) => props.theme.lineHeights[8]}px;
+  margin-top: 12px;
+`;
+
+const CompletionsClarificationOutset = styled.View`
+  padding-top: 8px;
+  padding-bottom: 8px;
+`;
+
+export { Card, CompletionsClarificationOutset };

--- a/source/components/molecules/CaseCard/CaseCard.tsx
+++ b/source/components/molecules/CaseCard/CaseCard.tsx
@@ -1,58 +1,10 @@
 import React from "react";
-import type { ImageSourcePropType } from "react-native";
-import styled from "styled-components/native";
+
 import { Icon, Text } from "../../atoms";
-import { Card } from "..";
 
-Card.LargeText = styled(Card.Text)`
-  font-size: ${(props) => props.theme.fontSizes[4]}px;
-  font-weight: ${(props) => props.theme.fontWeights[1]};
-  margin-bottom: 4px;
-`;
+import { Card, CompletionsClarificationOutset } from "./CaseCard.styled";
 
-Card.Meta = styled(Card.Text)`
-  font-size: ${(props) => props.theme.fontSizes[3]}px;
-  ${(props) => `color: ${props.theme.colors.neutrals[1]};`}
-`;
-
-Card.PinText = styled(Card.Text)`
-  font-size: ${(props) => props.theme.fontSizes[9]}px;
-  font-weight: ${(props) => props.theme.fontWeights[1]};
-  line-height: ${(props) => props.theme.lineHeights[8]}px;
-  margin-top: 12px;
-`;
-
-const CompletionsClarificationOutset = styled.View`
-  padding-top: 8px;
-  padding-bottom: 8px;
-`;
-
-interface CaseCardProps {
-  title: string;
-  subtitle?: string;
-  largeSubtitle?: string;
-  description?: string;
-  icon?: ImageSourcePropType;
-  colorSchema?: string;
-  onCardClick?: () => void;
-  showProgress?: boolean;
-  currentStep?: number;
-  totalSteps?: number;
-  showButton?: boolean;
-  showAppealButton?: boolean;
-  buttonText?: string;
-  buttonIconName?: string;
-  onButtonClick?: () => void;
-  onAppealButtonClick?: () => void;
-  showPayments?: boolean;
-  approvedAmount?: string | number;
-  declinedAmount?: string | number;
-  givedate?: string;
-  buttonColorScheme?: string;
-  completions?: string[];
-  completionsClarification?: string;
-  pin?: string;
-}
+import type { Props } from "./CaseCard.types";
 
 function CaseCard({
   title,
@@ -61,7 +13,6 @@ function CaseCard({
   description,
   icon,
   colorSchema = "red",
-  onCardClick,
   showProgress = false,
   currentStep,
   totalSteps,
@@ -69,8 +20,6 @@ function CaseCard({
   showAppealButton = false,
   buttonText,
   buttonIconName,
-  onButtonClick,
-  onAppealButtonClick,
   showPayments = false,
   approvedAmount,
   declinedAmount,
@@ -79,7 +28,12 @@ function CaseCard({
   completions = [],
   completionsClarification = "",
   pin,
-}: CaseCardProps): JSX.Element {
+  showDownloadPdfButton,
+  onCardClick,
+  onButtonClick,
+  onAppealButtonClick,
+  onOpenPdf,
+}: Props): JSX.Element {
   return (
     <Card colorSchema={colorSchema}>
       <Card.Body shadow color="neutral" onPress={onCardClick}>
@@ -144,6 +98,13 @@ function CaseCard({
           >
             <Text>{buttonText}</Text>
             <Icon name={buttonIconName || "arrow-forward"} />
+          </Card.Button>
+        )}
+
+        {showDownloadPdfButton && (
+          <Card.Button mt={1} onClick={onOpenPdf} colorSchema="neutral">
+            <Text>Visa inskickad ansökan</Text>
+            <Icon name="picture-as-pdf" />
           </Card.Button>
         )}
       </Card.Body>

--- a/source/components/molecules/CaseCard/CaseCard.types.ts
+++ b/source/components/molecules/CaseCard/CaseCard.types.ts
@@ -1,0 +1,30 @@
+import type { ImageSourcePropType } from "react-native";
+
+export interface Props {
+  title: string;
+  subtitle?: string;
+  largeSubtitle?: string;
+  description?: string;
+  icon?: ImageSourcePropType;
+  colorSchema?: string;
+  showProgress?: boolean;
+  currentStep?: number;
+  totalSteps?: number;
+  showButton?: boolean;
+  showAppealButton?: boolean;
+  buttonText?: string;
+  buttonIconName?: string;
+  showPayments?: boolean;
+  approvedAmount?: string | number;
+  declinedAmount?: string | number;
+  givedate?: string;
+  buttonColorScheme?: string;
+  completions?: string[];
+  completionsClarification?: string;
+  pin?: string;
+  showDownloadPdfButton: boolean;
+  onCardClick?: () => void;
+  onButtonClick?: () => void;
+  onAppealButtonClick?: () => void;
+  onOpenPdf: () => void;
+}

--- a/source/components/organisms/PdfModal/PdfModal.styled.ts
+++ b/source/components/organisms/PdfModal/PdfModal.styled.ts
@@ -1,0 +1,17 @@
+import styled from "styled-components/native";
+import PdfView from "react-native-pdf";
+
+const PdfInModal = styled(PdfView)<{ width: number; height: number }>`
+  background-color: white;
+  flex: 1;
+  width: ${({ width }) => width}px;
+  height: ${({ height }) => height}px;
+`;
+
+const ButtonWrapper = styled.View`
+  padding-bottom: 40px;
+  flex-direction: row;
+  justify-content: center;
+`;
+
+export { PdfInModal, ButtonWrapper };

--- a/source/components/organisms/PdfModal/PdfModal.tsx
+++ b/source/components/organisms/PdfModal/PdfModal.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Dimensions } from "react-native";
+
+import { Button, Text } from "../../atoms";
+
+import { Modal } from "../../molecules";
+
+import { PdfInModal, ButtonWrapper } from "./PdfModal.styled";
+
+import type { Props } from "./PdfModal.types";
+
+const PdfModal: React.FC<Props> = ({ uri, isVisible, toggleModal }: Props) => (
+  <Modal visible={isVisible} hide={toggleModal}>
+    <PdfInModal
+      source={{ uri }}
+      width={Dimensions.get("window").width}
+      height={Dimensions.get("window").height * 0.89}
+    />
+    <ButtonWrapper>
+      <Button colorSchema="red" onClick={toggleModal}>
+        <Text>Stäng</Text>
+      </Button>
+    </ButtonWrapper>
+  </Modal>
+);
+
+export default PdfModal;

--- a/source/components/organisms/PdfModal/PdfModal.types.ts
+++ b/source/components/organisms/PdfModal/PdfModal.types.ts
@@ -1,0 +1,5 @@
+export interface Props {
+  uri: string;
+  isVisible: boolean;
+  toggleModal: () => void;
+}

--- a/source/components/organisms/PdfModal/index.ts
+++ b/source/components/organisms/PdfModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PdfModal";

--- a/source/components/organisms/index.ts
+++ b/source/components/organisms/index.ts
@@ -4,3 +4,4 @@ export { default as PrivacyModal } from "./PrivacyModal/PrivacyModal";
 export { default as LoginModal } from "./LoginModal/LoginModal";
 export { default as CaseCalculationsModal } from "./CaseCalculationsModal/CaseCalculationsModal";
 export { default as RemoveCaseModal } from "./RemoveCaseModal/RemoveCaseModal";
+export { default as PdfModal } from "./PdfModal";

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -39,6 +39,7 @@ import PdfModal from "../../components/organisms/PdfModal/PdfModal";
 import statusTypeConstantMapper from "./statusTypeConstantMapper";
 import useGetFormPasswords from "./useGetFormPasswords";
 import useSetupForm from "../../containers/Form/hooks/useSetupForm";
+import { isPdfAvailable, pdfToBase64String } from "./pdf.helper";
 
 import ICON from "../../assets/images/icons";
 
@@ -115,7 +116,6 @@ const computeCaseCardComponent = (
 
   const persons = caseItem?.persons ?? [];
   const caseId = caseItem.id;
-  const pdf = caseItem?.pdf?.B ?? "";
 
   const details = caseItem?.details ?? {};
   const { workflow = {}, period = {} } = details;
@@ -153,7 +153,9 @@ const computeCaseCardComponent = (
     activeSubmittedCompletion,
   } = statusTypeConstantMapper(statusType);
 
-  const canShowPdf = !statusType.toLowerCase().includes(APPROVED) && !!pdf;
+  const canShowPdf =
+    !statusType.toLowerCase().includes(APPROVED) &&
+    isPdfAvailable(caseItem.pdf);
   const selfHasSigned = casePersonData?.hasSigned;
   const isCoApplicant = casePersonData?.role === "coApplicant";
 
@@ -566,7 +568,7 @@ function CaseOverview(props: CaseOverviewProps): JSX.Element {
       <PdfModal
         isVisible={!!showPdfForCase}
         toggleModal={hidePdfModal}
-        uri={`${BASE64_FILE_PREFIX}${cases[showPdfForCase]?.pdf?.B}`}
+        uri={pdfToBase64String(cases[showPdfForCase]?.pdf)}
       />
 
       {activeModal.modal === Modal.START_NEW_APPLICATION && (

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -36,6 +36,7 @@ import { put, remove } from "../../helpers/ApiRequest";
 import useSetupForm from "../../containers/Form/hooks/useSetupForm";
 import statusTypeConstantMapper from "./statusTypeConstantMapper";
 import useGetFormPasswords from "./useGetFormPasswords";
+import { isPdfAvailable, pdfToBase64String } from "./pdf.helper";
 
 import { ApplicationStatusType } from "../../types/Case";
 
@@ -57,11 +58,11 @@ import type {
   Decision,
   Calculations,
   Answer,
+  PDF,
 } from "../../types/Case";
 
 const { ACTIVE_SIGNATURE_PENDING, APPROVED } = ApplicationStatusType;
 const SCREEN_TRANSITION_DELAY = 1000;
-const BASE64_FILE_PREFIX = "data:application/pdf;base64,";
 
 const computeCaseCardComponent = (
   caseItem: Case,
@@ -81,7 +82,6 @@ const computeCaseCardComponent = (
   const status = caseItem?.status;
   const persons = caseItem.persons ?? [];
   const details = caseItem?.details ?? {};
-  const pdf = caseItem?.pdf?.B ?? "";
   const { workflow = {}, period = {} } = details;
   const { decision = {}, payments = {} } = workflow;
   const statusType = status?.type ?? "";
@@ -96,7 +96,9 @@ const computeCaseCardComponent = (
     ? getSwedishMonthNameByTimeStamp(period?.endDate, true)
     : "";
 
-  const canShowPdf = !statusType.toLowerCase().includes(APPROVED) && !!pdf;
+  const canShowPdf =
+    !statusType.toLowerCase().includes(APPROVED) &&
+    isPdfAvailable(caseItem?.pdf);
   const casePersonData = persons.find(
     (person) => person.personalNumber === personalNumber
   );
@@ -439,7 +441,7 @@ const CaseSummary = (props: Props): JSX.Element => {
       <PdfModal
         isVisible={openPdf}
         toggleModal={togglePdf}
-        uri={`${BASE64_FILE_PREFIX}${caseData.pdf?.B}`}
+        uri={pdfToBase64String(caseData.pdf as PDF)}
       />
 
       <RemoveCaseButtonContainer>

--- a/source/screens/caseScreens/pdf.helper.ts
+++ b/source/screens/caseScreens/pdf.helper.ts
@@ -8,6 +8,9 @@ export function isPdfAvailable(pdf: PDF | undefined): boolean {
   return (pdf?.data?.length ?? 0) > 0;
 }
 
-export function pdfToBase64String(pdf: PDF): string {
-  return `${BASE64_FILE_PREFIX}${Buffer.from(pdf.data).toString("base64")}`;
+export function pdfToBase64String(pdf: PDF | undefined): string {
+  return (
+    `${BASE64_FILE_PREFIX}${Buffer.from(pdf?.data ?? []).toString("base64")}` ??
+    ""
+  );
 }

--- a/source/screens/caseScreens/pdf.helper.ts
+++ b/source/screens/caseScreens/pdf.helper.ts
@@ -1,0 +1,13 @@
+import { Buffer } from "buffer";
+
+import type { PDF } from "../../types/Case";
+
+const BASE64_FILE_PREFIX = "data:application/pdf;base64,";
+
+export function isPdfAvailable(pdf: PDF | undefined): boolean {
+  return (pdf?.data?.length ?? 0) > 0;
+}
+
+export function pdfToBase64String(pdf: PDF): string {
+  return `${BASE64_FILE_PREFIX}${Buffer.from(pdf.data).toString("base64")}`;
+}

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -204,6 +204,11 @@ export interface Status {
   type: ApplicationStatusType;
 }
 
+export interface PDF {
+  data: number[];
+  type: string;
+}
+
 export interface Case {
   createdAt: number;
   currentFormId: string;
@@ -213,7 +218,7 @@ export interface Case {
     [formId: string]: AnsweredForm;
   };
   id: string;
-  pdf?: Buffer;
+  pdf?: PDF;
   pdfGenerated?: boolean;
   persons: Person[];
   PK: string;

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -9,6 +9,7 @@ export enum ApplicationStatusType {
   SIGNED = "signed",
   ACTIVE = "active",
   NOT_STARTED = "notStarted",
+  APPROVED = "approved",
   ACTIVE_RANDOM_CHECK_REQUIRED_VIVA = "active:randomCheckRequired:viva",
   ACTIVE_ONGOING_RANDOM_CHECK = "active:ongoing:randomCheck",
   ACTIVE_COMPLETION_REQUIRED_VIVA = "active:completionRequired:viva",


### PR DESCRIPTION
## Explain the changes you’ve made
Changed the way we show remove case button in casesummary. Added pdf button on casecard in both caseoverview and casesummary.

## Explain why these changes are made
A users should be able to show its submitted answers, hence added the possibility to let users see their answers in a PDF.

## Explain your solution
Added a new button on casecard for displaying the pdf.

**NOTE**
This PR replaces:
https://github.com/helsingborg-stad/app-mitt-helsingborg/pull/812

## How to test

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Make sure you have a case with PDF on it
4. Make sure that the case does not have a status that includes `approved`
5. The new button should appear on casecard on both caseoverview and casesummary


## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
