### PR TITLE
Ci/xcode 14.2

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -133,7 +133,7 @@ jobs:
           PERFORM_LONG_UPLOAD: ${{ secrets.PERFORM_LONG_UPLOAD }}
           TEAM_ID: ${{ secrets.TEAM_ID }}
           FASTLANE_SKIP_UPDATE_CHECK: 1
-          ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD: 1
+          ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD: 0
         run: |
           export CERT_KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           cd ios

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -199,7 +199,7 @@ end
 
 platform :ios do
   before_all do |_lane, _options|
-    xcversion(version: '~> 13.4')
+    xcversion(version: '~> 14.2')
 
     app_store_connect_api_key(
       key_content: ENV['CONNECT_API_KEY_CONTENT'],


### PR DESCRIPTION
## Explain the changes you’ve made

Upgraded which XCode version is used for CI builds to 14.2.

## Explain why these changes are made

Older versions are getting deprecated and new builds using older version won't be accepted soon.

## Explain your solution

Changed a hardcoded version number, and disabled `ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD` which was a pseudo-hack needed for a previous XCode version migration but now causes problems and is no longer needed it seems.

## How to test

Concrete example:

A CI build was [performed successfully](https://github.com/helsingborg-stad/app-mitt-helsingborg/actions/runs/4529872952).

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [] Building the Application on a Android device/simulator.

## Other notes

There is a new warning that `xcversion` command is deprecated in favor of a newer `xcodes` command. Migrating to the new command has to be done eventually as well (will create task).