### PR TITLE
fix(select): modify hit box for better clickability

### DIFF
--- a/source/components/atoms/Select/Select.styled.ts
+++ b/source/components/atoms/Select/Select.styled.ts
@@ -13,11 +13,14 @@ const InputRowWrapper = styled.View`
 `;
 
 const InputRowTextWrapper = styled.View`
-  flex-shrink: 1;
+  flex-grow: 1;
 `;
 
 const InputRowIconWrapper = styled.View`
   margin-left: 5px;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
 `;
 
 const StyledErrorText = styled(Text)`

--- a/source/components/atoms/Select/Select.tsx
+++ b/source/components/atoms/Select/Select.tsx
@@ -3,6 +3,8 @@ import { StyleSheet } from "react-native";
 import RNPickerSelect from "react-native-picker-select";
 import Icon from "react-native-vector-icons/Entypo";
 
+import type { PickerStyle } from "react-native-picker-select";
+
 import {
   Wrapper,
   InputRowWrapper,
@@ -15,18 +17,21 @@ import theme from "../../../theme/theme";
 
 import type { Props } from "./Select.types";
 
-const pickerSelectStyles = StyleSheet.create({
+const pickerSelectStyles: PickerStyle = StyleSheet.create({
   inputIOS: {
     paddingHorizontal: 10,
     textAlign: "right",
     color: theme.colors.neutrals[1],
-    paddingRight: 0,
+    paddingRight: 15,
   },
   inputAndroid: {
     paddingHorizontal: 10,
     textAlign: "right",
     color: theme.colors.neutrals[1],
-    paddingRight: 0,
+    paddingRight: 15,
+  },
+  iconContainer: {
+    height: "100%",
   },
 });
 
@@ -81,15 +86,17 @@ function Select(
             onValueChange={handleValueChange}
             items={items}
             ref={ref}
+            Icon={() => (
+              <InputRowIconWrapper>
+                <Icon name="select-arrows" />
+              </InputRowIconWrapper>
+            )}
             doneText="Klar"
             onOpen={handleOpen}
             onClose={handleClose}
             useNativeAndroidPickerStyle={false}
           />
         </InputRowTextWrapper>
-        <InputRowIconWrapper>
-          <Icon name="select-arrows" />
-        </InputRowIconWrapper>
       </InputRowWrapper>
       {showErrorMessage && error ? (
         <StyledErrorText>{error?.message}</StyledErrorText>


### PR DESCRIPTION
## Explain the changes you’ve made

Modified hit box for select fields to be bigger and include icon-part as clickable.

## Explain why these changes are made

UX issues with clicking on select fields; unclear what you had to click.

## Explain your solution

Changed so select field covers the remaining width, and used the select plugin's way of adding an icon instead of having it as a separate element beside the field.

## How to test

Concrete example:

1. Checkout this branch
2. Open a form with a select field
3. Verify that it feels intuitive to click the select field

## Tested environments

- [] Storybook on a iOS device/simulator.
- [x] Building the Application on a iOS device/simulator.
- [x] Building the Application on a Android device/simulator.

## Screenshots

Hitboxes before (green for select field, blue for icon):

![image](https://user-images.githubusercontent.com/2890987/227967105-db82514a-765c-452f-bfed-624c1071f72a.png)


Hitboxes after (icon is now part of the green area as well):

![image](https://user-images.githubusercontent.com/2890987/227967135-a8f17349-f56e-41f4-8962-904231543c43.png)
