### PR TITLE
feat(filepicker.tsx): make sure file extension is added to external d…

### DIFF
--- a/source/components/molecules/FilePicker/FilePicker.tsx
+++ b/source/components/molecules/FilePicker/FilePicker.tsx
@@ -27,6 +27,12 @@ const fileTypeMap: Record<FileType, (FileType.PDF | FileType.IMAGES)[]> = {
   [FileType.IMAGES]: [FileType.IMAGES],
 };
 
+const mimeExtensionMap: Record<string, string> = {
+  "application/pdf": ".pdf",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+};
+
 const FilePicker: React.FC<Props> = ({
   buttonText,
   value: files,
@@ -47,11 +53,11 @@ const FilePicker: React.FC<Props> = ({
     baseName: string,
     suffix: string
   ): File => {
-    const [, fileExtension] = file.mime.split("/");
+    const fileExtension = mimeExtensionMap[file.mime] ?? "";
 
     return {
       ...file,
-      externalDisplayName: `${baseName}_${suffix}.${fileExtension}`,
+      externalDisplayName: `${baseName}_${suffix}${fileExtension}`,
     };
   };
 

--- a/source/components/molecules/FilePicker/FilePicker.tsx
+++ b/source/components/molecules/FilePicker/FilePicker.tsx
@@ -46,10 +46,14 @@ const FilePicker: React.FC<Props> = ({
     file: File,
     baseName: string,
     suffix: string
-  ): File => ({
-    ...file,
-    externalDisplayName: `${baseName}_${suffix}`,
-  });
+  ): File => {
+    const [, fileExtension] = file.mime.split("/");
+
+    return {
+      ...file,
+      externalDisplayName: `${baseName}_${suffix}.${fileExtension}`,
+    };
+  };
 
   const addFilesToState = (newFiles: File[]) => {
     let updatedFiles = files === "" ? [...newFiles] : [...files, ...newFiles];


### PR DESCRIPTION
## Explain the changes you’ve made
Added file extension for external display name

## Explain why these changes are made
Attachments sent into VIVA needs the file extension, hence adding the file extension to the external display name.

## Explain your solution
in the `renameFileWithSuffix` function, make sure the file extension is taken from the mime property and added to the new external display name.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run a form with FilePicker component included
4. Console.log the external display name or 
5. check the submitted case 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
