### PR TITLE
fix: handle and transform error for when encryption params are missing

### DIFF
--- a/source/screens/caseScreens/useGetFormPasswords.ts
+++ b/source/screens/caseScreens/useGetFormPasswords.ts
@@ -24,10 +24,10 @@ function useGetFormPasswords(
       const { currentFormId, id } = caseItem;
       const form = caseItem.forms[currentFormId];
 
-      if (
-        !form.encryption.encryptionKeyId &&
-        !form.encryption.symmetricKeyName
-      ) {
+      const isMissingEncryptionParams =
+        !form.encryption.encryptionKeyId && !form.encryption.symmetricKeyName;
+
+      if (isMissingEncryptionParams) {
         console.warn(
           `case ${id} missing encryption params - possibly older case`
         );


### PR DESCRIPTION
## Explain the changes you’ve made

Handle missing encryption params on case.

## Explain why these changes are made

Sentry is bombarded with the error "unable to get params ID" which stems from (most likely) older cases using the older encryption structure. Since the error itself may occur for legitimate reasons, the specific scenario of older cases missing the encryption keys is instead handled explicitly with this PR.

## Explain your solution

Added a check at the point where the error occurs (`useGetFormPasswords.ts`) to see if the case is a suspect older case, and if so throw a new error different from the "unable to get params ID" error in order to differentiate them in Sentry.

## How to test

Concrete example:

For the test scenario have a user with two cases; one closed (`approved`/`partiallyApproved`/`rejected`) and one open (`notStarted`).

Also make sure the app is connected to dev Sentry.

1. Start the open application and save it so it is encrypted.
2. Edit the case and change/remove the keys "<current form>.encryption.encryptionKeyId" and "<current form>.encryption.symmetricKeyName".
3. Verify the case shows "något har gått fel" and can be removed by the user to reset.
4. Verify dev Sentry has received error reports on "case missing encryption params - possibly older case" and **not** "unable to get params ID".
5. Do step 2 but for the closed case.
6. Verify the app can still open and show the decisions of the closed case.
7. Verify step 4 again.

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.
