### PR TITLE
Fix/input align styling

### DIFF
--- a/ios/MittHelsingborg.xcodeproj/project.pbxproj
+++ b/ios/MittHelsingborg.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		555DD94E44C382C0500A7BB6 /* libPods-MittHelsingborg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B6C53F51890AACA298C826 /* libPods-MittHelsingborg.a */; };
+		7E57914B29AE458300A85173 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7E57914A29AE458300A85173 /* Entypo.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		D70FEAC01A6AA5153C85DBD7 /* libPods-MittHelsingborg-MittHelsingborgTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A9AA2295CFD02939543E5623 /* libPods-MittHelsingborg-MittHelsingborgTests.a */; };
 /* End PBXBuildFile section */
@@ -48,6 +49,7 @@
 		601302B9645C411BBC370907 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
 		62901B593A4B45BFAEEDF144 /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
 		779649D76861B8D8D5F33DE9 /* Pods-MittHelsingborg.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MittHelsingborg.release.xcconfig"; path = "Target Support Files/Pods-MittHelsingborg/Pods-MittHelsingborg.release.xcconfig"; sourceTree = "<group>"; };
+		7E57914A29AE458300A85173 /* Entypo.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = Entypo.ttf; path = "../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
 		80B6C53F51890AACA298C826 /* libPods-MittHelsingborg.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MittHelsingborg.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = MittHelsingborg/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8F11BE8BF4854AD3B4E6D879 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
@@ -145,6 +147,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		7E57914929AE453600A85173 /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				7E57914A29AE458300A85173 /* Entypo.ttf */,
+			);
+			path = Fonts;
+			sourceTree = "<group>";
+		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
@@ -155,6 +165,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				7E57914929AE453600A85173 /* Fonts */,
 				13B07FAE1A68108700A75B9A /* MittHelsingborg */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* MittHelsingborgTests */,
@@ -286,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
+				7E57914B29AE458300A85173 /* Entypo.ttf in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/source/components/atoms/Select/Select.styled.ts
+++ b/source/components/atoms/Select/Select.styled.ts
@@ -6,6 +6,20 @@ const Wrapper = styled.View`
   margin-bottom: 30px;
 `;
 
+const InputRowWrapper = styled.View`
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const InputRowTextWrapper = styled.View`
+  flex-shrink: 1;
+`;
+
+const InputRowIconWrapper = styled.View`
+  margin-left: 5px;
+`;
+
 const StyledErrorText = styled(Text)`
   font-size: ${({ theme }) => theme.fontSizes[3]}px;
   color: ${({ theme }) => theme.textInput.errorTextColor};
@@ -13,4 +27,10 @@ const StyledErrorText = styled(Text)`
   padding-top: 8px;
 `;
 
-export { Wrapper, StyledErrorText };
+export {
+  Wrapper,
+  InputRowWrapper,
+  InputRowTextWrapper,
+  InputRowIconWrapper,
+  StyledErrorText,
+};

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 import { StyleSheet } from "react-native";
 import RNPickerSelect from "react-native-picker-select";
+import Icon from "react-native-vector-icons/Entypo";
 
-import { Wrapper, StyledErrorText } from "./Select.styled";
+import {
+  Wrapper,
+  InputRowWrapper,
+  InputRowTextWrapper,
+  InputRowIconWrapper,
+  StyledErrorText,
+} from "./Select.styled";
 
 import theme from "../../../theme/theme";
 
@@ -13,14 +20,13 @@ const pickerSelectStyles = StyleSheet.create({
     paddingHorizontal: 10,
     textAlign: "right",
     color: theme.colors.neutrals[1],
-    paddingRight: 10,
+    paddingRight: 0,
   },
   inputAndroid: {
     paddingHorizontal: 10,
     textAlign: "right",
     color: theme.colors.neutrals[1],
-    paddingRight: 10,
-    height: 34,
+    paddingRight: 0,
   },
 });
 
@@ -65,23 +71,29 @@ function Select(
 
   return (
     <Wrapper style={style}>
-      <RNPickerSelect
-        style={pickerSelectStyles}
-        placeholder={{ label: placeholder, value: null }}
-        disabled={!editable}
-        value={currentItem?.value || null}
-        onValueChange={handleValueChange}
-        items={items}
-        ref={ref}
-        doneText="Klar"
-        onOpen={handleOpen}
-        onClose={handleClose}
-      />
+      <InputRowWrapper>
+        <InputRowTextWrapper>
+          <RNPickerSelect
+            style={pickerSelectStyles}
+            placeholder={{ label: placeholder, value: null }}
+            disabled={!editable}
+            value={currentItem?.value || null}
+            onValueChange={handleValueChange}
+            items={items}
+            ref={ref}
+            doneText="Klar"
+            onOpen={handleOpen}
+            onClose={handleClose}
+            useNativeAndroidPickerStyle={false}
+          />
+        </InputRowTextWrapper>
+        <InputRowIconWrapper>
+          <Icon name="select-arrows" />
+        </InputRowIconWrapper>
+      </InputRowWrapper>
       {showErrorMessage && error ? (
         <StyledErrorText>{error?.message}</StyledErrorText>
-      ) : (
-        <></>
-      )}
+      ) : null}
     </Wrapper>
   );
 }

--- a/source/components/molecules/EditableList/EditableList.styled.ts
+++ b/source/components/molecules/EditableList/EditableList.styled.ts
@@ -21,7 +21,6 @@ const EditableListItem = styled.TouchableOpacity<EditableListItemProps>`
   font-size: ${({ theme }) => theme.fontSizes[4]}px;
   flex-direction: row;
   height: auto;
-  background-color: transparent;
   border-radius: 4.5px;
   margin-bottom: 14px;
   ${({ theme, error }) =>
@@ -31,13 +30,15 @@ const EditableListItem = styled.TouchableOpacity<EditableListItemProps>`
     editable &&
     `background-color: ${theme.colors.complementary[colorSchema][2]};`};
   ${({ editable }) => editable && Platform.OS === "ios" && `padding: 16px;`};
+  ${({ editable }) => editable && `padding-right: 16px;`}
+  justify-content: space-between;
+  align-items: center;
 `;
 
 interface EditableListItemLabelWrapperProps {
   alignAtStart: boolean;
 }
 const EditableListItemLabelWrapper = styled.View<EditableListItemLabelWrapperProps>`
-  flex: 4;
   justify-content: ${(props) => (props.alignAtStart ? "flex-start" : "center")};
 `;
 
@@ -53,43 +54,25 @@ const EditableListItemLabel = styled.Text<EditableListItemLabelProps>`
     Platform.OS === "android" &&
     `
     margin: 16px;
-    margin-right: 0;
+    margin-right: 0px;
     `};
 `;
 
 const EditableListItemInputWrapper = styled.View`
-  flex-direction: column;
-  align-items: flex-end;
-  justify-content: center;
-  flex: 5;
+  flex-shrink: 1;
 `;
 
 const EditableListItemInput = styled(Input)`
-  text-align: right;
-  min-width: 80%;
   font-weight: 500;
   padding: 0px;
   color: ${(props) => props.theme.colors.neutrals[1]};
-  ${(props) =>
-    props.editable &&
-    Platform.OS === "android" &&
-    `
-    margin: 16px;
-    margin-left: 0;
-      `};
 `;
 
 const EditableListItemSelect = styled(Select)`
-  min-width: 80%;
+  min-width: 50%;
   font-weight: 500;
   margin-bottom: 0px;
-  ${({ editable }) =>
-    editable &&
-    Platform.OS === "android" &&
-    `
-    margin: 16px;
-    margin-left: 0;
-  `};
+  flex: 1;
 `;
 
 const FieldsetButton = styled(Button)`

--- a/source/components/molecules/RepeaterFieldListItem/RepeaterFieldListItem.styled.ts
+++ b/source/components/molecules/RepeaterFieldListItem/RepeaterFieldListItem.styled.ts
@@ -40,6 +40,9 @@ const RepeaterItem = styled.TouchableOpacity<RepeaterItemProps>`
     theme.repeater[colorSchema].inputBackground};
   padding: 10px;
   ${({ hidden }) => (hidden ? "display: none" : null)}
+
+  justify-content: space-between;
+  align-items: center;
 `;
 
 interface ItemLabelProps extends DefaultProps {
@@ -52,7 +55,6 @@ const ItemLabel = styled(Label)<ItemLabelProps>`
 `;
 
 const InputLabelWrapper = styled.View`
-  flex: 4;
   justify-content: center;
 `;
 
@@ -72,16 +74,15 @@ const InputWrapper = styled.View<InputWrapperProps>`
   flex-direction: column;
   align-items: flex-end;
   justify-content: center;
-  flex: 5;
   ${({ hidden }) => (hidden ? "display: none" : null)};
+  flex-shrink: 1;
+  padding-left: 10px;
 `;
 
 interface ItemInputProps extends DefaultProps {
   colorSchema: PrimaryColor;
 }
 const ItemInput = styled(Input)<ItemInputProps>`
-  text-align: right;
-  min-width: 80%;
   font-weight: 500;
   color: ${({ theme, colorSchema }) => theme.repeater[colorSchema].inputText};
   padding: 5px;

--- a/source/components/molecules/RepeaterFieldListItem/RepeaterFieldListItem.tsx
+++ b/source/components/molecules/RepeaterFieldListItem/RepeaterFieldListItem.tsx
@@ -45,7 +45,6 @@ const InputComponent = React.forwardRef(
           input.type === "hidden" ? input?.value?.toString() : value.toString();
         return (
           <ItemInput
-            textAlign="right"
             colorSchema={colorSchema}
             value={inputValue}
             onChangeText={onChange}


### PR DESCRIPTION
## Explain the changes you’ve made

* Fixed trailing spaces not appearing in the UI due to a styling bug (iOS only).
* Normalized how select inputs look across platforms.
* This also fixes padding issues for value field on Android and some problems with labels being wrapped poorly.

## Explain why these changes are made

* Invisible trailing spaces can cause validation issues without any obvious problem or action.
* Select dropdowns also were inconsistent and had to be altered due to how the fix for the trailing spaces works.

## Explain your solution

Trailing spaces were caused by a weird (bug?) with text that had "text-align: right". To fix, the styling was changed from being a somewhat arbitrary 4/5 flex split into having elements only occupy their required space and add "space-between" for the flexbox, causing the value field to automatically align as far right as possible.

Elements before fix (individual elements highlighted with unique background colors for clarity):
<img width="375" alt="image" src="https://user-images.githubusercontent.com/2890987/221911253-09a15739-9525-48aa-b793-b8dbe9b8c0de.png">

Elements after fix (notice spaces now visible):
<img width="402" alt="image" src="https://user-images.githubusercontent.com/2890987/221909773-2483de68-462f-49a4-81f0-ab59693b2700.png">

Select/dropdown was fixed by disabling Android native styling and manually adding a icon and styling for both platforms to be consistent as well as better indicate that it is a select/dropdown field.

## How to test

Concrete example:

1. Checkout this branch
2. Open a form and verify various fields appear to function as expected

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots

Select UI, pre-fix (ios):
<img width="379" alt="image" src="https://user-images.githubusercontent.com/2890987/221911946-4ec656ba-c694-4439-9909-45df1462ec3c.png">

Select UI, pre-fix (android):
<img width="404" alt="image" src="https://user-images.githubusercontent.com/2890987/221911983-654a66e7-9c5c-499d-84f3-a2f687643d86.png">

Select UI, post-fix (ios):
<img width="383" alt="image" src="https://user-images.githubusercontent.com/2890987/221912024-f11b5559-b1e2-4f73-89a4-943337148d3f.png">

Select UI, post-fix (android):
<img width="404" alt="image" src="https://user-images.githubusercontent.com/2890987/221912087-cb33cfd3-412d-41b7-ac82-bfa880fee962.png">

