### PR TITLE
fix: retry submit signed cases

### DIFF
--- a/source/helpers/promise.ts
+++ b/source/helpers/promise.ts
@@ -1,0 +1,38 @@
+export interface ResolvedSettledPromise<T> {
+  status: "fulfilled";
+  value: T;
+}
+export interface RejectedSettledPromise {
+  status: "rejected";
+  reason: Error;
+}
+
+function toResolvedSettledPromise<T>(value: T): ResolvedSettledPromise<T> {
+  return {
+    status: "fulfilled",
+    value,
+  };
+}
+
+function toRejectedSettledPromise(reason: unknown): RejectedSettledPromise {
+  return {
+    status: "rejected",
+    reason: reason as Error,
+  };
+}
+
+export function allSettled<T>(
+  promises: Promise<T>[]
+): Promise<(ResolvedSettledPromise<T> | RejectedSettledPromise)[]> {
+  const settlePromises = promises.map((p) =>
+    p.then(toResolvedSettledPromise).catch(toRejectedSettledPromise)
+  );
+
+  return Promise.all(settlePromises);
+}
+
+export function isRejectedSettledPromise<T>(
+  value: ResolvedSettledPromise<T> | RejectedSettledPromise
+): value is RejectedSettledPromise {
+  return value.status === "rejected";
+}

--- a/source/helpers/promise.ts
+++ b/source/helpers/promise.ts
@@ -7,14 +7,18 @@ export interface RejectedSettledPromise {
   reason: Error;
 }
 
-function toResolvedSettledPromise<T>(value: T): ResolvedSettledPromise<T> {
+export function toResolvedSettledPromise<T>(
+  value: T
+): ResolvedSettledPromise<T> {
   return {
     status: "fulfilled",
     value,
   };
 }
 
-function toRejectedSettledPromise(reason: unknown): RejectedSettledPromise {
+export function toRejectedSettledPromise(
+  reason: unknown
+): RejectedSettledPromise {
   return {
     status: "rejected",
     reason: reason as Error,
@@ -24,8 +28,8 @@ function toRejectedSettledPromise(reason: unknown): RejectedSettledPromise {
 export function allSettled<T>(
   promises: Promise<T>[]
 ): Promise<(ResolvedSettledPromise<T> | RejectedSettledPromise)[]> {
-  const settlePromises = promises.map((p) =>
-    p.then(toResolvedSettledPromise).catch(toRejectedSettledPromise)
+  const settlePromises = promises.map((promise) =>
+    promise.then(toResolvedSettledPromise).catch(toRejectedSettledPromise)
   );
 
   return Promise.all(settlePromises);

--- a/source/helpers/test/promise.test.tsx
+++ b/source/helpers/test/promise.test.tsx
@@ -2,9 +2,40 @@ import type {
   RejectedSettledPromise,
   ResolvedSettledPromise,
 } from "../promise";
-import { allSettled, isRejectedSettledPromise } from "../promise";
+import {
+  toRejectedSettledPromise,
+  toResolvedSettledPromise,
+  allSettled,
+  isRejectedSettledPromise,
+} from "../promise";
 
 describe("Promise helpers", () => {
+  describe("toResolvedSettledPromise", () => {
+    it("returns correct structure", () => {
+      const expected: ResolvedSettledPromise<number> = {
+        status: "fulfilled",
+        value: 5,
+      };
+
+      const result = toResolvedSettledPromise(5);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("toRejectedSettledPromise", () => {
+    it("returns correct structure", () => {
+      const expected: RejectedSettledPromise = {
+        status: "rejected",
+        reason: new Error("fail"),
+      };
+
+      const result = toRejectedSettledPromise(new Error("fail"));
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe("allSettled", () => {
     it("returns resolved values", async () => {
       const promises: Promise<number | string>[] = [
@@ -15,18 +46,10 @@ describe("Promise helpers", () => {
       const result = await allSettled(promises);
 
       expect(result).toHaveLength(2);
-      expect(result).toEqual(
-        expect.arrayContaining([
-          {
-            status: "fulfilled",
-            value: 1,
-          },
-          {
-            status: "fulfilled",
-            value: "Hello",
-          },
-        ])
-      );
+      expect(result).toEqual([
+        toResolvedSettledPromise(1),
+        toResolvedSettledPromise("Hello"),
+      ]);
     });
 
     it("returns rejected errors", async () => {
@@ -39,18 +62,10 @@ describe("Promise helpers", () => {
       const result = await allSettled(promises);
 
       expect(result).toHaveLength(2);
-      expect(result).toEqual(
-        expect.arrayContaining([
-          {
-            status: "rejected",
-            reason: errors[0],
-          },
-          {
-            status: "rejected",
-            reason: errors[1],
-          },
-        ])
-      );
+      expect(result).toEqual([
+        toRejectedSettledPromise(errors[0]),
+        toRejectedSettledPromise(errors[1]),
+      ]);
     });
 
     it("returns both resolved and rejected values", async () => {
@@ -63,16 +78,11 @@ describe("Promise helpers", () => {
       const result = await allSettled(promises);
 
       expect(result).toHaveLength(3);
-      expect(result).toEqual(
-        expect.arrayContaining([
-          { status: "fulfilled", value: 5 },
-          {
-            status: "rejected",
-            reason: expect.any(Error),
-          },
-          { status: "fulfilled", value: "hello world" },
-        ])
-      );
+      expect(result).toEqual([
+        toResolvedSettledPromise(5),
+        toRejectedSettledPromise(new Error("lorem ipsum")),
+        toResolvedSettledPromise("hello world"),
+      ]);
     });
   });
 

--- a/source/helpers/test/promise.test.tsx
+++ b/source/helpers/test/promise.test.tsx
@@ -1,0 +1,102 @@
+import type {
+  RejectedSettledPromise,
+  ResolvedSettledPromise,
+} from "../promise";
+import { allSettled, isRejectedSettledPromise } from "../promise";
+
+describe("Promise helpers", () => {
+  describe("allSettled", () => {
+    it("returns resolved values", async () => {
+      const promises: Promise<number | string>[] = [
+        Promise.resolve(1),
+        Promise.resolve("Hello"),
+      ];
+
+      const result = await allSettled(promises);
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            status: "fulfilled",
+            value: 1,
+          },
+          {
+            status: "fulfilled",
+            value: "Hello",
+          },
+        ])
+      );
+    });
+
+    it("returns rejected errors", async () => {
+      const errors = [new Error("Hello"), new Error("World")];
+      const promises: Promise<never>[] = [
+        Promise.reject(errors[0]),
+        Promise.reject(errors[1]),
+      ];
+
+      const result = await allSettled(promises);
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            status: "rejected",
+            reason: errors[0],
+          },
+          {
+            status: "rejected",
+            reason: errors[1],
+          },
+        ])
+      );
+    });
+
+    it("returns both resolved and rejected values", async () => {
+      const promises: Promise<number | string>[] = [
+        Promise.resolve(5),
+        Promise.reject(new Error("lorem ipsum")),
+        Promise.resolve("hello world"),
+      ];
+
+      const result = await allSettled(promises);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          { status: "fulfilled", value: 5 },
+          {
+            status: "rejected",
+            reason: expect.any(Error),
+          },
+          { status: "fulfilled", value: "hello world" },
+        ])
+      );
+    });
+  });
+
+  describe("isRejectedSettledPromise", () => {
+    it("returns true for rejected settled promises", () => {
+      const rejected: RejectedSettledPromise = {
+        status: "rejected",
+        reason: new Error("oops"),
+      };
+
+      const result = isRejectedSettledPromise(rejected);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false for non-rejected settled promises", () => {
+      const fulfilled: ResolvedSettledPromise<number> = {
+        status: "fulfilled",
+        value: 5,
+      };
+
+      const result = isRejectedSettledPromise(fulfilled);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/source/store/actions/CaseActions.ts
+++ b/source/store/actions/CaseActions.ts
@@ -1,23 +1,27 @@
 import uuid from "react-native-uuid";
-import type { Form } from "../../types/FormTypes";
+
+import { allSettled, isRejectedSettledPromise } from "../../helpers/promise";
+import { get, isRequestError, post, put } from "../../helpers/ApiRequest";
+import { convertAnswersToArray } from "../../helpers/CaseDataConverter";
+import { filterAsync } from "../../helpers/Objects";
+import { to } from "../../helpers/Misc";
+
+import { getCurrentForm } from "../../services/encryption/CaseEncryptionHelper";
+import { PasswordStrategy } from "../../services/encryption/PasswordStrategy";
+import { wrappedDefaultStorage } from "../../services/storage/StorageService";
+import { CaseEncryptionService } from "../../services/encryption";
+import { ApplicationStatusType } from "../../types/Case";
+import { ActionTypes } from "../../types/CaseContext";
+
+import type { UserInterface } from "../../services/encryption/CaseEncryptionHelper";
+import type { Case } from "../../types/Case";
 import type {
   Action,
+  AddCoApplicantParameters,
   CaseUpdate,
   UpdateCaseBody,
-  AddCoApplicantParameters,
 } from "../../types/CaseContext";
-import { ActionTypes } from "../../types/CaseContext";
-import { get, post, put } from "../../helpers/ApiRequest";
-import { convertAnswersToArray } from "../../helpers/CaseDataConverter";
-import type { Case } from "../../types/Case";
-import { ApplicationStatusType } from "../../types/Case";
-import type { UserInterface } from "../../services/encryption/CaseEncryptionHelper";
-import { getCurrentForm } from "../../services/encryption/CaseEncryptionHelper";
-import { CaseEncryptionService } from "../../services/encryption";
-import { wrappedDefaultStorage } from "../../services/storage/StorageService";
-import { to } from "../../helpers/Misc";
-import { PasswordStrategy } from "../../services/encryption/PasswordStrategy";
-import { filterAsync } from "../../helpers/Objects";
+import type { Form } from "../../types/FormTypes";
 
 const {
   NOT_STARTED,
@@ -27,73 +31,6 @@ const {
   ACTIVE_COMPLETION_REQUIRED_VIVA,
   ACTIVE_SUBMITTED_COMPLETION,
 } = ApplicationStatusType;
-
-export async function updateCase(
-  {
-    user,
-    caseId,
-    formId,
-    answerObject,
-    signature,
-    currentPosition,
-    formQuestions,
-    encryptAnswers = true,
-    encryption,
-  }: CaseUpdate,
-  callback: (updatedCase: Case) => Promise<Action>
-): Promise<Action> {
-  const encryptionService = new CaseEncryptionService(
-    wrappedDefaultStorage,
-    async () => user
-  );
-  let updateCaseRequestBody: UpdateCaseBody = {
-    answers: convertAnswersToArray(answerObject, formQuestions),
-    currentPosition,
-    currentFormId: formId,
-    encryption,
-  };
-
-  if (encryptAnswers) {
-    const encryptedForm = await encryptionService.encryptForm(
-      updateCaseRequestBody
-    );
-    updateCaseRequestBody = {
-      ...updateCaseRequestBody,
-      ...encryptedForm,
-    };
-  }
-
-  if (signature?.success) {
-    updateCaseRequestBody.signature = signature;
-  }
-
-  try {
-    const res = await put(
-      `/cases/${caseId}`,
-      JSON.stringify(updateCaseRequestBody)
-    );
-    const { id, attributes } = res.data.data;
-    const flatUpdatedCase = { id, updatedAt: Date.now(), ...attributes };
-    if (callback) {
-      await callback(flatUpdatedCase);
-    }
-
-    flatUpdatedCase.forms[formId] = await encryptionService.decryptForm(
-      flatUpdatedCase.forms[formId]
-    );
-
-    return {
-      type: ActionTypes.UPDATE_CASE,
-      payload: flatUpdatedCase,
-    };
-  } catch (error) {
-    console.log(`Update current case error: ${error}`);
-    return {
-      type: ActionTypes.API_ERROR,
-      payload: error as Error,
-    };
-  }
-}
 
 function setupPinForCases(user: UserInterface, cases: Case[]) {
   const promises = cases.map(async (caseData) => {
@@ -109,67 +46,6 @@ function setupPinForCases(user: UserInterface, cases: Case[]) {
   });
 
   return Promise.all(promises);
-}
-
-export async function createCase(
-  user: UserInterface,
-  form: Form,
-  callback: (newCase: Case) => void
-): Promise<Action> {
-  const keyId = uuid.v4();
-  const body = {
-    provider: form.provider,
-    statusType: NOT_STARTED,
-    currentFormId: form.id,
-    forms: {
-      [form.id]: {
-        answers: [],
-        currentPosition: {
-          index: 0,
-          level: 0,
-          currentMainStep: 1,
-          currentMainStepIndex: 0,
-        },
-        encryption: {
-          type: "decrypted",
-          symmetricKeyName: keyId,
-          encryptionKeyId: keyId,
-        },
-      },
-    },
-    details: {},
-  };
-
-  try {
-    const response = await post("/cases", JSON.stringify(body));
-    const newCase = response.data.data;
-    const flattenedNewCase = {
-      id: newCase.id,
-      ...newCase.attributes,
-    };
-
-    await setupPinForCases(user, [flattenedNewCase]);
-
-    callback(flattenedNewCase);
-
-    return {
-      type: ActionTypes.CREATE_CASE,
-      payload: flattenedNewCase,
-    };
-  } catch (error) {
-    console.log("create case api error", error);
-    return {
-      type: ActionTypes.API_ERROR,
-      payload: error as Error,
-    };
-  }
-}
-
-export function deleteCase(caseId: string): Action {
-  return {
-    type: ActionTypes.DELETE_CASE,
-    payload: caseId,
-  };
 }
 
 async function getCasesThatShouldGeneratePin(
@@ -215,9 +91,196 @@ async function getCasesThatShouldGeneratePin(
   return casesWithoutGeneratedPin;
 }
 
+function shouldCaseBeSubmitted(caseData: Case): boolean {
+  return caseData.status.type.includes(
+    ApplicationStatusType.ACTIVE_SIGNATURE_COMPLETED
+  );
+}
+
+async function putCaseUpdate(
+  user: UserInterface,
+  id: string,
+  updateCaseRequestBody: UpdateCaseBody
+) {
+  const encryptionService = new CaseEncryptionService(
+    wrappedDefaultStorage,
+    async () => user
+  );
+
+  const res = await put<{ id: string; attributes: Case }>(
+    `/cases/${id}`,
+    JSON.stringify(updateCaseRequestBody)
+  );
+
+  if (isRequestError(res)) {
+    throw new Error(res.message);
+  }
+
+  const { attributes } = res.data.data;
+  const flatUpdatedCase = { ...attributes };
+
+  flatUpdatedCase.forms[updateCaseRequestBody.currentFormId] =
+    await encryptionService.decryptForm(
+      flatUpdatedCase.forms[updateCaseRequestBody.currentFormId]
+    );
+
+  return flatUpdatedCase;
+}
+
+async function submitCase(user: UserInterface, caseData: Case): Promise<Case> {
+  console.log("(re)submitting", caseData.id);
+  const currentForm = caseData.forms[caseData.currentFormId];
+  const formId = caseData.currentFormId;
+
+  const updateCaseRequestBody: UpdateCaseBody = {
+    answers: currentForm.answers,
+    currentFormId: formId,
+    currentPosition: currentForm.currentPosition,
+    encryption: currentForm.encryption,
+  };
+
+  return putCaseUpdate(user, caseData.id, updateCaseRequestBody);
+}
+
+export async function updateCase(
+  {
+    user,
+    caseId,
+    formId,
+    answerObject,
+    signature,
+    currentPosition,
+    formQuestions,
+    encryptAnswers = true,
+    encryption,
+  }: CaseUpdate,
+  callback: (updatedCase: Case) => Promise<Action>
+): Promise<Action> {
+  const encryptionService = new CaseEncryptionService(
+    wrappedDefaultStorage,
+    async () => user
+  );
+  let updateCaseRequestBody: UpdateCaseBody = {
+    answers: convertAnswersToArray(answerObject, formQuestions),
+    currentPosition,
+    currentFormId: formId,
+    encryption,
+  };
+
+  if (encryptAnswers) {
+    const encryptedForm = await encryptionService.encryptForm(
+      updateCaseRequestBody
+    );
+    updateCaseRequestBody = {
+      ...updateCaseRequestBody,
+      ...encryptedForm,
+    };
+  }
+
+  if (signature?.success) {
+    updateCaseRequestBody.signature = signature;
+  }
+
+  try {
+    const flatUpdatedCase = await putCaseUpdate(
+      user,
+      caseId,
+      updateCaseRequestBody
+    );
+    if (callback) {
+      await callback(flatUpdatedCase);
+    }
+
+    return {
+      type: ActionTypes.UPDATE_CASE,
+      payload: flatUpdatedCase,
+    };
+  } catch (error) {
+    console.error(`Update current case error: ${error}`);
+    return {
+      type: ActionTypes.API_ERROR,
+      payload: error as Error,
+    };
+  }
+}
+
+export async function createCase(
+  user: UserInterface,
+  form: Form,
+  callback: (newCase: Case) => void
+): Promise<Action> {
+  const keyId = uuid.v4();
+  const body = {
+    provider: form.provider,
+    statusType: NOT_STARTED,
+    currentFormId: form.id,
+    forms: {
+      [form.id]: {
+        answers: [],
+        currentPosition: {
+          index: 0,
+          level: 0,
+          currentMainStep: 1,
+          currentMainStepIndex: 0,
+        },
+        encryption: {
+          type: "decrypted",
+          symmetricKeyName: keyId,
+          encryptionKeyId: keyId,
+        },
+      },
+    },
+    details: {},
+  };
+
+  try {
+    const response = await post<{ attributes: Case; id: string }>(
+      "/cases",
+      JSON.stringify(body)
+    );
+
+    if (isRequestError(response)) {
+      throw new Error(response.message);
+    }
+
+    const newCase = response.data.data;
+    const flattenedNewCase: Case = {
+      ...newCase.attributes,
+      id: newCase.id,
+    };
+
+    await setupPinForCases(user, [flattenedNewCase]);
+
+    callback(flattenedNewCase);
+
+    return {
+      type: ActionTypes.CREATE_CASE,
+      payload: flattenedNewCase,
+    };
+  } catch (error) {
+    console.log("create case api error", error);
+    return {
+      type: ActionTypes.API_ERROR,
+      payload: error as Error,
+    };
+  }
+}
+
+export function deleteCase(caseId: string): Action {
+  return {
+    type: ActionTypes.DELETE_CASE,
+    payload: caseId,
+  };
+}
+
 export async function fetchCases(user: UserInterface): Promise<Action> {
   try {
-    const response = await get("/cases");
+    const response = await get<{ attributes: { cases: Case[] } }>("/cases");
+
+    if (isRequestError(response)) {
+      throw new Error(response.message);
+    }
+
     const rawCases: Case[] = response?.data?.data?.attributes?.cases;
 
     if (rawCases) {
@@ -246,6 +309,18 @@ export async function fetchCases(user: UserInterface): Promise<Action> {
         readyCases
       );
       await setupPinForCases(user, casesToGeneratePinFor);
+
+      const casesToSubmit = readyCases.filter(shouldCaseBeSubmitted);
+      const submitCaseWithUser = (caseData: Case) => submitCase(user, caseData);
+      const submitResults = await allSettled(
+        casesToSubmit.map(submitCaseWithUser)
+      );
+      const failedToSubmit = submitResults.filter(isRejectedSettledPromise);
+      if (failedToSubmit.length > 0) {
+        console.warn(`failed to (re)submit ${failedToSubmit.length} cases`);
+        failedToSubmit.forEach(({ reason }) => console.error(reason));
+      }
+
       const casesMappedById = readyCases.reduce<Record<string, Case>>(
         (mappedCases, caseData) => ({
           ...mappedCases,
@@ -276,12 +351,16 @@ export async function addCaseCoApplicant(
   caseId: string,
   parameters: AddCoApplicantParameters
 ): Promise<{ type: ActionTypes.UPDATE_CASE; payload: Case }> {
-  const addCoApplicantResult = await put(
-    `/viva-cases/${caseId}/persons`,
-    JSON.stringify(parameters)
-  );
+  const addCoApplicantResult = await put<{
+    message: string;
+    attributes: { caseItem: Case };
+  }>(`/viva-cases/${caseId}/persons`, JSON.stringify(parameters));
 
-  if (addCoApplicantResult?.status !== 200) {
+  if (isRequestError(addCoApplicantResult)) {
+    throw new Error(addCoApplicantResult.message);
+  }
+
+  if (addCoApplicantResult.status !== 200) {
     const errorMessage =
       addCoApplicantResult?.data?.data?.message || "Något gick fel";
     throw new Error(errorMessage);

--- a/source/store/actions/CaseActions.ts
+++ b/source/store/actions/CaseActions.ts
@@ -246,7 +246,6 @@ export async function createCase(
     const newCase = response.data.data;
     const flattenedNewCase: Case = {
       ...newCase.attributes,
-      id: newCase.id,
     };
 
     await setupPinForCases(user, [flattenedNewCase]);


### PR DESCRIPTION
## Explain the changes you’ve made

Added a check when fetching for cases that should be submitted (fully signed) and try to re-submit them.

## Explain why these changes are made

Fixes potential issue where if decrypting or submission of form (see diagram below, step 3 and 4) the case would appear submitted (or "signed") but not actually submitted. This fix attempts to identify and re-submit those cases during case fetching.

## Explain your solution

Added function during `fetchCases` that checks for the problematic cases, and add another function to (re)submit them (also during `fetchCases`).

Additionally moved some parts in `CaseActions` around for better structure, and fixed some linting/error handling issues. 

## How to test

Concrete example:

1. Checkout this branch
2. Run through a form until sign
3. Simulate a problem after signing (for example throwing an error in `FormCaseScreen` line 110)
4. Verify that the case (in dynamo) is now signed but still encrypted
5. Exit the form and verify it says "signerad"
6. Refresh and verify that it was re-submitted and is now "inskickad"

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

Sequence diagram:
```mermaid
sequenceDiagram
    App->>Api: 1) UpdateCase (sign)
    note right of Api: (answers encrypted)
    Api->>App: 2) fully signed (SIGNATURE_COMPLETED)
    App->>App: 3) decrypt answers
    App->>Api: 4) UpdateCase (unencrypted/submit)
    note right of Api: (answers unencrypted)
```
