### PR TITLE
feat(casecalculationsmodal.tsx): show notes for calculations

### DIFF
--- a/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
+++ b/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
@@ -39,6 +39,7 @@ function CaseCalculationsModal({
   const calculationPeriodStartDate = calculation?.periodstartdate ?? "";
   const calculationPeriodEndDate = calculation?.periodenddate ?? "";
   const calculationIncomeSum = calculation?.incomesum ?? "";
+  const calculationNote = calculation.note ?? "";
 
   const calculationCostSum = formatAmount(calculation?.costsum, true);
   const calculationNormSubTotal = formatAmount(calculation?.normsubtotal, true);
@@ -297,6 +298,14 @@ function CaseCalculationsModal({
                       Det finns inga registrerade reduceringar.
                     </Card.Text>
                   )}
+
+                  <DetailsTitle type="h5">Notering</DetailsTitle>
+                  <CalculationRow paddingBottom={16}>
+                    <Card.Text italic={!calculationNote}>
+                      {calculationNote ||
+                        "Det finns ingen registrerad notering."}
+                    </Card.Text>
+                  </CalculationRow>
 
                   <CalculationRow>
                     <Card.Text strong>Summa</Card.Text>

--- a/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
+++ b/source/components/organisms/CaseCalculationsModal/CaseCalculationsModal.tsx
@@ -39,7 +39,7 @@ function CaseCalculationsModal({
   const calculationPeriodStartDate = calculation?.periodstartdate ?? "";
   const calculationPeriodEndDate = calculation?.periodenddate ?? "";
   const calculationIncomeSum = calculation?.incomesum ?? "";
-  const calculationNote = calculation.note ?? "";
+  const calculationNote = calculation?.note ?? "";
 
   const calculationCostSum = formatAmount(calculation?.costsum, true);
   const calculationNormSubTotal = formatAmount(calculation?.normsubtotal, true);

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -122,6 +122,7 @@ export interface Calculation {
   costs: Costs;
   incomes: Incomes;
   reductions: Reductions;
+  note?: string;
 }
 
 export interface Calculations {


### PR DESCRIPTION
## Explain the changes you’ve made
Show the calculation note in application

## Explain why these changes are made
There is a need of showing the calculation an administrator has made on a calculation to a user, hence adding the note in the casecalculationsmodal

## Explain your solution
Check the calculation object for the note property, if note exist, show it, otherwise hide it. 

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
4. Open a case with calculation on it and specifically the note property set
5. Open the calculation modal in CaseSummary and expand the details view

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots
**With note**

![image](https://user-images.githubusercontent.com/9610681/203061439-f8fc240c-75f0-4b7b-a474-6a4194bd0879.png)

**Without note**
![image](https://user-images.githubusercontent.com/9610681/203061504-8642ec7c-5526-4d22-8f66-3e81e5c4359c.png)
