### PR TITLE
feat: enable removing ongoing cases

### DIFF
--- a/source/helpers/Case.ts
+++ b/source/helpers/Case.ts
@@ -1,0 +1,17 @@
+import type { Case } from "../types/Case";
+import { ApplicationStatusType } from "../types/Case";
+
+const {
+  ACTIVE_SIGNATURE_PENDING,
+  ACTIVE_ONGOING,
+  ACTIVE_ONGOING_NEW_APPLICATION,
+} = ApplicationStatusType;
+
+// eslint-disable-next-line import/prefer-default-export
+export function canCaseBeRemoved(caseData: Case): boolean {
+  return [
+    ACTIVE_SIGNATURE_PENDING,
+    ACTIVE_ONGOING,
+    ACTIVE_ONGOING_NEW_APPLICATION,
+  ].includes(caseData.status.type);
+}

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -225,7 +225,7 @@ const computeCaseCardComponent = (
   if (shouldEnterPin) {
     buttonProps.onClick = onShowPinInput;
     buttonProps.text = "Ange pinkod";
-    cardProps.onClick = undefined;
+    cardProps.onClick = () => navigation.onOpenCaseSummary(caseId);
   }
 
   const shouldShowPin = isWaitingForSign && !isCoApplicant;

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -32,6 +32,7 @@ import { convertDataToArray, calculateSum } from "../../helpers/FormatVivaData";
 import { launchPhone, launchEmail } from "../../helpers/LaunchExternalApp";
 import { getSwedishMonthNameByTimeStamp } from "../../helpers/DateHelpers";
 import { put, remove } from "../../helpers/ApiRequest";
+import { canCaseBeRemoved } from "../../helpers/Case";
 
 import useSetupForm from "../../containers/Form/hooks/useSetupForm";
 import statusTypeConstantMapper from "./statusTypeConstantMapper";
@@ -61,7 +62,7 @@ import type {
   PDF,
 } from "../../types/Case";
 
-const { ACTIVE_SIGNATURE_PENDING, APPROVED } = ApplicationStatusType;
+const { APPROVED } = ApplicationStatusType;
 const SCREEN_TRANSITION_DELAY = 1000;
 
 const computeCaseCardComponent = (
@@ -261,8 +262,7 @@ const CaseSummary = (props: Props): JSX.Element => {
     ? convertDataToArray(decision.decisions.decision)
     : [];
 
-  const canRemoveCase =
-    [ACTIVE_SIGNATURE_PENDING].includes(caseData.status.type) && isApplicant;
+  const canRemoveCase = canCaseBeRemoved(caseData) && isApplicant;
 
   const removeCase = async () => {
     const result = await remove(`cases/${caseId}`, undefined, undefined);


### PR DESCRIPTION
## Explain the changes you’ve made

Enabled user to remove ongoing (new/recurring) cases if desired.

## Explain why these changes are made

Users can remove ongoing cases to solve common issues with lost encryption, and supportcenter can refer users to this functionality without involving the developer team.

## Explain your solution

Changed the list of valid removable statuses to include ongoing statuses. Also refactored it into a separate function for future use.

## How to test

Concrete example:

1. Checkout this branch
2. Start a form and save it without submitting
3. Verify the "Ta bort ansökan" button is visible in case details and works as expected
4. Verify it works for recurring as well as new (but **not** random check/completions)

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.