### PR TITLE
feat: add viva case id to the case summary page

### DIFF
--- a/source/components/molecules/CaseCard/CaseCard.tsx
+++ b/source/components/molecules/CaseCard/CaseCard.tsx
@@ -29,15 +29,23 @@ function CaseCard({
   completionsClarification = "",
   pin,
   showDownloadPdfButton,
+  vivaCaseId,
   onCardClick,
   onButtonClick,
   onAppealButtonClick,
   onOpenPdf,
 }: Props): JSX.Element {
+  function showVivaCaseId(id: string): JSX.Element | null {
+    return id ? (
+      <Card.SubTitle colorSchema="neutral">Ärende-ID: {id}</Card.SubTitle>
+    ) : null;
+  }
+
   return (
     <Card colorSchema={colorSchema}>
       <Card.Body shadow color="neutral" onPress={onCardClick}>
         {icon && <Card.Image source={icon} />}
+        {showVivaCaseId(vivaCaseId)}
         <Card.Title colorSchema="neutral">{title}</Card.Title>
         {largeSubtitle && (
           <Card.LargeText mt={0.5}>{largeSubtitle}</Card.LargeText>

--- a/source/components/molecules/CaseCard/CaseCard.types.ts
+++ b/source/components/molecules/CaseCard/CaseCard.types.ts
@@ -23,6 +23,7 @@ export interface Props {
   completionsClarification?: string;
   pin?: string;
   showDownloadPdfButton: boolean;
+  vivaCaseId: string;
   onCardClick?: () => void;
   onButtonClick?: () => void;
   onAppealButtonClick?: () => void;

--- a/source/screens/caseScreens/CaseOverview.tsx
+++ b/source/screens/caseScreens/CaseOverview.tsx
@@ -289,6 +289,7 @@ const computeCaseCardComponent = (
       pin={shouldShowPin ? formPassword : undefined}
       showDownloadPdfButton={canShowPdf}
       onOpenPdf={onOpenPdf}
+      vivaCaseId=""
     />
   );
 };

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -239,6 +239,7 @@ const computeCaseCardComponent = (
       pin={shouldShowPin ? formPassword : undefined}
       showDownloadPdfButton={canShowPdf}
       onOpenPdf={onOpenPdf}
+      vivaCaseId={details.vivaCaseId}
     />
   );
 };

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -160,6 +160,7 @@ export interface VIVACaseDetails {
   period: Period;
   workflowId: string;
   workflow: Workflow;
+  readonly vivaCaseId: string;
 }
 
 interface AnswerField {


### PR DESCRIPTION
## Explain the changes you’ve made
Added 'Ärende-ID' to the case summary page

## Explain why these changes are made
Make the applicant able to authenticate themself when in contact with AMF admins

## Explain your solution
Added new vivaCaseId type to Case interface. Updated case card component to display id if exists.

## How to test
1. Checkout this branch
2. Fire upp the simulator by running the command `yarn ios`
4. Login with applicant that has an open period showing in the case overview list
5. Click on the case and verify the id at the top left corner on the card

## Tested environments
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.