### PR TITLE
fix(textreplacement.ts): fix markdown text replacement for markdownText property

### DIFF
--- a/source/containers/Form/hooks/test/textReplacement.test.ts
+++ b/source/containers/Form/hooks/test/textReplacement.test.ts
@@ -88,6 +88,7 @@ const doTest = (
                 text: placeholder,
                 type: "text",
                 heading: "some sort of heading",
+                markdownText: placeholder,
               },
             ],
           },
@@ -127,6 +128,7 @@ const doTest = (
 
   expect(res[0]?.questions?.[1].items?.[0].title).toBe(expected);
   expect(res[0]?.questions?.[1].components?.[0].text).toBe(expected);
+  expect(res[0]?.questions?.[1].components?.[0].markdownText).toBe(expected);
   expect(res[0]?.questions?.[2].inputs?.[0].label).toBe(expected);
   expect(res[0]?.questions?.[2].inputs?.[0].title).toBe(expected);
   expect(res[0]?.questions?.[2].text).toBe(expected);

--- a/source/containers/Form/hooks/textReplacement.ts
+++ b/source/containers/Form/hooks/textReplacement.ts
@@ -270,6 +270,7 @@ export function replaceMarkdownTextInSteps(
       components: (question.components ?? []).map((component) => ({
         ...component,
         text: replaceString(component.text),
+        markdownText: replaceString(component.markdownText),
       })),
       items: (question.items ?? []).map((item) => ({
         ...item,


### PR DESCRIPTION
## Explain the changes you’ve made
Make `replaceMarkdownTextInSteps` function also replace text for markdownText property

## Explain why these changes are made
The InfoModal component where showing markdown instead of user friendly text

## Explain your solution
Made the `replaceMarkdownTextInSteps` also replace text for `markdownText` property, which was not included before.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run any form that uses InfoModal (like grundansökan) and see the replaced text 

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

**Before:**
<img width="255" alt="image" src="https://user-images.githubusercontent.com/9610681/203313689-5a9e372c-832b-4591-a7da-1fbad868ab92.png">


**After:**
<img width="249" alt="image" src="https://user-images.githubusercontent.com/9610681/203313620-8fa6adac-127d-40d1-83f3-327d1addab1b.png">
