### PR TITLE
feat(form): save form when app is put into background

### DIFF
--- a/source/containers/Form/Form.tsx
+++ b/source/containers/Form/Form.tsx
@@ -153,19 +153,20 @@ const Form: React.FC<FormProps> = ({
   );
 
   useEffect(() => {
-    if (!isInForeground) {
-      if (wasJustInForeground.current) {
-        void updateCase()
-          .then(() => {
-            console.log("updated case in background");
-          })
-          .catch((updateCaseError) => {
-            console.error(
-              "failed to update case in background:",
-              updateCaseError?.message ?? updateCaseError
-            );
-          });
-      }
+    const didJustChangeFromForegroundToBackground =
+      !isInForeground && wasJustInForeground.current;
+
+    if (didJustChangeFromForegroundToBackground) {
+      void updateCase()
+        .then(() => {
+          console.log("updated case in background");
+        })
+        .catch((updateCaseError) => {
+          console.error(
+            "failed to update case in background:",
+            updateCaseError?.message ?? updateCaseError
+          );
+        });
     }
 
     wasJustInForeground.current = isInForeground;

--- a/source/containers/Form/Form.types.ts
+++ b/source/containers/Form/Form.types.ts
@@ -23,7 +23,7 @@ export interface FormProps {
   steps: StepType[];
   connectivityMatrix: StepperActions[][];
   user: User;
-  initialAnswers: Record<string, unknown>;
+  initialAnswers: Record<string, Answer>;
   status: Status;
   onClose: () => void;
   onSubmit: () => void;

--- a/source/containers/Form/hooks/useForm.ts
+++ b/source/containers/Form/hooks/useForm.ts
@@ -2,7 +2,7 @@ import { useReducer, useEffect } from "react";
 import formReducer from "./formReducer";
 import type { Question, Step, StepperActions } from "../../../types/FormTypes";
 import type { User } from "../../../types/UserTypes";
-import type { Person } from "../../../types/Case";
+import type { Answer, Person } from "../../../types/Case";
 
 export interface FormPosition {
   index: number;
@@ -24,7 +24,7 @@ export interface FormReducerState {
   allQuestions: Question[];
   user: User;
   connectivityMatrix: StepperActions[][];
-  formAnswers: Record<string, unknown>;
+  formAnswers: Record<string, Answer>;
   formAnswerSnapshot: Record<string, unknown>;
   validations: Record<string, unknown>;
   dirtyFields: Record<string, unknown>;
@@ -36,7 +36,41 @@ export interface FormReducerState {
   completionsClarificationMessage: string;
 }
 
-function useForm(initialState: FormReducerState): Record<string, unknown> {
+interface FormHook {
+  formState: FormReducerState;
+  formNavigation: {
+    next: () => void;
+    back: () => void;
+    up: (targetStep: number | string) => void;
+    down: (targetStep: number | string) => void;
+    start: (callback: () => void) => void;
+    goToMainForm: () => void;
+    goToMainFormAndNext: () => void;
+    createSnapshot: () => void;
+    deleteSnapshot: () => void;
+    restoreSnapshot: () => void;
+    close: () => void;
+    isLastStep: () => boolean;
+  };
+  handleInputChange: (
+    answer: Record<string, Answer>,
+    questionId: string
+  ) => void;
+  handleBlur: (answer: Record<string, unknown>, questionId: string) => void;
+  handleSubmit: (
+    callback: (formAnswers: Record<string, unknown>) => void
+  ) => void;
+  handleAddAnswer: (
+    answer: Record<string, unknown>,
+    questionId: string
+  ) => void;
+  validateStepAnswers: (
+    onErrorCallback: () => void,
+    onValidCallback: () => void
+  ) => void;
+}
+
+function useForm(initialState: FormReducerState): FormHook {
   const [formState, dispatch] = useReducer(formReducer, initialState);
 
   useEffect(() => {

--- a/source/hooks/useAppState.ts
+++ b/source/hooks/useAppState.ts
@@ -1,0 +1,37 @@
+/* eslint-disable import/no-unused-modules */
+import { useEffect, useRef, useState } from "react";
+import type { AppStateStatus } from "react-native";
+import { AppState as RNAppState } from "react-native";
+
+export interface AppState {
+  isInForeground: boolean;
+}
+
+function isAppStateInForeground(appState: AppStateStatus): boolean {
+  return appState !== "background";
+}
+
+export default function useAppState(): AppState {
+  const appState = useRef(RNAppState.currentState);
+  const [isInForeground, setIsInForeground] = useState(
+    isAppStateInForeground(appState.current)
+  );
+
+  useEffect(() => {
+    const subscription = RNAppState.addEventListener(
+      "change",
+      (nextAppState) => {
+        appState.current = nextAppState;
+        setIsInForeground(isAppStateInForeground(appState.current));
+      }
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
+  return {
+    isInForeground,
+  };
+}


### PR DESCRIPTION
## Explain the changes you’ve made

Form now saves when app is put into background.

## Explain why these changes are made

To mitigate data loss when users switches app to perform other actions. Sometimes when returning to the app the app is reset back to overview screen (a different issue - will fix in other task), put user may also inadvertently close the app.

## Explain your solution

Added a hook that uses [React AppState](https://reactnative.dev/docs/appstate) to listen for when app is moving between background and foreground. Edited `Form` to use this in order to call `updateCase` appropriately.

## How to test

Concrete example:

1. Checkout this branch
2. Open a form and fill out something
3. Put the app into background without closing it
4. Verify that the case data is updated (e.g. gone from NOT_STARTED to an encrypted form in cases db)
5. Close app without exiting the form
6. Open app again and verify the filled answers are still there

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.