### PR TITLE
fix(addcoapplicantmodal): avoid view when keyboard is shown

### DIFF
--- a/source/components/molecules/Dialog/Wrapper.tsx
+++ b/source/components/molecules/Dialog/Wrapper.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components/native";
 
-export const Wrapper = styled.View`
+const Wrapper = styled.View`
   flex: 1;
   align-items: center;
   justify-content: center;

--- a/source/components/organisms/AddCoApplicantModal/AddCoApplicantModal.styled.ts
+++ b/source/components/organisms/AddCoApplicantModal/AddCoApplicantModal.styled.ts
@@ -4,6 +4,10 @@ import type { ThemeType } from "../../../theme/themeHelpers";
 
 import { Text } from "../../atoms";
 
+const AvoidingViewContainer = styled.KeyboardAvoidingView`
+  flex: 1;
+`;
+
 interface DialogContainerProps {
   theme: ThemeType;
 }
@@ -38,4 +42,4 @@ const ErrorText = styled(Text)`
   color: ${({ theme }: { theme: ThemeType }) => theme.colors.primary.red[1]};
 `;
 
-export { DialogContainer, Container, ErrorText };
+export { AvoidingViewContainer, DialogContainer, Container, ErrorText };

--- a/source/components/organisms/AddCoApplicantModal/AddCoApplicantModal.tsx
+++ b/source/components/organisms/AddCoApplicantModal/AddCoApplicantModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { ActivityIndicator } from "react-native";
+import { ActivityIndicator, View } from "react-native";
 
 import Wrapper from "../../molecules/Dialog/Wrapper";
 import { Modal } from "../../molecules/Modal";
@@ -12,6 +12,7 @@ import { ValidationHelper } from "../../../helpers";
 import InputFields from "./InputFields";
 
 import {
+  AvoidingViewContainer,
   DialogContainer,
   Container,
   ErrorText,
@@ -94,38 +95,46 @@ export default function AddCoApplicantModal({
       statusBarTranslucent
       hide={() => undefined}
     >
-      <BackgroundBlurWrapper>
-        <Wrapper>
-          <DialogContainer>
-            <Container border>
-              <Text>
-                Ange personnummer, namn och efternamn för din fru, man eller
-                sambo
-              </Text>
+      <AvoidingViewContainer behavior="padding">
+        <View style={{ flex: 1 }}>
+          <BackgroundBlurWrapper>
+            <Wrapper>
+              <DialogContainer>
+                <Container border>
+                  <Text>
+                    Ange personnummer, namn och efternamn för din fru, man eller
+                    sambo
+                  </Text>
 
-              <InputFields fields={inputFields} />
+                  <InputFields fields={inputFields} />
 
-              {!!errorMessage && <ErrorText>{errorMessage}</ErrorText>}
-            </Container>
-            <Container>
-              {isLoading && <ActivityIndicator size="large" />}
+                  {!!errorMessage && <ErrorText>{errorMessage}</ErrorText>}
+                </Container>
+                <Container>
+                  {isLoading && <ActivityIndicator size="large" />}
 
-              {!isLoading && (
-                <Button
-                  size="large"
-                  fullWidth
-                  colorSchema="red"
-                  disabled={!hasValidInput}
-                  onClick={handleAddCoApplicant}
-                >
-                  <Text>Nästa</Text>
-                </Button>
-              )}
-            </Container>
-            <TextButton label="Avbryt" onPress={onClose} disabled={isLoading} />
-          </DialogContainer>
-        </Wrapper>
-      </BackgroundBlurWrapper>
+                  {!isLoading && (
+                    <Button
+                      size="large"
+                      fullWidth
+                      colorSchema="red"
+                      disabled={!hasValidInput}
+                      onClick={handleAddCoApplicant}
+                    >
+                      <Text>Nästa</Text>
+                    </Button>
+                  )}
+                </Container>
+                <TextButton
+                  label="Avbryt"
+                  onPress={onClose}
+                  disabled={isLoading}
+                />
+              </DialogContainer>
+            </Wrapper>
+          </BackgroundBlurWrapper>
+        </View>
+      </AvoidingViewContainer>
     </Modal>
   );
 }


### PR DESCRIPTION
## Explain the changes you’ve made
Added keyboardavoidingview for coApplicant modal

## Explain why these changes are made
The lowest input field in the modal became hidden when the device keyboard poped up, making it hard for the user to actually see its input.

## Explain your solution
Added keyboardavodingview, and a "normal" view which lets the keyboard "push" the modal content up in the screen, making the input field be shown even when the keyboard is shown.

## How to test

1. Checkout this branch
2. Swap the application to run storybook
3. Search for AddCoApplicantModal
4. Try the modal with the software keyboard for the emulator

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots
**Before**

<img width="339" alt="image" src="https://user-images.githubusercontent.com/9610681/203323597-c5ae5126-7dd1-4ae4-b9fd-0182b9b2214b.png">


**After**

<img width="341" alt="image" src="https://user-images.githubusercontent.com/9610681/203323512-0871b439-95ec-4cdf-8719-982ece3db89e.png">
