### PR TITLE
fix(formcasescreen): fetch encrytion before opening form

### DIFF
--- a/source/screens/form/FormCaseScreen.tsx
+++ b/source/screens/form/FormCaseScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState, useMemo } from "react";
+import { ActivityIndicator } from "react-native";
 
 import Form, { defaultInitialStatus } from "../../containers/Form/Form";
 
@@ -16,6 +17,7 @@ import { getPasswordForForm } from "../../services/encryption/CaseEncryptionHelp
 import { wrappedDefaultStorage } from "../../services/storage/StorageService";
 
 import type { CaseUpdate, Signature, Action } from "../../types/CaseContext";
+// eslint-disable-next-line unused-imports/no-unused-imports
 import { ApplicationStatusType } from "../../types/Case";
 import type { Props } from "./FormCaseScreen.types";
 import type { User } from "../../types/UserTypes";
@@ -26,8 +28,12 @@ import type {
   Answer,
 } from "../../types/Case";
 
+const FROM_LOADING_TO_FORM_DELAY = 500;
+
 const FormCaseScreen = ({ route, navigation }: Props): JSX.Element => {
   const [encryptionPin, setEncryptionPin] = useState("");
+  const [loadingEncryptionPin, setLoadinEncryptionpin] = useState(true);
+
   const { caseId, isSignMode } = route?.params || {};
   const { user } = useContext(AuthContext);
   const { forms } = useContext(FormContext);
@@ -72,6 +78,10 @@ const FormCaseScreen = ({ route, navigation }: Props): JSX.Element => {
       const pinCodeToUse = (pinCode ?? "") as string;
 
       setEncryptionPin(pinCodeToUse);
+      setTimeout(
+        () => setLoadinEncryptionpin(false),
+        FROM_LOADING_TO_FORM_DELAY
+      );
     };
 
     void setupEncryptionPin();
@@ -119,6 +129,15 @@ const FormCaseScreen = ({ route, navigation }: Props): JSX.Element => {
   const handleSubmitForm = () => {
     handleCloseForm();
   };
+
+  if (loadingEncryptionPin) {
+    return (
+      <ActivityIndicator
+        style={{ flex: 1, justifyContent: "center" }}
+        size="large"
+      />
+    );
+  }
 
   return (
     <Form

--- a/source/screens/form/FormCaseScreen.tsx
+++ b/source/screens/form/FormCaseScreen.tsx
@@ -17,7 +17,6 @@ import { getPasswordForForm } from "../../services/encryption/CaseEncryptionHelp
 import { wrappedDefaultStorage } from "../../services/storage/StorageService";
 
 import type { CaseUpdate, Signature, Action } from "../../types/CaseContext";
-// eslint-disable-next-line unused-imports/no-unused-imports
 import { ApplicationStatusType } from "../../types/Case";
 import type { Props } from "./FormCaseScreen.types";
 import type { User } from "../../types/UserTypes";

--- a/source/screens/form/FormCaseScreen.tsx
+++ b/source/screens/form/FormCaseScreen.tsx
@@ -31,7 +31,7 @@ const FROM_LOADING_TO_FORM_DELAY = 500;
 
 const FormCaseScreen = ({ route, navigation }: Props): JSX.Element => {
   const [encryptionPin, setEncryptionPin] = useState("");
-  const [loadingEncryptionPin, setLoadinEncryptionpin] = useState(true);
+  const [loadingEncryptionPin, setLoadingEncryptionPin] = useState(true);
 
   const { caseId, isSignMode } = route?.params || {};
   const { user } = useContext(AuthContext);
@@ -78,7 +78,7 @@ const FormCaseScreen = ({ route, navigation }: Props): JSX.Element => {
 
       setEncryptionPin(pinCodeToUse);
       setTimeout(
-        () => setLoadinEncryptionpin(false),
+        () => setLoadingEncryptionPin(false),
         FROM_LOADING_TO_FORM_DELAY
       );
     };


### PR DESCRIPTION
## Explain the changes you’ve made
Make sure that the encryption is set before opening the form.

## Explain why these changes are made
The form were opened before the encryption pin were set in state, which meant that the useForm hook were setting an initial state without the encryption pin. This meant that there were no encryption bin to show to the user at the end of the form.

## Explain your solution
Added a loading state and an activity indicator which tricks the user that the form is loading when it actually only sets the encryption pin in the state. By doing this we ensure that the pin is loaded (and hopefully exist) before opening the form and sets the initial state in the useForm hook.

Concrete example:

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios` or `yarn android`
3. Run a form where there is both an applicant and co-applicant, like an ongoing form
4. Make sure the encryption pin is shown at the end of the form, after sign

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Screenshots

<img width="397" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/9610681/207858708-a2dbfd80-2e3a-4809-b8f7-4edce2cef881.png">
