### PR TITLE
feat: add ContactCard component instead of administrators display

### DIFF
--- a/source/components/molecules/ContactCard/ContactCard.stories.tsx
+++ b/source/components/molecules/ContactCard/ContactCard.stories.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { storiesOf } from "@storybook/react-native";
+import styled from "styled-components/native";
+
+import StoryWrapper from "../StoryWrapper";
+import ContactCard from "./index";
+
+const FlexContainer = styled.ScrollView`
+  background-color: #fff;
+  padding: 16px;
+`;
+
+storiesOf("ContactCard", module).add("Default", () => (
+  <StoryWrapper>
+    <FlexContainer>
+      <ContactCard
+        name="Karl Svensson"
+        description="Kontakta **Karl** på telefon genom att ringa [076 123 45 67](https://example.com). Alternativt via e-post [karl@example.com](mailto://karl@example.com)."
+      />
+    </FlexContainer>
+  </StoryWrapper>
+));

--- a/source/components/molecules/ContactCard/ContactCard.tsx
+++ b/source/components/molecules/ContactCard/ContactCard.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable import/no-unused-modules */
+import React from "react";
+import Card from "../Card";
+import ICON from "../../../assets/images/icons";
+import MarkdownConstructor from "../../../helpers/MarkdownConstructor";
+
+interface ContactCardProps {
+  name: string;
+  description: string;
+}
+
+export default function ContactCard({
+  name,
+  description,
+}: ContactCardProps): JSX.Element {
+  return (
+    <Card key={`${name}`} colorSchema="red">
+      <Card.Body shadow color="neutral">
+        <Card.Section>
+          <Card.Image
+            style={{ width: 50, height: 50 }}
+            circle
+            source={ICON.ICON_CONTACT_PERSON}
+          />
+          <Card.Title colorSchema="neutral">{name}</Card.Title>
+          <MarkdownConstructor italic={false} rawText={description} />
+        </Card.Section>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/source/components/molecules/ContactCard/ContactCard.tsx
+++ b/source/components/molecules/ContactCard/ContactCard.tsx
@@ -14,7 +14,7 @@ export default function ContactCard({
   description,
 }: ContactCardProps): JSX.Element {
   return (
-    <Card key={`${name}`} colorSchema="red">
+    <Card key={name} colorSchema="red">
       <Card.Body shadow color="neutral">
         <Card.Section>
           <Card.Image

--- a/source/components/molecules/ContactCard/index.ts
+++ b/source/components/molecules/ContactCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ContactCard";

--- a/source/containers/Form/hooks/test/textReplacement.test.ts
+++ b/source/containers/Form/hooks/test/textReplacement.test.ts
@@ -252,7 +252,6 @@ beforeEach(() => {
         attachmentUploaded: [],
         description: "completions clarification message",
       },
-      administrators: [],
       workflowId: "123",
       workflow: {
         application: {
@@ -270,6 +269,7 @@ beforeEach(() => {
     expirationTime: 0,
     forms: {},
     persons: [],
+    contacts: [],
     provider: "",
     updatedAt: 0,
   } as unknown as Case;

--- a/source/screens/caseScreens/CaseSummary.tsx
+++ b/source/screens/caseScreens/CaseSummary.tsx
@@ -15,17 +15,17 @@ import {
   SetupFormModal,
 } from "../../components/organisms";
 
-import { Card, ScreenWrapper, CaseCard } from "../../components/molecules";
+import { ScreenWrapper, CaseCard } from "../../components/molecules";
+import ContactCard from "../../components/molecules/ContactCard";
 import { useModal } from "../../components/molecules/Modal";
 
-import { Icon, Text, Button } from "../../components/atoms";
+import { Text, Button } from "../../components/atoms";
 
 import { CaseState, CaseDispatch } from "../../store/CaseContext";
 import AuthContext from "../../store/AuthContext";
 
 import getUnapprovedCompletionDescriptions from "../../helpers/FormatCompletions";
 import { convertDataToArray, calculateSum } from "../../helpers/FormatVivaData";
-import { launchPhone } from "../../helpers/LaunchExternalApp";
 import { getSwedishMonthNameByTimeStamp } from "../../helpers/DateHelpers";
 import { put, remove } from "../../helpers/ApiRequest";
 import { canCaseBeRemoved } from "../../helpers/Case";
@@ -37,8 +37,6 @@ import { answersAreEncrypted } from "../../services/encryption";
 import useGetFormPasswords from "./useGetFormPasswords";
 
 import { ApplicationStatusType } from "../../types/Case";
-
-import ICON from "../../assets/images/icons";
 
 import {
   Container,
@@ -266,7 +264,8 @@ const CaseSummary = (props: Props): JSX.Element => {
   const isApplicant = person?.role === "applicant";
 
   const details = caseData?.details ?? ({} as VIVACaseDetails);
-  const { workflow = {}, administrators } = details;
+  const contacts = caseData?.contacts ?? [];
+  const { workflow = {} } = details;
   const {
     decision = {} as Decision,
     calculations = {} as Calculations,
@@ -415,34 +414,11 @@ const CaseSummary = (props: Props): JSX.Element => {
             handleRemoveCaseButtonClick
           )}
 
-        {administrators && (
+        {contacts.length > 0 && (
           <View>
-            <SummaryHeading type="h5">Mina kontaktpersoner</SummaryHeading>
-            {administrators.map(({ name, title, phone }) => (
-              <Card key={`${name}`} colorSchema={colorSchema}>
-                <Card.Body shadow color="neutral">
-                  <Card.Section>
-                    <Card.Image
-                      style={{ width: 50, height: 50 }}
-                      circle
-                      source={ICON.ICON_CONTACT_PERSON}
-                    />
-                    {title && <Card.SubTitle>{title}</Card.SubTitle>}
-                    {name && (
-                      <Card.Title colorSchema="neutral">{name}</Card.Title>
-                    )}
-                  </Card.Section>
-                  {phone && (
-                    <Card.Button
-                      colorSchema="neutral"
-                      onClick={() => launchPhone(phone)}
-                    >
-                      <Icon name="phone" />
-                      <Text>{phone}</Text>
-                    </Card.Button>
-                  )}
-                </Card.Body>
-              </Card>
+            <SummaryHeading type="h5">Kontakt</SummaryHeading>
+            {contacts.map(({ name, description }) => (
+              <ContactCard key={name} name={name} description={description} />
             ))}
           </View>
         )}

--- a/source/types/Case.ts
+++ b/source/types/Case.ts
@@ -155,7 +155,6 @@ export interface Workflow {
 }
 
 export interface VIVACaseDetails {
-  administrators: Administrator[];
   readonly completions: Completions;
   period: Period;
   workflowId: string;
@@ -211,6 +210,11 @@ export interface PDF {
   type: string;
 }
 
+export interface Contact {
+  name: string;
+  description: string;
+}
+
 export interface Case {
   createdAt: number;
   currentFormId: string;
@@ -229,4 +233,5 @@ export interface Case {
   provider: string;
   status: Status;
   updatedAt: number;
+  contacts: Contact[];
 }

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -20,6 +20,7 @@ function loadStories() {
   require("../source/components/molecules/CalendarPicker/CalendarPickerForm.stories");
   require("../source/components/molecules/Card/Card.stories");
   require("../source/components/molecules/CaseCard/CaseCard.stories");
+  require("../source/components/molecules/ContactCard/ContactCard.stories");
   require("../source/components/molecules/CheckboxField/CheckboxField.stories");
   require("../source/components/molecules/EditableList/EditableList.stories");
   require("../source/components/molecules/FilePicker/FilePicker.stories");
@@ -71,6 +72,7 @@ const stories = [
   "../source/components/molecules/CalendarPicker/CalendarPickerForm.stories",
   "../source/components/molecules/Card/Card.stories",
   "../source/components/molecules/CaseCard/CaseCard.stories",
+  "../source/components/molecules/ContactCard/ContactCard.stories",
   "../source/components/molecules/CheckboxField/CheckboxField.stories",
   "../source/components/molecules/EditableList/EditableList.stories",
   "../source/components/molecules/FilePicker/FilePicker.stories",


### PR DESCRIPTION
## Explain the changes you’ve made

Replaced administrators ("Mina Kontaktpersoner") with a more generic "Contacts" property from the case. Description supports markdown.

## Explain why these changes are made

Administrators are no longer a point of contact for EKB and instead generic contact information needs to be displayed. With this PR the contact information can more generically be specified by the API. (NOTE: API not updated yet - no contacts will be shown).

## Explain your solution

* Added new ContactCard component, based on how administrators were rendered before
* Use `case.contacts` property instead of `case.details.administrators` with slightly different structure

## How to test

Concrete example:

1. Checkout this branch
2. Open a case summary and verify that no contacts are shown (see image)
3. Add to the case and verify that contacts are shown:

```json
{
  ...
  "contacts": [{
      "name": "Kontaktcenter",
      "description":
        "Ring Kontaktcenter [042-10 50 00](tel://042105000). Där kan du få svar på frågor om ditt ärende.",
    }
  ]
}
```

## Tested environments

- [x] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots

With contact:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/2890987/224328611-953ee2d1-5520-4268-ae30-38f61aa1d9d0.png">

No contacts:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/2890987/224328652-80c1d355-3835-4d02-94f1-f0943da4171b.png">
