### PR TITLE
Feat/attachments modal

### DIFF
--- a/source/components/organisms/SetupFormModal/SetupFormModal.test.tsx
+++ b/source/components/organisms/SetupFormModal/SetupFormModal.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { render } from "../../../../test-utils";
+
+import SetupFormModal from "./SetupFormModal";
+
+it("renders without crashing", () => {
+  const component = () =>
+    render(
+      <SetupFormModal
+        hasError={false}
+        visible
+        onRetryOpenForm={() => undefined}
+        onCloseModal={() => undefined}
+      />
+    );
+
+  expect(component).not.toThrow();
+});

--- a/source/components/organisms/SetupFormModal/SetupFormModal.tsx
+++ b/source/components/organisms/SetupFormModal/SetupFormModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 
 import { CloseDialog } from "../../molecules";
 
@@ -17,31 +17,30 @@ const getModalButtonSet = (
 
 function SetupFormModal({
   visible,
-  errorMessage,
+  hasError,
   onCloseModal,
   onRetryOpenForm,
 }: Props): JSX.Element | null {
-  const { text, buttons } = useMemo(() => {
-    if (errorMessage) {
-      return {
-        text: {
-          title: "Ett fel har uppstått ",
-          body: "Vill du försöka igen?",
-        },
-        buttons: [
-          getModalButtonSet("Avbryt", "neutral", onCloseModal),
-          getModalButtonSet("Ja", "red", onRetryOpenForm),
-        ],
-      };
-    }
-    return {
-      text: {
-        title: "Förbereder formulär",
-        body: "Vänligen vänta ...",
-      },
-      buttons: [],
-    };
-  }, [errorMessage, onCloseModal, onRetryOpenForm]);
+  const defaultContent = {
+    text: {
+      title: "Förbereder formulär",
+      body: "Vänligen vänta ...",
+    },
+    buttons: [],
+  };
+
+  const errorContent = {
+    text: {
+      title: "Ett fel har uppstått ",
+      body: "Vill du försöka igen?",
+    },
+    buttons: [
+      getModalButtonSet("Avbryt", "neutral", onCloseModal),
+      getModalButtonSet("Ja", "red", onRetryOpenForm),
+    ],
+  };
+
+  const { text, buttons } = hasError ? errorContent : defaultContent;
 
   if (!visible) return null;
 

--- a/source/components/organisms/SetupFormModal/SetupFormModal.tsx
+++ b/source/components/organisms/SetupFormModal/SetupFormModal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { CloseDialog } from "../../molecules";
 
-import type { ButtonSet, Props } from "./SetupFormModal.types";
+import type { ButtonSet, Props, ModalContent } from "./SetupFormModal.types";
 import type { PrimaryColor } from "../../../theme/themeHelpers";
 
 const getModalButtonSet = (
@@ -21,7 +21,7 @@ function SetupFormModal({
   onCloseModal,
   onRetryOpenForm,
 }: Props): JSX.Element | null {
-  const defaultContent = {
+  const defaultContent: ModalContent = {
     text: {
       title: "Förbereder formulär",
       body: "Vänligen vänta ...",
@@ -29,7 +29,7 @@ function SetupFormModal({
     buttons: [],
   };
 
-  const errorContent = {
+  const errorContent: ModalContent = {
     text: {
       title: "Ett fel har uppstått ",
       body: "Vill du försöka igen?",

--- a/source/components/organisms/SetupFormModal/SetupFormModal.tsx
+++ b/source/components/organisms/SetupFormModal/SetupFormModal.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from "react";
+
+import { CloseDialog } from "../../molecules";
+
+import type { ButtonSet, Props } from "./SetupFormModal.types";
+import type { PrimaryColor } from "../../../theme/themeHelpers";
+
+const getModalButtonSet = (
+  text: string,
+  color: PrimaryColor,
+  clickHandler: () => void | Promise<void>
+): ButtonSet => ({
+  text,
+  color,
+  clickHandler,
+});
+
+function SetupFormModal({
+  visible,
+  errorMessage,
+  onCloseModal,
+  onRetryOpenForm,
+}: Props): JSX.Element | null {
+  const { text, buttons } = useMemo(() => {
+    if (errorMessage) {
+      return {
+        text: {
+          title: "Ett fel har uppstått ",
+          body: "Vill du försöka igen?",
+        },
+        buttons: [
+          getModalButtonSet("Avbryt", "neutral", onCloseModal),
+          getModalButtonSet("Ja", "red", onRetryOpenForm),
+        ],
+      };
+    }
+    return {
+      text: {
+        title: "Förbereder formulär",
+        body: "Vänligen vänta ...",
+      },
+      buttons: [],
+    };
+  }, [errorMessage, onCloseModal, onRetryOpenForm]);
+
+  if (!visible) return null;
+
+  return (
+    <CloseDialog
+      visible={visible}
+      title={text.title}
+      body={text.body}
+      buttons={buttons}
+    />
+  );
+}
+
+export default SetupFormModal;

--- a/source/components/organisms/SetupFormModal/SetupFormModal.types.ts
+++ b/source/components/organisms/SetupFormModal/SetupFormModal.types.ts
@@ -2,7 +2,7 @@ import type { PrimaryColor } from "../../../theme/themeHelpers";
 
 export interface Props {
   visible: boolean;
-  errorMessage: string;
+  hasError: boolean;
   onRetryOpenForm: () => void;
   onCloseModal: () => void;
 }

--- a/source/components/organisms/SetupFormModal/SetupFormModal.types.ts
+++ b/source/components/organisms/SetupFormModal/SetupFormModal.types.ts
@@ -1,0 +1,22 @@
+import type { PrimaryColor } from "../../../theme/themeHelpers";
+
+export interface Props {
+  visible: boolean;
+  errorMessage: string;
+  onRetryOpenForm: () => void;
+  onCloseModal: () => void;
+}
+
+export interface ButtonSet {
+  text: string;
+  color: PrimaryColor;
+  clickHandler: () => void | Promise<void>;
+}
+
+export interface ModalContent {
+  text: {
+    title: string;
+    body: string;
+  };
+  buttons: ButtonSet[];
+}

--- a/source/components/organisms/SetupFormModal/index.ts
+++ b/source/components/organisms/SetupFormModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SetupFormModal";

--- a/source/components/organisms/index.ts
+++ b/source/components/organisms/index.ts
@@ -6,3 +6,4 @@ export { default as CaseCalculationsModal } from "./CaseCalculationsModal/CaseCa
 export { default as RemoveCaseModal } from "./RemoveCaseModal/RemoveCaseModal";
 export { default as PdfModal } from "./PdfModal";
 export { default as ApiStatusMessages } from "./ApiStatusMessages";
+export { default as SetupFormModal } from "./SetupFormModal";

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -39,7 +39,7 @@ import {
 import { ApplicationStatusType } from "../../types/Case";
 import ICON from "../../assets/images/icons";
 
-import type { /* Answer, */ AnsweredForm, Case } from "../../types/Case";
+import type { Answer, AnsweredForm, Case } from "../../types/Case";
 import type {
   AddCoApplicantParameters,
   Dispatch as CaseContextDispatch,

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -657,7 +657,7 @@ function CaseOverview(props: CaseOverviewProps): JSX.Element {
       {activeModal.modal === Modal.SETUP_LOADING_FORM_MODAL && (
         <SetupFormModal
           onRetryOpenForm={retryOpenForm}
-          errorMessage={activeModal?.error ?? ""}
+          hasError={!!activeModal?.error}
           onCloseModal={closeOpenModal}
           visible
         />

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -269,7 +269,7 @@ const CaseSummary = (props: Props): JSX.Element => {
   const [showRemoveCaseModal, toggleRemoveCaseModal] = useModal();
 
   const [showSetupFormModal, setShowSetupFormModal] = useState(false);
-  const [setupFormError, setSetupFormError] = useState("");
+  const [hasSetupFormError, setSetupFormError] = useState(false);
 
   const [setupForm] = useSetupForm();
   const passwords = useGetFormPasswords(cases, authContext.user);
@@ -340,7 +340,7 @@ const CaseSummary = (props: Props): JSX.Element => {
   };
 
   const openForm = async (id: string, isSignMode = false) => {
-    setSetupFormError("");
+    setSetupFormError(false);
     setShowSetupFormModal(true);
 
     try {
@@ -352,7 +352,7 @@ const CaseSummary = (props: Props): JSX.Element => {
       closeSetupFormModal();
       navigation.navigate("Form", { caseId: id, isSignMode });
     } catch (error) {
-      setSetupFormError(error?.message);
+      setSetupFormError(true);
     }
   };
 
@@ -468,7 +468,7 @@ const CaseSummary = (props: Props): JSX.Element => {
           visible
           onCloseModal={closeSetupFormModal}
           onRetryOpenForm={onRetryOpenForm}
-          errorMessage={setupFormError}
+          hasError={hasSetupFormError}
         />
       )}
 

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -12,14 +12,10 @@ import {
   CaseCalculationsModal,
   RemoveCaseModal,
   PdfModal,
+  SetupFormModal,
 } from "../../components/organisms";
 
-import {
-  Card,
-  ScreenWrapper,
-  CaseCard,
-  CloseDialog,
-} from "../../components/molecules";
+import { Card, ScreenWrapper, CaseCard } from "../../components/molecules";
 import { useModal } from "../../components/molecules/Modal";
 
 import { Icon, Text, Button } from "../../components/atoms";
@@ -271,7 +267,9 @@ const CaseSummary = (props: Props): JSX.Element => {
 
   const [isModalVisible, toggleModal] = useModal();
   const [showRemoveCaseModal, toggleRemoveCaseModal] = useModal();
-  const [showLoadingModal, toggleLoadingModal] = useModal();
+
+  const [showSetupFormModal, setShowSetupFormModal] = useState(false);
+  const [setupFormError, setSetupFormError] = useState("");
 
   const [setupForm] = useSetupForm();
   const passwords = useGetFormPasswords(cases, authContext.user);
@@ -337,16 +335,26 @@ const CaseSummary = (props: Props): JSX.Element => {
     [navigation]
   );
 
+  const closeSetupFormModal = () => {
+    setShowSetupFormModal(false);
+  };
+
   const openForm = async (id: string, isSignMode = false) => {
-    toggleLoadingModal();
+    setShowSetupFormModal(true);
+    setSetupFormError("");
 
-    await setupForm(
-      cases[id].forms[cases[id].currentFormId].answers as Answer[],
-      cases[id].currentFormId
-    );
+    try {
+      await setupForm(
+        cases[id].forms[cases[id].currentFormId].answers as Answer[],
+        cases[id].currentFormId
+      );
 
-    toggleLoadingModal();
-    navigation.navigate("Form", { caseId: id, isSignMode });
+      closeSetupFormModal();
+      navigation.navigate("Form", { caseId: id, isSignMode });
+    } catch (error) {
+      setSetupFormError(error?.message);
+      console.log("ERROR: ", error);
+    }
   };
 
   useEffect(() => {
@@ -452,11 +460,12 @@ const CaseSummary = (props: Props): JSX.Element => {
         onRemoveCase={removeCase}
       />
 
-      {showLoadingModal && (
-        <CloseDialog
+      {showSetupFormModal && (
+        <SetupFormModal
           visible
-          title="Förbereder formulär"
-          body="Vänligen vänta ..."
+          onCloseModal={closeSetupFormModal}
+          onRetryOpenForm={openForm}
+          errorMessage={setupFormError}
         />
       )}
 

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -340,8 +340,8 @@ const CaseSummary = (props: Props): JSX.Element => {
   };
 
   const openForm = async (id: string, isSignMode = false) => {
-    setShowSetupFormModal(true);
     setSetupFormError("");
+    setShowSetupFormModal(true);
 
     try {
       await setupForm(
@@ -353,8 +353,11 @@ const CaseSummary = (props: Props): JSX.Element => {
       navigation.navigate("Form", { caseId: id, isSignMode });
     } catch (error) {
       setSetupFormError(error?.message);
-      console.log("ERROR: ", error);
     }
+  };
+
+  const onRetryOpenForm = async () => {
+    await openForm(caseId);
   };
 
   useEffect(() => {
@@ -464,7 +467,7 @@ const CaseSummary = (props: Props): JSX.Element => {
         <SetupFormModal
           visible
           onCloseModal={closeSetupFormModal}
-          onRetryOpenForm={openForm}
+          onRetryOpenForm={onRetryOpenForm}
           errorMessage={setupFormError}
         />
       )}

--- a/source/store/FormContext.tsx
+++ b/source/store/FormContext.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
 import type { Form } from "../types/FormTypes";
-import { get } from "../helpers/ApiRequest";
+import { get, isRequestError } from "../helpers/ApiRequest";
 
 interface FormContextValue {
   forms: Record<string, Form>;
@@ -41,24 +41,21 @@ export function FormProvider({ children }: FormProviderProps): JSX.Element {
   }, [formSummaries]);
 
   const getForm = useCallback(
-    async (id: string): Promise<Form | null> => {
+    async (id: string): Promise<Form> => {
       if (Object.keys(forms).includes(id)) {
         return forms[id];
       }
 
-      try {
-        const res = await get(`/forms/${id}`);
-        if (res && res.data) {
-          const newForm = res.data.data;
-          setForms((oldForms) => ({ ...oldForms, [newForm.id]: newForm }));
-          return newForm;
-        }
-        console.log("Form data not found");
-      } catch (error) {
-        console.error(error);
+      const res = await get<Form>(`/forms/${id}`);
+
+      if (isRequestError(res)) {
+        console.error("Could not fetch form:", res.message);
+        throw new Error(res.message);
       }
 
-      return null;
+      const newForm = res.data.data;
+      setForms((oldForms) => ({ ...oldForms, [newForm.id]: newForm }));
+      return newForm;
     },
     [forms]
   );


### PR DESCRIPTION
## Explain the changes you’ve made
Added new modal for handling loading text and retries when failing downloading attachments and form

## Explain why these changes are made
There was no error handling before when trying to opening a modal, which could have lead to people getting stuck when opening a form. This modal gives the user an option to retry opening the modal or give up the attempt.

## Explain your solution
Created a new modal which displays an loading text, if there is an error message, show the buttons for aborting or retry

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Try to open any form, the modal should then be visible
4. try to create an error when downloading attachments, the retry buttons should then be visible

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.


## Screenshots

<img width="515" alt="image" src="https://user-images.githubusercontent.com/9610681/204004235-48a294a0-51fa-4b9c-9da5-0062ba1d3630.png">


<img width="513" alt="image" src="https://user-images.githubusercontent.com/9610681/204004393-dad0778f-f4f6-469e-aa28-affa6be0229f.png">
