### PR TITLE
feat: enable removing cases with broken encryption

### DIFF
--- a/source/components/organisms/RemoveCaseModal/RemoveCaseModal.tsx
+++ b/source/components/organisms/RemoveCaseModal/RemoveCaseModal.tsx
@@ -42,8 +42,8 @@ function RemoveCaseModal({
   const modalContent: Record<RemoveCaseState, ModalContent> = {
     [RemoveCaseState.Default]: {
       text: {
-        title: "Vill du ta bort din ansökan?",
-        body: "När en ansökan tagits bort kan en ny ansökan för perioden skapas",
+        title: "Vill du göra om denna ansökan?",
+        body: "Din tidigare ansökan tas bort och en ny ansökan skapas upp.",
       },
       buttons: [
         getModalButtonSet("Avbryt", "neutral", handleCloseModal),
@@ -52,7 +52,7 @@ function RemoveCaseModal({
     },
     [RemoveCaseState.Loading]: {
       text: {
-        title: "Ditt ärende tas bort",
+        title: "Ditt ärende rensas",
         body: "Vänligen vänta ...",
       },
       buttons: [],

--- a/source/components/organisms/RemoveCaseModal/RemoveCaseModal.tsx
+++ b/source/components/organisms/RemoveCaseModal/RemoveCaseModal.tsx
@@ -52,7 +52,7 @@ function RemoveCaseModal({
     },
     [RemoveCaseState.Loading]: {
       text: {
-        title: "Ditt ärende rensas",
+        title: "Din ansökan tas bort",
         body: "Vänligen vänta ...",
       },
       buttons: [],

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -305,11 +305,11 @@ const CaseSummary = (props: Props): JSX.Element => {
 
   const updateCaseSignature = useCallback(
     async (caseItem, signatureSuccessful) => {
-      const currentForm = caseItem.forms[caseItem.currentFormId];
+      const caseForm = caseItem.forms[caseItem.currentFormId];
 
       const updateCaseRequestBody = {
         currentFormId: caseItem.currentFormId,
-        ...currentForm,
+        ...caseForm,
         signature: { success: signatureSuccessful },
       };
 


### PR DESCRIPTION
## Explain the changes you’ve made

Enabled cases with broken encryption (key missing from device) to removed. Changed texts and UX as well to be clearer.

## Explain why these changes are made

So users are informed and can act accordingly after re-installing app or changing device.

## Explain your solution

* Copied and tweaked how `RemoveCaseModal` is handled from `CaseSummary` to `CaseOverview`.
* Changed texts and UI in `CaseOverview` accordingly to detect and present a case with "broken" encryption.
* Changed texts in RemoveCaseModal to try to improve the UX.

## How to test

Test the following steps with both new and recurring application, as single/main/co-applicant, for both overview and summary screen.

Verify that only single or main applicant has the ability to remove broken cases.

1. Start the form
2. Save and close it
3. Remove key (dev features -> "Nollställ data" or re-install app)
4. Verify that the case is shown as broken and prompts to start-over
5. Press the button to start-over
6. Verify that the case is "reset" and the form can be started again

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

A broken case:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/2890987/203813646-dbb9a597-099f-4337-b1ff-8db3c294d476.png">

Summary view. Notice that the default remove case button is not visible.
<img width="472" alt="image" src="https://user-images.githubusercontent.com/2890987/203813729-046750fa-1d88-4952-af6d-f1226d0a7967.png">

Modal changes:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/2890987/203813878-8fc5128e-8f96-4ad1-8eb8-b5cf4eddd617.png">

Co-applicant view (not really correct but unchanged in this PR):
<img width="464" alt="image" src="https://user-images.githubusercontent.com/2890987/203814348-af061c7e-ac00-4aec-989d-edbc9f48b2e3.png">

