### PR TITLE
Fix/summarylistitem remove input fix

### DIFF
--- a/source/components/molecules/GroupedList/GroupedList.tsx
+++ b/source/components/molecules/GroupedList/GroupedList.tsx
@@ -8,7 +8,7 @@ import { Heading, Fieldset, Text, Button } from "../../atoms";
 import theme from "../../../theme/theme";
 import { getValidColorSchema } from "../../../theme/themeHelpers";
 
-import type { SummaryListItem } from "../../organisms/SummaryList/SummaryList";
+import type { SummaryListItem } from "../../organisms/SummaryList/SummaryList.types";
 import type { PrimaryColor } from "../../../theme/themeHelpers";
 import type { Help } from "../../../types/FormTypes";
 

--- a/source/components/organisms/SummaryList/SummaryList.styled.ts
+++ b/source/components/organisms/SummaryList/SummaryList.styled.ts
@@ -1,0 +1,53 @@
+import styled from "styled-components/native";
+
+import { Text, Heading } from "../../atoms";
+
+import type { PrimaryColor, ThemeType } from "../../../theme/themeHelpers";
+
+interface SumLabelProps {
+  colorSchema: PrimaryColor;
+}
+const SumLabel = styled(Heading)<SumLabelProps>`
+  margin-top: 5px;
+  margin-left: 3px;
+  font-weight: ${({ theme }) => theme.fontWeights[1]};
+  font-size: ${({ theme }) => theme.fontSizes[3]}px;
+  color: ${({ theme, colorSchema }) => theme.colors.primary[colorSchema][1]};
+`;
+
+const SumText = styled(Text)`
+  margin-left: 4px;
+  margin-top: 10px;
+`;
+
+// TODO: the sum component should be sent as a footer to the grouped list, at which point this container should be removed.
+// Currently it's using a negative margin, which is a hack and only meant as a temporary fix.
+interface SumContainerProps {
+  colorSchema: PrimaryColor;
+  theme: ThemeType;
+}
+const SumContainer = styled.View<SumContainerProps>`
+  width: 100%;
+  height: auto;
+  border-radius: 9.5px;
+  overflow: hidden;
+  margin-bottom: 24px;
+  margin-top: -64px;
+  padding: 16px 16px 20px 16px;
+  background: ${({ theme, colorSchema }) =>
+    theme.colors.complementary[colorSchema][3]};
+`;
+
+interface SummarySpacerProps {
+  colorSchema: PrimaryColor;
+  theme: ThemeType;
+}
+const SummarySpacer = styled.View<SummarySpacerProps>`
+  margin-bottom: 16px;
+  height: 4px;
+  width: 32px;
+  background: ${({ theme, colorSchema }) =>
+    theme.label.colors[colorSchema].underline};
+`;
+
+export { SumLabel, SumText, SumContainer, SummarySpacer };

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -1,10 +1,6 @@
 import React, { useMemo } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components/native";
 
 import { GroupedList } from "../../molecules";
-
-import { Text, Heading } from "../../atoms";
 
 import SummaryListItemComponent from "./SummaryListItem";
 
@@ -12,123 +8,20 @@ import { isObject, deepCopy } from "../../../helpers/Objects";
 
 import { getValidColorSchema } from "../../../theme/themeHelpers";
 
-import type { PrimaryColor, ThemeType } from "../../../theme/themeHelpers";
-import type { InputType } from "../../atoms/Input/Input";
-import type { Help } from "../../../types/FormTypes";
+import {
+  SumLabel,
+  SumText,
+  SumContainer,
+  SummarySpacer,
+} from "./SummaryList.styled";
 
-const SumLabel = styled(Heading)<{ colorSchema: string }>`
-  margin-top: 5px;
-  margin-left: 3px;
-  font-weight: ${(props) => props.theme.fontWeights[1]};
-  font-size: ${(props) => props.theme.fontSizes[3]}px;
-  color: ${(props) => props.theme.colors.primary[props.colorSchema][1]};
-`;
-const SumText = styled(Text)`
-  margin-left: 4px;
-  margin-top: 10px;
-`;
-// TODO: the sum component should be sent as a footer to the grouped list, at which point this container should be removed.
-// Currently it's using a negative margin, which is a hack and only meant as a temporary fix.
-const SumContainer = styled.View<{ colorSchema: string }>`
-  width: 100%;
-  height: auto;
-  border-radius: 9.5px;
-  overflow: hidden;
-  margin-bottom: 24px;
-  margin-top: -64px;
-  padding-bottom: 20px;
-  padding-top: 16px;
-  padding-left: 16px;
-  padding-right: 16px;
-  background: ${(props) =>
-    props.theme.colors.complementary[props.colorSchema][3]};
-`;
-
-interface SummarySpacerProps {
-  colorSchema: PrimaryColor;
-  theme: ThemeType;
-}
-
-const SummarySpacer = styled.View<SummarySpacerProps>`
-  margin-bottom: 16px;
-  height: 4px;
-  width: 32px;
-
-  background: ${(props) =>
-    props.theme.label.colors[props.colorSchema].underline};
-`;
-
-export interface SummaryListItem {
-  title: string;
-  id: string;
-  type:
-    | "number"
-    | "text"
-    | "date"
-    | "checkbox"
-    | "arrayNumber"
-    | "arrayText"
-    | "arrayDate"
-    | "editableListText"
-    | "editableListNumber"
-    | "editableListDate"
-    | "spacer";
-  category?: string;
-  inputId?: string;
-  inputSelectValue?: InputType;
-  fieldStyle?: string;
-}
-
-interface SummaryListCategory {
-  category: string;
-  description: string;
-  sortField?: string;
-}
-
-interface Props {
-  heading: string;
-  items: SummaryListItem[];
-  categories?: SummaryListCategory[];
-  onChange: (
-    answers: Record<string, any> | string | number | boolean,
-    fieldId: string
-  ) => void;
-  onBlur: (
-    answers: Record<string, any> | string | number | boolean,
-    fieldId: string
-  ) => void;
-  colorSchema: PrimaryColor;
-  answers: Record<string, any>;
-  validationErrors?: Record<
-    string,
-    | { isValid: boolean; message: string }
-    | Record<string, { isValid: boolean; message: string }>[]
-  >;
-  showSum: boolean;
-  startEditable?: boolean;
-  help?: Help;
-  editable?: boolean;
-}
-
-type Answer = {
-  otherassetDescription?: string;
-  text?: string;
-  description?: string;
-} & Record<string, string | boolean | number>;
-
-interface List {
-  items: SummaryListItem[];
-  answers: Answer[] | string | number | boolean;
-}
-
-type Item = {
-  item: SummaryListItem;
-  value?: string | boolean | number;
-  index: number;
-  otherassetDescription?: string;
-  text?: string;
-  description?: string;
-} & Record<string, unknown>;
+import type {
+  SummaryListItem,
+  Props,
+  Answer,
+  List,
+  Item,
+} from "./SummaryList.types";
 
 const ArrayType = ["arrayNumber", "arrayText", "arrayDate"];
 
@@ -161,20 +54,22 @@ function findLastIndex<T>(
  * The things to summarize is specified in the items prop.
  * The things are grouped into categories, as specified by the categories props.
  */
-const SummaryList: React.FC<Props> = ({
-  heading,
-  items,
-  categories,
-  onChange,
-  onBlur,
-  colorSchema,
-  answers,
-  validationErrors,
-  showSum,
-  startEditable,
-  help,
-  editable,
-}) => {
+const SummaryList = (props: Props): JSX.Element | null => {
+  const {
+    heading,
+    items = [],
+    categories = [],
+    onBlur,
+    colorSchema,
+    answers,
+    validationErrors,
+    showSum = true,
+    startEditable,
+    help,
+    editable,
+    onChange = () => undefined,
+  } = props;
+
   const validColorSchema = getValidColorSchema(colorSchema);
 
   const sortedAnswers = useMemo(() => {
@@ -249,7 +144,7 @@ const SummaryList: React.FC<Props> = ({
   let sum = 0;
   const addToSum = (value: string | number) => {
     if (typeof value === "string") {
-      const summand = parseInt(value);
+      const summand = parseInt(value, 10);
       // eslint-disable-next-line no-restricted-globals
       sum += isNaN(summand) ? 0 : summand;
     } else {
@@ -445,7 +340,6 @@ const SummaryList: React.FC<Props> = ({
       listItems.push(
         <SummarySpacer
           key={`${listEntry.item.id}`}
-          category={listEntry.item.category}
           colorSchema={validColorSchema}
         />
       );
@@ -457,94 +351,34 @@ const SummaryList: React.FC<Props> = ({
   ).length;
 
   if (spacerCount > 1) {
-    const lastSpacerIndex = findLastIndex(listItems, (item) =>
-      item?.key?.toString().startsWith("spacer-")
+    const lastSpacerIndex = findLastIndex(
+      listItems,
+      (item) => !!item?.key?.toString().startsWith("spacer-")
     );
 
     listItems.splice(lastSpacerIndex, 1);
   }
 
-  return (
-    listItems.length > 0 && (
-      <>
-        <GroupedList
-          heading={heading}
-          categories={categories}
-          colorSchema={validColorSchema}
-          showEditButton={editable}
-          startEditable={startEditable && editable}
-          help={help}
-        >
-          {listItems}
-        </GroupedList>
-        {showSum && (
-          <SumContainer colorSchema={validColorSchema}>
-            <SumLabel colorSchema={validColorSchema}>Summa</SumLabel>
-            <SumText type="h1">{sum} kr</SumText>
-          </SumContainer>
-        )}
-      </>
-    )
-  );
-};
-
-SummaryList.propTypes = {
-  /**
-   * The header text of the list.
-   */
-  heading: PropTypes.string,
-  /**
-   * List of all items, corresponding to all subforms
-   */
-  items: PropTypes.array,
-  /**
-   * The categories of the grouping
-   */
-  categories: PropTypes.array,
-  /**
-   * What should happen to update the values
-   */
-  onChange: PropTypes.func,
-  /**
-   * What should happen when a field loses focus.
-   */
-  onBlur: PropTypes.func,
-  /**
-   * Sets the color scheme of the list. default is red.
-   */
-  color: PropTypes.string,
-  /**
-   * The form state answers
-   */
-  answers: PropTypes.object,
-  /**
-   * Object containing all validation errors for the entire form
-   */
-  validationErrors: PropTypes.object,
-  /**
-   * Whether or not to show a sum of all numeric values at the bottom. Defaults to true.
-   */
-  showSum: PropTypes.bool,
-  /**
-   * Whether to start in editable mode or not.
-   */
-  startEditable: PropTypes.bool,
-  /**
-   * Show a help button
-   */
-  help: PropTypes.shape({
-    text: PropTypes.string,
-    size: PropTypes.number,
-    heading: PropTypes.string,
-    tagline: PropTypes.string,
-    url: PropTypes.string,
-  }),
-};
-SummaryList.defaultProps = {
-  items: [],
-  color: "blue",
-  showSum: true,
-  onChange: () => {},
+  return listItems.length > 0 ? (
+    <>
+      <GroupedList
+        heading={heading}
+        categories={categories}
+        colorSchema={validColorSchema}
+        showEditButton={editable}
+        startEditable={startEditable && editable}
+        help={help}
+      >
+        {listItems}
+      </GroupedList>
+      {showSum && (
+        <SumContainer colorSchema={validColorSchema}>
+          <SumLabel colorSchema={validColorSchema}>Summa</SumLabel>
+          <SumText type="h1">{sum} kr</SumText>
+        </SumContainer>
+      )}
+    </>
+  ) : null;
 };
 
 export default SummaryList;

--- a/source/components/organisms/SummaryList/SummaryList.tsx
+++ b/source/components/organisms/SummaryList/SummaryList.tsx
@@ -244,34 +244,6 @@ const SummaryList: React.FC<Props> = ({
         if (onBlur) onBlur(sortedAnswers[item.id], item.id);
       } else if (onBlur) onBlur(value, item.id);
     };
-  /**
-   * Given an item, and index in the case of repeater fields, this generates the function for clearing the associated data
-   * in the form state.
-   * @param item The list item
-   * @param index The index, when summarizing a repeater field with multiple answers
-   */
-  const removeListItem = (item: SummaryListItem, index?: number) => () => {
-    if (typeof index !== "undefined") {
-      const oldAnswer: Record<string, string | number>[] = {
-        ...sortedAnswers[item.id],
-      };
-      oldAnswer.splice(index, 1);
-      onChange(oldAnswer, item.id);
-    } else if (
-      ["editableListText", "editableListNumber", "editableListDate"].includes(
-        item.type
-      ) &&
-      item.inputId
-    ) {
-      const oldAnswer: Record<string, string | number> = {
-        ...sortedAnswers[item.id],
-      };
-      oldAnswer[item.inputId] = undefined;
-      onChange(oldAnswer, item.id);
-    } else {
-      onChange(undefined, item.id);
-    }
-  };
 
   // Code for computing sum of all numeric values shown in the list
   let sum = 0;
@@ -396,7 +368,6 @@ const SummaryList: React.FC<Props> = ({
           value={listEntry.value ?? ""}
           changeFromInput={changeFromInput(listEntry.item, listEntry.index)}
           onBlur={onItemBlur(listEntry.item, listEntry.index)}
-          removeItem={removeListItem(listEntry.item, listEntry.index)}
           colorSchema={colorSchema}
           validationError={validationError}
           category={listEntry.item.category}
@@ -423,7 +394,6 @@ const SummaryList: React.FC<Props> = ({
           value={sortedAnswers[listEntry.item.id][listEntry.item.inputId]}
           changeFromInput={changeFromInput(listEntry.item)}
           onBlur={onItemBlur(listEntry.item)}
-          removeItem={removeListItem(listEntry.item)}
           colorSchema={colorSchema}
           validationError={
             validationErrors?.[listEntry.item.id]?.[listEntry.item.inputId]
@@ -448,7 +418,6 @@ const SummaryList: React.FC<Props> = ({
           value={sortedAnswers[listEntry.item.id]}
           changeFromInput={changeFromInput(listEntry.item)}
           onBlur={onItemBlur(listEntry.item)}
-          removeItem={removeListItem(listEntry.item)}
           colorSchema={colorSchema}
           validationError={
             validationErrors

--- a/source/components/organisms/SummaryList/SummaryList.types.ts
+++ b/source/components/organisms/SummaryList/SummaryList.types.ts
@@ -1,0 +1,75 @@
+import type { PrimaryColor } from "../../../theme/themeHelpers";
+import type { InputType } from "../../atoms/Input/Input";
+import type { Help } from "../../../types/FormTypes";
+
+export interface SummaryListItem {
+  title: string;
+  id: string;
+  type:
+    | "number"
+    | "text"
+    | "date"
+    | "checkbox"
+    | "arrayNumber"
+    | "arrayText"
+    | "arrayDate"
+    | "editableListText"
+    | "editableListNumber"
+    | "editableListDate"
+    | "spacer";
+  category?: string;
+  inputId?: string;
+  inputSelectValue?: InputType;
+  fieldStyle?: string;
+}
+
+export interface SummaryListCategory {
+  category: string;
+  description: string;
+  sortField?: string;
+}
+
+export interface Props {
+  heading: string;
+  items: SummaryListItem[];
+  categories?: SummaryListCategory[];
+  onChange: (
+    answers: Record<string, any> | string | number | boolean,
+    fieldId: string
+  ) => void;
+  onBlur: (
+    answers: Record<string, any> | string | number | boolean,
+    fieldId: string
+  ) => void;
+  colorSchema: PrimaryColor;
+  answers: Record<string, any>;
+  validationErrors?: Record<
+    string,
+    | { isValid: boolean; message: string }
+    | Record<string, { isValid: boolean; message: string }>[]
+  >;
+  showSum: boolean;
+  startEditable?: boolean;
+  help?: Help;
+  editable?: boolean;
+}
+
+export type Answer = {
+  otherassetDescription?: string;
+  text?: string;
+  description?: string;
+} & Record<string, string | boolean | number>;
+
+export interface List {
+  items: SummaryListItem[];
+  answers: Answer[] | string | number | boolean;
+}
+
+export type Item = {
+  item: SummaryListItem;
+  value?: string | boolean | number;
+  index: number;
+  otherassetDescription?: string;
+  text?: string;
+  description?: string;
+} & Record<string, unknown>;

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -7,7 +7,7 @@ import type { PrimaryColor } from "../../../theme/themeHelpers";
 import { getValidColorSchema } from "../../../theme/themeHelpers";
 import { Input, Text } from "../../atoms";
 import CalendarPicker from "../../molecules/CalendarPicker/CalendarPickerForm";
-import type { SummaryListItem as SummaryListItemType } from "./SummaryList";
+import type { SummaryListItem as SummaryListItemType } from "./SummaryList.types";
 
 interface ItemWrapperProps {
   error?: { isValid: boolean; message: string };

--- a/source/components/organisms/SummaryList/SummaryListItem.tsx
+++ b/source/components/organisms/SummaryList/SummaryListItem.tsx
@@ -3,10 +3,9 @@ import PropTypes from "prop-types";
 import React, { useRef } from "react";
 import { Platform } from "react-native";
 import styled from "styled-components/native";
-import { colorPalette } from "../../../theme/palette";
 import type { PrimaryColor } from "../../../theme/themeHelpers";
 import { getValidColorSchema } from "../../../theme/themeHelpers";
-import { Icon, Input, Text } from "../../atoms";
+import { Input, Text } from "../../atoms";
 import CalendarPicker from "../../molecules/CalendarPicker/CalendarPickerForm";
 import type { SummaryListItem as SummaryListItemType } from "./SummaryList";
 
@@ -92,18 +91,6 @@ const SmallText = styled(Text)`
     margin: 16px;
     margin-right: 0px;
   `}
-`;
-
-const DeleteButton = styled(Icon)`
-  padding-left: 5px;
-  margin-bottom: 8px;
-  margin-top: 8px;
-  color: ${(props) => props.theme.colors.neutrals[4]};
-`;
-
-const DeleteButtonHighligth = styled.TouchableHighlight`
-  padding: 0px;
-  margin: 0px;
 `;
 
 const ValidationErrorMessage = styled(Text)`
@@ -237,11 +224,9 @@ interface Props {
   item: SummaryListItemType;
   value: string | number | boolean;
   userDescriptionLabel?: string;
-  index?: number;
   editable?: boolean;
   changeFromInput: (value: string | number | boolean) => void;
   onBlur?: (value: Record<string, any> | string | number | boolean) => void;
-  removeItem: () => void;
   colorSchema: PrimaryColor;
   validationError?: { isValid: boolean; message: string };
   fieldStyle?: string;
@@ -251,11 +236,9 @@ const SummaryListItem: React.FC<Props> = ({
   item,
   value,
   userDescriptionLabel,
-  index,
   changeFromInput,
   onBlur,
   editable,
-  removeItem,
   colorSchema,
   validationError,
   fieldStyle,
@@ -321,15 +304,6 @@ const SummaryListItem: React.FC<Props> = ({
             />
           </InputWrapper>
         </ItemWrapper>
-        {editable && (
-          <DeleteButtonHighligth
-            activeOpacity={0.6}
-            underlayColor={colorPalette.complementary[validColorSchema][1]}
-            onPress={removeItem}
-          >
-            <DeleteButton name="clear" />
-          </DeleteButtonHighligth>
-        )}
       </Row>
       {validationError?.isValid === false && (
         <ValidationErrorMessage>
@@ -347,10 +321,6 @@ SummaryListItem.propTypes = {
   value: PropTypes.any,
   changeFromInput: PropTypes.func,
   onBlur: PropTypes.func,
-  /**
-   * The function to remove the row and clear the associated input
-   */
-  removeItem: PropTypes.func,
   /**
    * Default is blue
    */


### PR DESCRIPTION
## Explain the changes you’ve made
Remove the ability to remove an inputfield in a SummaryList

## Explain why these changes are made
When removing an InputField from a SummaryList, the application crashes. To avoid the crash from happening again we remove the ability to remove an inputfield. 
A user should not be able to remove an inputfield from a summarylist because of unexpected issue and errors in the app or api, hence removing it.

## Explain your solution
Removed the button which deleted the inputfield.
Smaller refactoring to agreed format.

## How to test

1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
3. Run a grundansökan form and try to remove an inputfield in a SummaryList

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
